### PR TITLE
updating parameter table for cert

### DIFF
--- a/security/cert_policy_ctrl.adoc
+++ b/security/cert_policy_ctrl.adoc
@@ -100,7 +100,7 @@ Certificate policy controller only supports `inform` feature.
 | Required. Informs the user of the severity when the policy is non-compliant. Use the following parameter values: `low`, `medium`, or `high`.
 
 | spec.minimumDuration
-| Required. Parameter specifies the smallest duration (in hours) before a certificate is considered non-compliant. The default value is `100h`. The parameter value uses the time duration format from Golang. See link:https://golang.org/pkg/time/#ParseDuration[Golang Parse Duration] for more information.
+| Required. When a value is not specified, the default value is `100h`. This parameter specifies the smallest duration (in hours) before a certificate is considered non-compliant. The parameter value uses the time duration format from Golang. See link:https://golang.org/pkg/time/#ParseDuration[Golang Parse Duration] for more information.
 
 | spec.minimumCADuration
 | Optional. Set a value to identify signed certificates that might expire soon with a different value from other certificates. If the parameter value is not specified, the CA certificate expiration is the value used for the `minimumDuration`. See link:https://golang.org/pkg/time/#ParseDuration[Golang Parse Duration] for more information.


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/5807

@drkho @gparvin I think we should continue to keep "Required" to maintain consistency. Let me know your thoughts