### PR TITLE
Update release_images.adoc

### DIFF
--- a/manage_cluster/release_images.adoc
+++ b/manage_cluster/release_images.adoc
@@ -5,16 +5,24 @@ When you create a cluster on a provider by using the {product-title}, you must s
 The release image specifies which version of Red Hat OpenShift Container Platform is used to build the cluster.
 
 The files that reference the release images are `yaml` files that are maintained in the `acm-hive-openshift-releases` GitHub repository.
-{product-title} uses those files to create the list of the available release images in the console.
+{product-title} uses those files to create the list of the available release images in the console. This includes the latest fast channel images from Red Hat OpenShift Container Platform.
 The repository contains the `clusterImageSets` directory and the `subscription` directory, which are the directories that you use when working with the release images.
 
 The `clusterImageSets` directory contains the following directories:
 
-* Fast - Contains files that reference the latest two versions of the release images for each OpenShift Container Platform version that is supported
-* Releases - Contains files that reference all of the release images for each OpenShift Container Platform version that is supported.
+* Fast - Contains files that reference the latest versions of the release images for each OpenShift Container Platform version that is supported. The release images in this folder are tested, verified and supported.
+* Releases - Contains files that reference all of the release images for each OpenShift Container Platform version (stable, fast and candidate channels)
 *Note:* These releases have not all been tested and determined to be stable.
 * Stable - Contains files that reference the latest two stable versions of the release images for each OpenShift Container Platform version that is supported.
-The release images in this folder are tested and verified.
+The release images in this folder are tested, verified and supported.
+
+The automatic curation of the latest fast ClusterImageSets can be disabled via an installer parameter on the multiclusterhub resource. By toggling the the `spec.disableUpdateClusterImageSets` parameter between true and false, the subscription installed with {product-title} will be disabled or enabled. If you would like to curate your own images, you should set the `spec.disableUpdateClusterImageSets` to `true`.
+
+You can curate your own ClusterImageSets in three ways.
+First disable the included subscription that performs the automatic update of the latest fast channel images
+Option 1: In the console when creating a cluster, specify the image reference for the specific ClusterImageSet you want to use. Each new entry you make, will persist and be available for all future cluster provisions. Example: `quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64`
+OPTION 2: Manually create/apply the ClusterImageSets yaml from the `acm-hive-openshift-releases` GitHub repository
+OPTION 3: Follow the `README.md` in the `acm-hive-openshift-releases` GitHub repository to enable automatic updates of ClusterImageSets from a forked GitHub repository
 
 The `subscription` directory contains files that specify where the list of release images is pulled from.
 The default release images for Red Hat Advanced Cluster Management are provided in a Quay.io directory.

