### PR TITLE
Update quick_start.md

### DIFF
--- a/about/quick_start.md
+++ b/about/quick_start.md
@@ -20,7 +20,7 @@ After installation, review the [Web console](../console/console_intro.md) guide 
 
 ## Manage clusters
 
-You are now ready to create and import clusters. From your hub cluster, you can create clustersn from other Kubernetes services to manage, and you can view cluster information. 
+You are now ready to create and import clusters. From your hub cluster, you can create clusters from other Kubernetes services to manage, and you can view cluster information. 
 
 1. See [Creating a cluster](../manage_cluster/create.md) to learn about the types of managed clusters you can create. When you create a managed cluster, the new managed cluster imports automatically. 
 
@@ -43,4 +43,4 @@ You can also manage security and compliance across your created and imported man
 
 2. From the _Policies_ page, you can view a summary of cluster and policy violations. 
 
-3. View your policies from the _Governance and risk_ page in the console. You can also click on the cluster to view that cluster _Overview_ and learn more about any policy violations.
+3. View your policies from the _Governance and risk_ page in the console. You can also view policy details from the cluster _Overview_.


### PR DESCRIPTION
Small update from suggestion by laura and caught a small spelling error.
https://coreos.slack.com/archives/DUFKG1KCZ/p1587995771001800

in the new getting started guide docs, the GRC area alludes to you being able to go to the Cluster Overview to get more policy violation details - but when you're on the Cluster Overview page it directs you to GRC for more details. So I might tweak it along the lines of: you can get more details on the policy violations (in GRC) and can go directly to that cluster's overview.