### PR TITLE
Update subscription annotations for git

### DIFF
--- a/apis/master.html
+++ b/apis/master.html
@@ -2993,8 +2993,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
       "app" : "sample_subscription-app"
     },
     "annotations" : {
-      "apps.open-cluster-management.io/github-path" : "apps/sample/",
-      "apps.open-cluster-management.io/github-branch" : "sample_branch"
+      "apps.open-cluster-management.io/git-path" : "apps/sample/",
+      "apps.open-cluster-management.io/git-branch" : "sample_branch"
     }
   },
   "spec" : {

--- a/apis/subscriptions.json.adoc
+++ b/apis/subscriptions.json.adoc
@@ -108,8 +108,8 @@ __required__|Parameters describing the subscription to be created.|<<_rhacm-docs
       "app" : "sample_subscription-app"
     },
     "annotations" : {
-      "apps.open-cluster-management.io/github-path" : "apps/sample/",
-      "apps.open-cluster-management.io/github-branch" : "sample_branch"
+      "apps.open-cluster-management.io/git-path" : "apps/sample/",
+      "apps.open-cluster-management.io/git-branch" : "sample_branch"
     }
   },
   "spec" : {

--- a/manage_applications/master.html
+++ b/manage_applications/master.html
@@ -4369,8 +4369,8 @@ spec:
       name: sample-subscription
       namespace: default
       annotations:
-        apps.open-cluster-management.io/github-path: sample_app_1/dir1
-        apps.open-cluster-management.io/github-branch: branch1
+        apps.open-cluster-management.io/git-path: sample_app_1/dir1
+        apps.open-cluster-management.io/git-branch: branch1
     spec:
       channel: default/sample-channel
       placement:
@@ -4380,15 +4380,15 @@ spec:
 </div>
 </div>
 <div class="paragraph">
-<p>In this example subscription, the annotation <code>apps.open-cluster-management.io/github-path</code> indicates that the subscription subscribes to all Helm charts and Kubernetes resources within the <code>sample_app_1/dir1</code> directory of the Git repository that is specified in the channel.
+<p>In this example subscription, the annotation <code>apps.open-cluster-management.io/git-path</code> indicates that the subscription subscribes to all Helm charts and Kubernetes resources within the <code>sample_app_1/dir1</code> directory of the Git repository that is specified in the channel.
 The subscription subscribes to <code>master</code> branch by default.
-In this example subscription, the annotation <code>apps.open-cluster-management.io/github-branch: branch1</code> is specified to subscribe to <code>branch1</code> branch of the repository.</p>
+In this example subscription, the annotation <code>apps.open-cluster-management.io/git-branch: branch1</code> is specified to subscribe to <code>branch1</code> branch of the repository.</p>
 </div>
 </div>
 <div class="sect6">
 <h7 id="adding-a-file">Adding a <code>.kubernetesignore</code> file</h7>
 <div class="paragraph">
-<p>You can include a <code>.kubernetesignore</code> file within your Git repository root directory, or within the <code>apps.open-cluster-management.io/github-path</code> directory that is specified in subscription&#8217;s annotations.</p>
+<p>You can include a <code>.kubernetesignore</code> file within your Git repository root directory, or within the <code>apps.open-cluster-management.io/git-path</code> directory that is specified in subscription&#8217;s annotations.</p>
 </div>
 <div class="paragraph">
 <p>You can use this <code>.kubernetesignore</code> file to specify patterns of files or subdirectories, or both, to ignore when the subscription deploys Kubernetes resources or Helm charts from the repository.</p>
@@ -4398,8 +4398,8 @@ In this example subscription, the annotation <code>apps.open-cluster-management.
 The pattern format of the <code>.kubernetesignore</code> file is the same as a <code>.gitignore</code> file.</p>
 </div>
 <div class="paragraph">
-<p>If the <code>apps.open-cluster-management.io/github-path</code> annotation is not defined, the subscription looks for a <code>.kubernetesignore</code> file in the repository root directory.
-If the <code>apps.open-cluster-management.io/github-path</code> field is defined, the subscription looks for the <code>.kubernetesignore</code> file in the <code>apps.open-cluster-management.io/github-path</code> directory.
+<p>If the <code>apps.open-cluster-management.io/git-path</code> annotation is not defined, the subscription looks for a <code>.kubernetesignore</code> file in the repository root directory.
+If the <code>apps.open-cluster-management.io/git-path</code> field is defined, the subscription looks for the <code>.kubernetesignore</code> file in the <code>apps.open-cluster-management.io/git-path</code> directory.
 Subscriptions do not search in any other directory for a <code>.kubernetesignore</code> file.</p>
 </div>
 </div>

--- a/manage_applications/subscription_sample.adoc
+++ b/manage_applications/subscription_sample.adoc
@@ -445,8 +445,8 @@ spec:
       name: sample-subscription
       namespace: default
       annotations:
-        apps.open-cluster-management.io/github-path: sample_app_1/dir1
-        apps.open-cluster-management.io/github-branch: branch1
+        apps.open-cluster-management.io/git-path: sample_app_1/dir1
+        apps.open-cluster-management.io/git-branch: branch1
     spec:
       channel: default/sample-channel
       placement:
@@ -455,22 +455,22 @@ spec:
           name: dev-clusters
 ----
 
-In this example subscription, the annotation `apps.open-cluster-management.io/github-path` indicates that the subscription subscribes to all Helm charts and Kubernetes resources within the `sample_app_1/dir1` directory of the Git repository that is specified in the channel.
+In this example subscription, the annotation `apps.open-cluster-management.io/git-path` indicates that the subscription subscribes to all Helm charts and Kubernetes resources within the `sample_app_1/dir1` directory of the Git repository that is specified in the channel.
 The subscription subscribes to `master` branch by default.
-In this example subscription, the annotation `apps.open-cluster-management.io/github-branch: branch1` is specified to subscribe to `branch1` branch of the repository.
+In this example subscription, the annotation `apps.open-cluster-management.io/git-branch: branch1` is specified to subscribe to `branch1` branch of the repository.
 
 [#adding-a-file]
 ==== Adding a `.kubernetesignore` file
 
-You can include a `.kubernetesignore` file within your Git repository root directory, or within the `apps.open-cluster-management.io/github-path` directory that is specified in subscription's annotations.
+You can include a `.kubernetesignore` file within your Git repository root directory, or within the `apps.open-cluster-management.io/git-path` directory that is specified in subscription's annotations.
 
 You can use this `.kubernetesignore` file to specify patterns of files or subdirectories, or both, to ignore when the subscription deploys Kubernetes resources or Helm charts from the repository.
 
 You can also use the `.kubernetesignore` file for fine-grain filtering to selectively apply Kubernetes resources.
 The pattern format of the `.kubernetesignore` file is the same as a `.gitignore` file.
 
-If the `apps.open-cluster-management.io/github-path` annotation is not defined, the subscription looks for a `.kubernetesignore` file in the repository root directory.
-If the `apps.open-cluster-management.io/github-path` field is defined, the subscription looks for the `.kubernetesignore` file in the `apps.open-cluster-management.io/github-path` directory.
+If the `apps.open-cluster-management.io/git-path` annotation is not defined, the subscription looks for a `.kubernetesignore` file in the repository root directory.
+If the `apps.open-cluster-management.io/git-path` field is defined, the subscription looks for the `.kubernetesignore` file in the `apps.open-cluster-management.io/git-path` directory.
 Subscriptions do not search in any other directory for a `.kubernetesignore` file.
 
 [#applying-kustomize]


### PR DESCRIPTION
Issue: #1062 

In 2.0, the annotations for selecting a git branch and path on a subscription were updated from:

`apps.open-cluster-management.io/github-branch`
`apps.open-cluster-management.io/github-path`

To:

`apps.open-cluster-management.io/git-branch`
`apps.open-cluster-management.io/git-path`

The old annotations are still supported for backwards compatibility, but we should be using the new ones so that users do not think that only GitHub is supported.