### PR TITLE
3.11 on hub

### DIFF
--- a/install/supported_os.md
+++ b/install/supported_os.md
@@ -2,17 +2,15 @@
 
 copyright:
   years: 2020
-lastupdated: "2020-03-25"
+lastupdated: "2020-04-09"
 
 ---
 
 # Supported operating systems and platforms
 
-You can install Red Hat Advanced Cluster Management for Kubernetes on Linux x86_64 with Red Hat OpenShift Container Platform version 4.2 or 4.3.
+You can install Red Hat Advanced Cluster Management for Kubernetes on Linux x86_64 with Red Hat OpenShift Container Platform version 4.3.
 
 |Platform|Operating system| OpenShift Container Platform version
 |--------|----------------|---|
-|   Linux x86_64            | Red Hat Enterprise Linux 7.6 and 7.7 | 4.2 |
-|                           | Red Hat Enterprise Linux 7.6 and 7.7 | 4.3 |
-| | Red Hat Enterprise Linux CoreOS 4.2 | 4.2 |
+|   Linux x86_64       | Red Hat Enterprise Linux 7.6 and 7.7 | 4.3 |
 {: caption="Table 1. Supported operating systems" caption-side="top"}

--- a/install/supported_os.md
+++ b/install/supported_os.md
@@ -8,12 +8,11 @@ lastupdated: "2020-03-25"
 
 # Supported operating systems and platforms
 
-You can install Red Hat Advanced Cluster Management for Kubernetes on Linux x86_64 with Red Hat OpenShift Container Platform version 3.11, 4.2, or 4.3.
+You can install Red Hat Advanced Cluster Management for Kubernetes on Linux x86_64 with Red Hat OpenShift Container Platform version 4.2 or 4.3.
 
 |Platform|Operating system| OpenShift Container Platform version
 |--------|----------------|---|
-| Linux x86_64 | Red Hat Enterprise Linux 7.5 and 7.6| 3.11 |
-|                           | Red Hat Enterprise Linux 7.6 and 7.7 | 4.2 |
+|   Linux x86_64            | Red Hat Enterprise Linux 7.6 and 7.7 | 4.2 |
 |                           | Red Hat Enterprise Linux 7.6 and 7.7 | 4.3 |
 | | Red Hat Enterprise Linux CoreOS 4.2 | 4.2 |
 {: caption="Table 1. Supported operating systems" caption-side="top"}


### PR DESCRIPTION
I think we need to make this clear across install doc what versions are supported. 

When I redid supported clouds a couple weeks ago, there was some stuff that had been removed; I added the supported hub and managed info back into the doc. Devs confirmed on the hub that 3.11 is not supported at that time. 

Please check on the rest of this OS table:

https://github.com/open-cluster-management/rhacm-docs/issues/353