### PR TITLE
open-cluster-management/backlog#5106 no hub mgt

### DIFF
--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -129,7 +129,7 @@ error: unable to recognize "./mch.yaml": no matches for kind "MultiClusterHub" i
 ----
 +
 Run the command again in a few minutes when the resources are created.
-. *Optional:* Disable hub self management, if necessary. By default, the hub cluster is automatically imported and managed by itself, like any other cluster. If you want to manage the hub cluster with a different hub cluster, then change the setting for `disableHubSelfManagement` from `false` to `true`. If the setting is not included in the `.yaml` file that defines the custom resource, add it as shown in the example of the previous step.
+. *Optional:* Disable hub self management, if necessary. By default, the hub cluster is automatically imported and managed by itself, like any other cluster. If you do not want the hub cluster to manage itself, then change the setting for `disableHubSelfManagement` from `false` to `true`. If the setting is not included in the `.yaml` file that defines the custom resource, add it as shown in the example of the previous step.
 . It can take up to 10 minutes for the `MultiClusterHub` custom resource status to show as `Running` in the _status.phase_ field after you run the following command:
 +
 ----
@@ -201,7 +201,7 @@ Replace _secret_ with the name of the pull secret that you created.
 Confirm that the _namespace_ is your project namespace.
 +
 *Important:* The `local-cluster` namespace is used for the imported self-managed hub cluster. You must not have a local-cluster namespace on you cluster prior to installing. 
- .. *Optional:* Disable hub self management, if necessary. By default, the hub cluster is automatically imported and managed by itself, like any other cluster. If you want to manage the hub cluster with a different hub cluster, then change the setting for `disableHubSelfManagement` from `false` to `true`. If the setting is not included in the `.yaml` file that defines the custom resource, add it as shown in the example of the previous step.
+ .. *Optional:* Disable hub self management, if necessary. By default, the hub cluster is automatically imported and managed by itself, like any other cluster. If you do not want the hub cluster to manage itself, then change the setting for `disableHubSelfManagement` from `false` to `true`. If the setting is not included in the `.yaml` file that defines the custom resource, add it as shown in the example of the previous step.
 . Select *Create* to initialize the custom resource.
 It can take up to 10 minutes for the hub to build and start.
 +


### PR DESCRIPTION
Nathan requested a change because the hub cluster cannot be managed by another cluster.  Changed the wording to reflect that.