### PR TITLE
Updating the asterisk element

### DIFF
--- a/troubleshooting/trouble_obs_cert.adoc
+++ b/troubleshooting/trouble_obs_cert.adoc
@@ -6,13 +6,13 @@ The metrics collector might fail to push metrics to the {product-short} hub clus
 [#symptom-observability-invalid-certification]
 == Symptom 1: Certification is invalid
 
-After you import your managed cluster, you might receive the following error message due to invalid certfication for the `metrics-collector-deployment-*`: 
+After you import your managed cluster, you might receive the following error message due to invalid certfication for the `metrics-collector-deployment-&ast;`: 
  
 ----
 x509: certificate signed by unknown authority
 ----
 
-You might receive the error if the `observability-managed-cluster-certs` secret is deleted or recreated after the `metrics-collector-deployment-*` pod restarted. The certificates are not updated in the secret.  
+You might receive the error if the `observability-managed-cluster-certs` secret is deleted or recreated after the `metrics-collector-deployment-&ast;` pod restarted. The certificates are not updated in the secret.  
 
 
 [#resolving-observability-invalid-certification]
@@ -21,15 +21,15 @@ You might receive the error if the `observability-managed-cluster-certs` secret 
 If you have this problem, complete the following steps:
 
 . Log in to your {product-short} hub cluster. 
-. Restart `multicluster-observability-operator-*` pod.
-. Access the `open-cluster-management-addon-observability` namespace and restart the `metrics-collector-deployment-*` pod on your managed cluster.
+. Restart `multicluster-observability-operator-&ast;` pod.
+. Access the `open-cluster-management-addon-observability` namespace and restart the `metrics-collector-deployment-&ast;` pod on your managed cluster.
 
 [#symptom-observability-storage-used-up]
 == Symptom 2: Storage in mounted persistent volume is used up
 
-If the storage of the mounted persistent volume on the `data-observability-observatorium-thanos-receive-default-*` pod reaches capacity, the metrics collector fails to send metrics to the hub cluster.
+If the storage of the mounted persistent volume on the `data-observability-observatorium-thanos-receive-default-&ast;` pod reaches capacity, the metrics collector fails to send metrics to the hub cluster.
 
-You might receive the following error message in the logs of `metrics-collector-deployment-*` pod: `no space left on device`. 
+You might receive the following error message in the logs of `metrics-collector-deployment-&ast;` pod: `no space left on device`. 
 
 [#resolving-observability-storage-used-up]
 == Resolving the problem: Storage in mounted persistent volume is used up
@@ -37,5 +37,5 @@ You might receive the following error message in the logs of `metrics-collector-
 If you have this problem, complete the following steps:
 
 . Log in to your {ocp-short} managed cluster.
-. Access the `data-observability-observatorium-thanos-receive-default-*` pod and increase the persistent volume claim.
-. Restart `data-observability-observatorium-thanos-receive-default-*` pod in the `open-cluster-management-observability` namespace. 
+. Access the `data-observability-observatorium-thanos-receive-default-&ast;` pod and increase the persistent volume claim.
+. Restart `data-observability-observatorium-thanos-receive-default-&ast;` pod in the `open-cluster-management-observability` namespace. 

--- a/troubleshooting/trouble_obs_cert.adoc
+++ b/troubleshooting/trouble_obs_cert.adoc
@@ -6,13 +6,13 @@ The metrics collector might fail to push metrics to the {product-short} hub clus
 [#symptom-observability-invalid-certification]
 == Symptom 1: Certification is invalid
 
-After you import your managed cluster, you might receive the following error message due to invalid certfication for the `metrics-collector-deployment-&ast;`: 
+After you import your managed cluster, you might receive the following error message due to invalid certfication for the `metrics-collector-deployment-<pod_name>`: 
  
 ----
 x509: certificate signed by unknown authority
 ----
 
-You might receive the error if the `observability-managed-cluster-certs` secret is deleted or recreated after the `metrics-collector-deployment-&ast;` pod restarted. The certificates are not updated in the secret.  
+You might receive the error if the `observability-managed-cluster-certs` secret is deleted or recreated after the `metrics-collector-deployment-<pod_name>` pod restarted. The certificates are not updated in the secret.  
 
 
 [#resolving-observability-invalid-certification]
@@ -21,15 +21,15 @@ You might receive the error if the `observability-managed-cluster-certs` secret 
 If you have this problem, complete the following steps:
 
 . Log in to your {product-short} hub cluster. 
-. Restart `multicluster-observability-operator-&ast;` pod.
-. Access the `open-cluster-management-addon-observability` namespace and restart the `metrics-collector-deployment-&ast;` pod on your managed cluster.
+. Restart `multicluster-observability-operator-<pod_name>` pod.
+. Access the `open-cluster-management-addon-observability` namespace and restart the `metrics-collector-deployment-<pod_name>` pod on your managed cluster.
 
 [#symptom-observability-storage-used-up]
 == Symptom 2: Storage in mounted persistent volume is used up
 
-If the storage of the mounted persistent volume on the `data-observability-observatorium-thanos-receive-default-&ast;` pod reaches capacity, the metrics collector fails to send metrics to the hub cluster.
+If the storage of the mounted persistent volume on the `data-observability-observatorium-thanos-receive-default-<pod_name>` pod reaches capacity, the metrics collector fails to send metrics to the hub cluster.
 
-You might receive the following error message in the logs of `metrics-collector-deployment-&ast;` pod: `no space left on device`. 
+You might receive the following error message in the logs of `metrics-collector-deployment-<your_pod_name>` pod: `no space left on device`. 
 
 [#resolving-observability-storage-used-up]
 == Resolving the problem: Storage in mounted persistent volume is used up
@@ -37,5 +37,5 @@ You might receive the following error message in the logs of `metrics-collector-
 If you have this problem, complete the following steps:
 
 . Log in to your {ocp-short} managed cluster.
-. Access the `data-observability-observatorium-thanos-receive-default-&ast;` pod and increase the persistent volume claim.
-. Restart `data-observability-observatorium-thanos-receive-default-&ast;` pod in the `open-cluster-management-observability` namespace. 
+. Access the `data-observability-observatorium-thanos-receive-default-<pod_name>` pod and increase the persistent volume claim.
+. Restart `data-observability-observatorium-thanos-receive-default-<pod_name>` pod in the `open-cluster-management-observability` namespace. 


### PR DESCRIPTION
Fixing the Pantheon book by removing an invalid element. The asterisk is considered an invalid element. There is a specific [HTML entity](https://theasciicode.com.ar/ascii-printable-characters/asterisk-ascii-code-42.html) that must be entered. 

Reason for update:
<img width="884" alt="Pantheon-invalid-element" src="https://user-images.githubusercontent.com/60616885/98128364-d4867f80-1e85-11eb-9f75-1026733d015e.png">

Invalid element from VSCode:

<img width="755" alt="VSC-invalid-ascii-syntax" src="https://user-images.githubusercontent.com/60616885/98128424-ea944000-1e85-11eb-8b7a-b944def995f5.png">


Update in PR: 
<img width="823" alt="VSC-html-entry-asterisk" src="https://user-images.githubusercontent.com/60616885/98128468-f97af280-1e85-11eb-9ac1-822afaecc91e.png">
