### PR TITLE
Update cleanup script with missing search operator crd

### DIFF
--- a/troubleshooting/trouble_reinstall.adoc
+++ b/troubleshooting/trouble_reinstall.adoc
@@ -32,7 +32,7 @@ oc delete apiservice v1.admission.cluster.open-cluster-management.io v1beta1.web
 oc delete clusterimageset --all
 oc delete configmap -n $ACM_NAMESPACE cert-manager-controller cert-manager-cainjector-leader-election cert-manager-cainjector-leader-election-core
 oc delete consolelink acm-console-link
-oc delete crd klusterletaddonconfigs.agent.open-cluster-management.io placementbindings.policy.open-cluster-management.io policies.policy.open-cluster-management.io userpreferences.console.open-cluster-management.io
+oc delete crd klusterletaddonconfigs.agent.open-cluster-management.io placementbindings.policy.open-cluster-management.io policies.policy.open-cluster-management.io userpreferences.console.open-cluster-management.io searchservices.search.acm.com
 oc delete mutatingwebhookconfiguration cert-manager-webhook
 oc delete oauthclient multicloudingress
 oc delete rolebinding -n kube-system cert-manager-webhook-webhook-authentication-reader


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/3689

This is a documentation refresh for 2.0.1, no code changes are associated with this change.

This change updates the uninstall cleanup script with the missing search operator crd `searchservices.search.acm.com` 