### PR TITLE
Update search.json.adoc

### DIFF
--- a/apis/search.json.adoc
+++ b/apis/search.json.adoc
@@ -43,7 +43,7 @@ __URL__ : http://swagger.io
 
 
 
-[[_rhacm-docs_apis_policy_jsonpaths]]
+[[_rhacm-docs_apis_searchcustomization_jsonpaths]]
 == Paths
 
 [[_rhacm-docs_apis_searchcustomization_jsoncreate]]
@@ -368,9 +368,9 @@ __optional__|String value that represents the REST resource.|string
 |**metadata** +
 __required__|Describes rules that define the policy. |object
 | **complianceType** | Used to list expected behavior for roles and other Kubernetes object that must be evaluated or applied to the managed clusters.| string
-|<<_rhacm-docs_apis_policy_jsonpolicy_selector,**clusterConditions**>> +
+|<<_rhacm-docs_apis_searchcustomization_jsonpolicy_selector,**clusterConditions**>> +
 __optional__| Section to define labels.|string
-|<<_rhacm-docs_apis_policy_jsonpolicy_rules,**rules**>> +
+|<<_rhacm-docs_apis_searchcustomization_jsonpolicy_rules,**rules**>> +
 __optional__| |string
 |===
 


### PR DESCRIPTION
updates to fix book in Pantheon

`asciidoctor: WARNING: search.json.adoc: line 47: id assigned to section already in use: _rhacm-docs_apis_policy_jsonpaths
[31m[1mID "_rhacm-docs_apis_policy_jsonpaths" is duplicated in the source content[0m`