### PR TITLE
removing MongoDB

### DIFF
--- a/release_notes/gdpr_readiness.adoc
+++ b/release_notes/gdpr_readiness.adoc
@@ -142,7 +142,7 @@ Users and groups that are defined in LDAP can be added to {product-title} platfo
 Group membership is not persisted in any long-term way.
 Securing user and group data at rest in the enterprise LDAP must be considered.
 {product-title} platform also includes an authentication service, Open ID Connect (OIDC) that interacts with the enterprise directory and maintains access tokens.
-This service uses MongoDB as a backing store.
+This service uses ETCD as a backing store.
 * *Service authentication data, including user IDs and passwords:* Credentials that are used by {product-title} platform components for inter-component access are defined as Kubernetes Secrets.
 All Kubernetes resource definitions are persisted in the `etcd` key-value data store.
 Initial credentials values are defined in the platform configuration data as Kubernetes Secret configuration YAML files.
@@ -172,7 +172,6 @@ The cookie is refreshed during the session.
 It is valid for 12 hours after you sign out of the console or close your web browser.
 
 For all subsequent authentication requests made from the console, the front-end NGINX server decodes the available authentication cookie in the request and validates the request by calling the authentication manager.
-// nginx is not used, correct? I think this paragraph should be removed
 
 The {product-title} platform CLI requires the user to provide credentials to log in.
 


### PR DESCRIPTION
No issue, was reminded via slack that MongoDB is no longer used. ETCD is used as backing store.

https://coreos.slack.com/archives/DURBT9SQ4/p1602101633003300