### PR TITLE
Update trouble_cluster_offline_cert.adoc

### DIFF
--- a/troubleshooting/trouble_cluster_offline_cert.adoc
+++ b/troubleshooting/trouble_cluster_offline_cert.adoc
@@ -37,8 +37,6 @@ E0917 02:58:27.613963       1 reflector.go:127] k8s.io/client-go@v0.19.0/tools/c
 
 To manually restore your clusters after updating your certificate information, complete the following steps for each managed cluster:
 
-. Add the new certificate authority to the certificate chain.
-. Wait for the certificate rotation to complete to pick up the new certificate authority, which happens every 2 hours.
 . Manually import the cluster again. {ocp} clusters that were created from {product-title-short} will resynchronize every 2 hours, so you can skip this step for those clusters.
 .. On the hub cluster, display the import command by entering the following command:
 + 


### PR DESCRIPTION
issue: https://github.com/open-cluster-management/backlog/issues/4916
removing some not needed steps. 

user don't need to wait for 2 hours, once showing offline on hub, user can start reimport.
