### PR TITLE
Updates for RBAC

### DIFF
--- a/security/rbac.adoc
+++ b/security/rbac.adoc
@@ -3,7 +3,13 @@
 
 {product-title} supports role-based access control (RBAC). Your role determines the actions that you can perform. RBAC is based on the authorization mechanisms in Kubernetes, similar to OpenShift Container Platform. For more information about RBAC, see the OpenShift _RBAC_ overview in the link:https://docs.openshift.com/container-platform/4.3/authentication/using-rbac.html[OpenShift Container Platform documentation].
 
-View the following sections for  details of supported RBAC by component.
+View the following sections for  details of supported RBAC by component:
+
+* <<overview-of-roles,Overview of roles>>
+* <<rbac-implementation,RBAC implementation>>
+* <<application-lifecycle-RBAC,Application lifecycle RBAC>>
+* <<governance-lifecycle-RBAC,Governance lifecycle RBAC>>
+
 
 [#overview-of-roles]
 == Overview of roles
@@ -115,59 +121,6 @@ View the following console and API RBAC tables for Cluster lifecycle:
 |===
 
 
-[#governance-lifecycle-RBAC]
-=== Governance lifecycle RBAC
-
-To perform Governance lifecylce operations, users must have access to the namespace where a policy is created, and access to the `managedcluster` namespace. An user with cluster-wide binding to `admin` or `view` access, also have write and read access to all policies and all management clusters on the hub cluster.
-
-View the following examples:
-
-* To view policies in namespace "N" the following role is required:
-
-  ** A namespace binding to the `view` role for namespace "X".
-
-* To create a policy in namespace "N" and apply it on `managedcluster x`, the following roles are required:
-
-  ** A namespace binding to the `admin` role for namespace "N".
-  ** A namespace binding to the `admin` role for namespace "X".
-
-View the following console and API RBAC tables for Governance lifecycle:
-
-.Console RBAC table for Governance lifecycle
-|===
-| Action | Admin | Edit | View
-
-| Policies
-| create, read, update, delete
-| read
-| read
-
-| PlacementBindings
-| create, read, update, delete
-| read
-| read
-
-| PlacementRules
-| create, read, update, delete
-| read
-| read
-|===
-
-.API RBAC table for Governance lifecycle
-|===
-| API | Admin | Edit | View
-
-| policies.policy.open-cluster-management.io
-| create, read, update, delete
-| read
-| read
-
-| placementbindings.policy.open-cluster-management.io
-| create, read, update, delete
-| read
-| read
-|===
-
 [#application-lifecycle-RBAC]
 === Application lifecycle RBAC
 
@@ -249,6 +202,60 @@ View the following console and API RBAC tables for Application lifecycle:
 | namespaces
 | create, read, update, delete
 | create, read, update, delete
+| read
+|===
+
+
+[#governance-lifecycle-RBAC]
+=== Governance lifecycle RBAC
+
+To perform Governance lifecylce operations, users must have access to the namespace where a policy is created, and access to the `managedcluster` namespace. An user with cluster-wide binding to `admin`  access, also has write and read access to all policies and all management clusters on the hub cluster.
+
+View the following examples:
+
+* To view policies in namespace "N" the following role is required:
+
+  ** A namespace binding to the `view` role for namespace "N".
+
+* To create a policy in namespace "N" and apply it on `managedcluster` "X", the following roles are required:
+
+  ** A namespace binding to the `admin` role for namespace "N".
+  ** A namespace binding to the `admin` role for namespace "X".
+
+View the following console and API RBAC tables for Governance lifecycle:
+
+.Console RBAC table for Governance lifecycle
+|===
+| Action | Admin | Edit | View
+
+| Policies
+| create, read, update, delete
+| read, update
+| read
+
+| PlacementBindings
+| create, read, update, delete
+| read, update
+| read
+
+| PlacementRules
+| create, read, update, delete
+| read, update
+| read
+|===
+
+.API RBAC table for Governance lifecycle
+|===
+| API | Admin | Edit | View
+
+| policies.policy.open-cluster-management.io
+| create, read, update, delete
+| read, update
+| read
+
+| placementbindings.policy.open-cluster-management.io
+| create, read, update, delete
+| read, update
 | read
 |===
 


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/4794

Switched the order of the sections for consistency. The order on the about page is the following: Cluster lifecycle, Application lifecycle, and Governance and risk lifecycle 

Added childlinks to help with navigating the page

CC: @ckandag 