### PR TITLE
remote prereq on storage and rhacm showing in the operatorhub

### DIFF
--- a/install/install_disconnected.adoc
+++ b/install/install_disconnected.adoc
@@ -12,12 +12,10 @@ You must meet the following requirements before you install Red Hat Advanced Clu
 
 * Red Hat OpenShift Container Platform version 4.3, or later, must be deployed in your environment, and you must be logged into it with the command line interface (CLI).
 See the https://docs.openshift.com/container-platform/4.3/welcome/index.html[OpenShift version 4.3 documentation] or https://docs.openshift.com/container-platform/4.4/welcome/index.html[OpenShift version 4.4 documentation].
-* A preconfigured StorageClass in Red Hat OpenShift Container Platform that can be used to create storage for Red Hat Advanced Cluster Management for Kubernetes.
 * Your Red Hat OpenShift Container Platform CLI must be version 4.3, or later, and configured to run `oc` commands.
 See https://docs.openshift.com/container-platform/4.3/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the CLI] for information about installing and configuring the Red Hat OpenShift CLI.
 * Your Red Hat OpenShift Container Platform permissions must allow you to create a namespace.
 * You must have a workstation with Internet connection to download the dependencies for the operator.
-* Your Red Hat OpenShift Container Platform must have access to the Red Hat Advanced Cluster Management operator in the OperatorHub catalog.
 
 [#installing-red-hat-advanced-cluster-management-for-kubernetes-in-a-disconnected-environment]
 == Installing Red Hat Advanced Cluster Management for Kubernetes in a disconnected environment
@@ -30,17 +28,13 @@ If you do not already have a mirror registry, create one by completing the proce
 +
 If you already have a mirror registry, you can configure and use your existing one.
 +
-NOTE: Red Hat Advanced Cluster Management for Kubernetes must deploy the Community Operator catalog, so the container image must support the Kubernetes V1 container specification.
-See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core[Container v1 core] in the Kubernetes documentation for more information about the V1 container specification.
 
 . Enable the disconnected Operator Lifecycle Manager (OLM) Red Hat Operators and Community Operators.
 +
-Advanced Cluster Management for Kubernetes is included in the OLM Red Hat Operator catalog, and has a dependency on the Community Operator catalog for the `etcd` operator.
+Advanced Cluster Management for Kubernetes is included in the OLM Red Hat Operator catalog.
 +
-TIP: Make sure that your default storageClass is configured.
-See https://kubernetes.io/docs/tasks/administer-cluster/change-default-storage-class/[Change the default storageClass] for more information about setting your default storageClass.
 
-. Configure the disconnected OLM for the Red Hat Operator catalog and the Community Operator catalog.
+. Configure the disconnected OLM for the Red Hat Operator catalog.
 Follow the steps in the Using Operator Lifecycle Manager on restricted networks topic of the Red Hat OpenShift Container Platform documentation.
 . Now that you have the image in the disconnected OLM, continue to install Advanced Cluster Management for Kubernetes from the OLM catalog.
 See the steps in xref:../install/install_connected.adoc#installing-while-connected-online[Installing while connected online] for the required steps.


### PR DESCRIPTION
* remove references to storage in 2.0
* remove confusing line from prerequisites
* remove references to etcd or community catalog