--- a/manage_cluster/release_images.adoc
+++ b/manage_cluster/release_images.adoc
@@ -1,29 +1,31 @@
 [#release-images]
 = Release images
 
-When you create a cluster on a provider by using the {product-title}, you must specify a release image to use for the new cluster.
-The release image specifies which version of Red Hat OpenShift Container Platform is used to build the cluster.
+When you create a cluster on a provider by using {product-title}, you must specify a release image to use for the new cluster.
+The release image specifies which version of {ocp} is used to build the cluster.
 
 The files that reference the release images are `yaml` files that are maintained in the `acm-hive-openshift-releases` GitHub repository.
-{product-title} uses those files to create the list of the available release images in the console. This includes the latest fast channel images from Red Hat OpenShift Container Platform.
+{product-title-short} uses those files to create the list of the available release images in the console. This includes the latest fast channel images from {ocp-short}.
 The repository contains the `clusterImageSets` directory and the `subscription` directory, which are the directories that you use when working with the release images.
 
 The `clusterImageSets` directory contains the following directories:
 
-* Fast - Contains files that reference the latest versions of the release images for each OpenShift Container Platform version that is supported. The release images in this folder are tested, verified and supported.
-* Releases - Contains files that reference all of the release images for each OpenShift Container Platform version (stable, fast and candidate channels)
+* Fast - Contains files that reference the latest versions of the release images for each {ocp-short} version that is supported. The release images in this folder are tested, verified and supported.
+* Releases - Contains files that reference all of the release images for each {ocp-short} version (stable, fast, and candidate channels)
 *Note:* These releases have not all been tested and determined to be stable.
-* Stable - Contains files that reference the latest two stable versions of the release images for each OpenShift Container Platform version that is supported.
+* Stable - Contains files that reference the latest two stable versions of the release images for each {ocp-short} version that is supported.
 The release images in this folder are tested, verified and supported.
 
-The automatic curation of the latest fast ClusterImageSets can be disabled via an installer parameter on the multiclusterhub resource. By toggling the the `spec.disableUpdateClusterImageSets` parameter between true and false, the subscription installed with {product-title} will be disabled or enabled. If you would like to curate your own images, you should set the `spec.disableUpdateClusterImageSets` to `true`.
+You can curate your own `ClusterImageSets` in three ways:
 
-You can curate your own ClusterImageSets in three ways.
-First disable the included subscription that performs the automatic update of the latest fast channel images
-Option 1: In the console when creating a cluster, specify the image reference for the specific ClusterImageSet you want to use. Each new entry you make, will persist and be available for all future cluster provisions. Example: `quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64`
-OPTION 2: Manually create/apply the ClusterImageSets yaml from the `acm-hive-openshift-releases` GitHub repository
-OPTION 3: Follow the `README.md` in the `acm-hive-openshift-releases` GitHub repository to enable automatic updates of ClusterImageSets from a forked GitHub repository
+The first step for any of the three ways is to disable the included subscription that performs the automatic update of the latest fast channel images. The automatic curation of the latest fast `ClusterImageSets` can be disabled by using an installer parameter on the multiclusterhub resource. By toggling the `spec.disableUpdateClusterImageSets` parameter between `true` and `false`, the subscription installed with {product-title-short} is disabled or enabled, respectively. If you want to curate your own images, set the `spec.disableUpdateClusterImageSets` to `true` to disable the subscription.
+
+Option 1: Specify the image reference for the specific `ClusterImageSet` that you want to use in the console when creating a cluster. Each new entry you specify persists and is available for all future cluster provisions. An example of an entry is: `quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64`.
+
+OPTION 2: Manually create/apply the `ClusterImageSets` yaml file from the `acm-hive-openshift-releases` GitHub repository.
+
+OPTION 3: Follow the `README.md` in the `acm-hive-openshift-releases` GitHub repository to enable automatic updates of `ClusterImageSets` from a forked GitHub repository.
 
 The `subscription` directory contains files that specify where the list of release images is pulled from.
-The default release images for Red Hat Advanced Cluster Management are provided in a Quay.io directory.
-They are referenced by the files in the https://github.com/open-cluster-management/acm-hive-openshift-releases[acm-hive-openshift-releases GitHub repository].
+The default release images for {product-title-short} are provided in a Quay.io directory.
+The images are referenced by the files in the https://github.com/open-cluster-management/acm-hive-openshift-releases[acm-hive-openshift-releases GitHub repository].

--- a/manage_cluster/release_images.adoc
+++ b/manage_cluster/release_images.adoc
@@ -22,7 +22,7 @@ The first step for any of the three ways is to disable the included subscription
 
 Option 1: Specify the image reference for the specific `ClusterImageSet` that you want to use in the console when creating a cluster. Each new entry you specify persists and is available for all future cluster provisions. An example of an entry is: `quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64`.
 
-OPTION 2: Manually create/apply the `ClusterImageSets` yaml file from the `acm-hive-openshift-releases` GitHub repository.
+OPTION 2: Manually create and apply a `ClusterImageSets` YAML file from the `acm-hive-openshift-releases` GitHub repository.
 
 OPTION 3: Follow the `README.md` in the `acm-hive-openshift-releases` GitHub repository to enable automatic updates of `ClusterImageSets` from a forked GitHub repository.
 


### PR DESCRIPTION
New statements.  In ACM 2.2 we no longer use a static set of images, we provide the subscription that dynamically pulls in the ClusterImageSets.

it should be noted if you use a disconnected ACM Hub install, then you will see NO clusterImageSets.

Related issue: https://github.com/open-cluster-management/backlog/issues/6973