### PR TITLE
For discussion/review

### DIFF
--- a/manage_cluster/scale.md
+++ b/manage_cluster/scale.md
@@ -10,14 +10,14 @@ lastupdated: "2020-03-26"
 
 You can customize your cluster specifications, such as virtual machine sizes and number of nodes. See the following list of recommended settings for each available cloud provider, but also see the documentation for more specific information:
 
-* [Red Hat OpenShift Container Platform cluster in Amazon Web Services (AWS)](#ocp_aws) <!--check these, of only create is represented now, I can removed managed-->
+* [Red Hat OpenShift Container Platform cluster in Amazon Web Services (AWS)](#ocp_aws) <!--NOTE: check these, of only create is represented now, I can removed managed-->
 * [Red Hat OpenShift on IBM Cloud](#rhoks)
 * [IBM Kubernetes Service cluster](#iks)
 * [Google Kubernetes Engine (GKE)](#gke)
 * [Azure Kubernetes Service (AKS) cluster](#aks)
 * [Amazon Elastic Kubernetes Service (EKS)](#eks)
 
-<!-- if this is all we are recommending, I think add to system req -->
+<!-- if this is all we are offering (links) I think add to system req, which was suggested in an arch call -->
 
 ## Red Hat OpenShift Container Platform cluster in Amazon Web Services (AWS)
 {: #ocp_aws}

--- a/manage_cluster/scale.md
+++ b/manage_cluster/scale.md
@@ -6,25 +6,16 @@ lastupdated: "2020-03-26"
 
 ---
 
-# Resizing a cluster (In review)
+# Customization resources for imported managed clusters
 
-You can customize your cluster specifications, such as virtual machine sizes and number of nodes. See the following list of recommended settings for each available cloud provider, but also see the documentation for more specific information:
+See the following list of recommended settings for each available cloud provider, but also see the documentation for more specific information:
 
-* [Red Hat OpenShift Container Platform cluster in Amazon Web Services (AWS)](#ocp_aws) <!--NOTE: check these, of only create is represented now, I can removed managed-->
 * [Red Hat OpenShift on IBM Cloud](#rhoks)
 * [IBM Kubernetes Service cluster](#iks)
 * [Google Kubernetes Engine (GKE)](#gke)
 * [Azure Kubernetes Service (AKS) cluster](#aks)
 * [Amazon Elastic Kubernetes Service (EKS)](#eks)
 
-<!-- if this is all we are offering (links) I think add to system req, which was suggested in an arch call -->
-
-## Red Hat OpenShift Container Platform cluster in Amazon Web Services (AWS)
-{: #ocp_aws}
-
-See the Amazon documentation at [Amazon EC2 Instance Types](https://aws.amazon.com/ec2/instance-types/) for more details.
-
-After the cluster is created, you can resize your cluster to increase or decrease the number of nodes in that cluster. To learn how to resize your cluster, refer to [Creating a MachineSet to scale your cluster](https://docs.openshift.com/container-platform/4.1/machine_management/creating-machineset.html).
 
 ## Red Hat OpenShift on IBM Cloud
 {: #rhoks}


### PR DESCRIPTION
Do we just use what is for Hive here, or do we also have managed clusters here? (We had managed in the past, I believe). I think we have had enough request to have this topic--Josh mentioned integrating it with system reqs (having a section inside system reqs) which I can do, but first I want to make sure we are on the same page about the content.

@evelinec FYI I started a PR


Thank @mikeshng for the input, I made your changes.

**berenss commented 19 hours ago • 
I'm not a fan of documenting cluster scale unless that is a feature we will actually support. Since we do not create/destroy any managed clusters, I don't see the need why we would want to document how to scale one.
If we can scale an OCP cluster (I've not seen this yet, today) then we should have a scale topic and discuss how that works using Hive.

As I'm hearing from Michael that "we have deferred managing scaling from ACM at this time", I propose that we do not have any cluster scaling topic. unless we want to walk folks thru how to flex this in Hive directly.**


**bcpswope commented 18 hours ago
If we removed managed, then don't we still need what is created (destroyed) from the create section:**

https://github.com/open-cluster-management/rhacm-docs/blob/doc_stage/manage_cluster/create.md