### PR TITLE
adding the anchor back for the Security link

### DIFF
--- a/about/architecture.adoc
+++ b/about/architecture.adoc
@@ -51,7 +51,7 @@ See link:../manage_applications/app_management_overview.adoc[Managing applicatio
 Governance and risk is the term used to define the processes that are used to manage security and compliance from a central interface page.
 After you configure a {product-title} hub cluster and a managed cluster, you can view and create policies with the {product-title-short} policy framework.
 
-For more information about Governance and risk, see the link:../security/security_intro.adoc[Security] introduction. Additionally, learn about access requirements from the link:../security/rbac.adoc#role-based-access-control[Role-based access control] documentation.
+For more information about Governance and risk, see the link:../security/security_intro.adoc#security[Security] introduction. Additionally, learn about access requirements from the link:../security/rbac.adoc#role-based-access-control[Role-based access control] documentation.
 
 See the product link:../install/install_overview.adoc#installing[Installing] section to prepare your cluster and get configuration information.
 


### PR DESCRIPTION
No issue here, just needed to add the anchor back. Security is a broken link on the Arch page. Vikram is investigating as well 