### PR TITLE
Remove references to Cloud Pak

### DIFF
--- a/console/vwt_search.md
+++ b/console/vwt_search.md
@@ -14,14 +14,14 @@ lastupdated: "2019-12-11"
 {:child: .link .ulchildlink}
 {:childlinks: .ullinks}
 
-# Searching with {{site.data.keyword.kui}}
+# Searching with Visual Web Terminal
 
-The {{site.data.keyword.kui}} Search function provides visibility into your {{site.data.keyword.product}} resources across all your clusters. 
+The Visual Web Terminal search function provides visibility into your resources across all your clusters. 
 
-You can only search for resources based on your role-based access control level assignment. If you save and share a Search query with another user, returned results for that user depend on his or her access level. For more information on role access, see [Role-based access control](../iam/3.4.0/assign_role.md). 
+You can only search for resources based on your role-based access control level assignment. If you save and share a search query with another user, returned results for that user depend on his or her access level.
 
-1. Start a {{site.data.keyword.kui}} session.
-2. In the command entry field of the {{site.data.keyword.kui}}, type: `search`. When you run a `search` command, the {{site.data.keyword.kui}} verifies that the search function is available. If it is not available, a message indicates that either the search function is not installed, or that it is just not available. If it is installed, but not available, it might be a network issue. 
+1. Start a Visual Web Terminal session.
+2. In the command entry field of the Visual Web Terminal, type: `search`. When you run a `search` command, the Visual Web Terminal verifies that the search function is available. If it is not available, a message indicates that either the search function is not installed, or that it is just not available. If it is installed, but not available, it might be a network issue. 
 3. Add a space after the `search` command. The list of filters that are available for the search is displayed. **Remember:** The list of filters might be empty, because it is dependent on the resources that are available in your environment and your role permissions. 
 4. Select one of the filters from the list. The selected filter is added to the search criteria on your command line, and the next level of filters for that selection are displayed. **Tip:** You can also enter a string after the `search` command, rather than selecting a filter from the list. 
 5. Optional: Add filters by entering a single space after each filter entry until your command contains all of the required filters. 	 


### PR DESCRIPTION
- Removed references to Cloud Paks and the case where KUI is not installed as it will always be installed on the hub cluster in Red Hat Advanced Cluster Management
- Also removed statement in discussion of `savedsearches` that is no longer true (that you cannot save searches in KUI)