### PR TITLE
Update api reference for cluster

### DIFF
--- a/apis/cluster.json.adoc
+++ b/apis/cluster.json.adoc
@@ -272,14 +272,16 @@ __required__|<<_rhacm-docs_apis_cluster_jsoncluster_spec,spec>>
 [options="header", cols=".^3a,.^4a"]
 |===
 |Name|Schema
-|**HubAcceptsClient** +
+|**hubAcceptsClient** +
 __required__|bool
-|**SpokeClientConfigs** +
-__optional__|<<_rhacm-docs_apis_cluster_jsoncluster_spokeclientconfigs,SpokeClientConfigs>>
+|**managedClusterClientConfigs** +
+__optional__|< <<_rhacm-docs_apis_cluster_jsoncluster_managedClusterClientConfigs,managedClusterClientConfigs>> > array
+|**leaseDurationSeconds** +
+__optional__|integer (int32)
 |===
 
-[[_rhacm-docs_apis_cluster_jsoncluster_spokeclientconfigs]]
-**SpokeClientConfigs**
+[[_rhacm-docs_apis_cluster_jsoncluster_managedClusterClientConfigs]]
+**managedClusterClientConfigs**
 
 [options="header", cols=".^3a,.^11a,.^4a"]
 |===


### PR DESCRIPTION
Update out-of-date api reference for Cluster. See https://github.com/open-cluster-management/backlog/issues/6498 for more details.