### PR TITLE
Update trouble_obs_mco.adoc

### DIFF
--- a/troubleshooting/trouble_obs_mco.adoc
+++ b/troubleshooting/trouble_obs_mco.adoc
@@ -12,7 +12,7 @@ Data from the {product-title-short} cluster overview dashboard is empty, however
 [#symptom-2-pvc-does-not-change-after-editing-statefulSetSize]
 == Symptom 2: PVC does not change after editing statefulSetSize
 
-Additionally, on your managed clusters you might receive a message in the logs for any `_metrics-collector-deployment-x_` pods that are running in the `_open-cluster-management-addon-observability_` namespace. You might receive the following error message, along with text that references that the disk is full:
+Additionally, on your managed clusters you might receive a message in the logs for any `metrics-collector-deployment-x` pods that are running in the `open-cluster-management-addon-observability` namespace. You might receive the following error message, along with text that references that the disk is full:
 
 ----
 HTTP 500
@@ -37,13 +37,13 @@ kubelet_volume_stats_available_bytes{namespace="open-cluster-management-observab
 +
 *Note:* If the value is 0, then the disk is full. If the disk is full continue with the following tasks.
 
-. Expand the `_data-observability-observatorium-thanos-receive-default-x_` PVC to update the `_storage_` parameter to a greater value than the `_statefulSetSize_` value  from the MultiClusterObservability (mco) CR. Run the following command for each `_data-observability-observatorium-thanos-receive-default-x_` PVC:
+. Expand the `data-observability-observatorium-thanos-receive-default-x` PVC to update the `_storage_` parameter to a greater value than the `_statefulSetSize_` value  from the MultiClusterObservability (mco) CR. Run the following command for each `data-observability-observatorium-thanos-receive-default-x` PVC:
 +
 ----
 kubectl get pvc data-observability-observatorium-thanos-receive-default-0 -o yaml
 ----
 +
-Your `_data-observability-observatorium-thanos-receive-default-x_` PVC might resemble the following content:
+Your `data-observability-observatorium-thanos-receive-default-x` PVC might resemble the following content:
 +
 ----
 spec:
@@ -60,7 +60,7 @@ This might take some time to work. Your changes go into effect when the value of
 .. Log in to your {product-title-short} console.
 .. From the navigation menu, select *Observe environments* > *Overview*.
 .. Click the Grafana link that is near the console header to view the metrics from your managed clusters.
-.. Check the `_metrics-collector-deployment-x_` pod logs. When the error is fixed in the logs, the following message appears: `Metrics pushed successfully`.
+.. Check the `metrics-collector-deployment-x` pod logs. When the error is fixed in the logs, the following message appears: `Metrics pushed successfully`.
 .. Confirm if the disk space is no longer full by running a query from your {ocp} console. Enter the following query in the _Expression_ window and sort the query to ascend by the _Volume_ column:
 +
 ----

--- a/troubleshooting/trouble_obs_mco.adoc
+++ b/troubleshooting/trouble_obs_mco.adoc
@@ -12,7 +12,7 @@ Data from the {product-title-short} cluster overview dashboard is empty, however
 [#symptom-2-pvc-does-not-change-after-editing-statefulSetSize]
 == Symptom 2: PVC does not change after editing statefulSetSize
 
-Additionally, on your managed clusters you might receive a message in the logs for any `metrics-collector-deployment-*` pods that are running in the `open-cluster-management-addon-observability` namespace. You might receive the following error message, along with text that references that the disk is full:
+Additionally, on your managed clusters you might receive a message in the logs for any `_metrics-collector-deployment-x_` pods that are running in the `_open-cluster-management-addon-observability_` namespace. You might receive the following error message, along with text that references that the disk is full:
 
 ----
 HTTP 500
@@ -37,13 +37,13 @@ kubelet_volume_stats_available_bytes{namespace="open-cluster-management-observab
 +
 *Note:* If the value is 0, then the disk is full. If the disk is full continue with the following tasks.
 
-. Expand the `data-observability-observatorium-thanos-receive-default-*` PVC to update the `storage` parameter to a greater value than the `statefulSetSize` value  from the MultiClusterObservability (mco) CR. Run the following command for each `data-observability-observatorium-thanos-receive-default-*` PVC:
+. Expand the `_data-observability-observatorium-thanos-receive-default-x_` PVC to update the `_storage_` parameter to a greater value than the `_statefulSetSize_` value  from the MultiClusterObservability (mco) CR. Run the following command for each `_data-observability-observatorium-thanos-receive-default-x_` PVC:
 +
 ----
-kubectl get pvc data-observability-observatorium-thanos-receive-default-* -o yaml
+kubectl get pvc data-observability-observatorium-thanos-receive-default-0 -o yaml
 ----
 +
-Your `data-observability-observatorium-thanos-receive-default-x` PVC might resemble the following content:
+Your `_data-observability-observatorium-thanos-receive-default-x_` PVC might resemble the following content:
 +
 ----
 spec:
@@ -54,13 +54,13 @@ spec:
       storage: 
 ----
 +
-This might take some time to work. Your changes go into effect when the value of `storage` and `status` match. Run the previous command to check.
+This might take some time to work. Your changes go into effect when the value of `_storage_` and `_status_` match. Run the previous command to check.
 
 . Verify the fix by completing the following steps:
 .. Log in to your {product-title-short} console.
 .. From the navigation menu, select *Observe environments* > *Overview*.
 .. Click the Grafana link that is near the console header to view the metrics from your managed clusters.
-.. Check the `metrics-collector-deployment-x` pod logs. When the error is fixed in the logs, the following message appears: `Metrics pushed successfully`.
+.. Check the `_metrics-collector-deployment-x_` pod logs. When the error is fixed in the logs, the following message appears: `Metrics pushed successfully`.
 .. Confirm if the disk space is no longer full by running a query from your {ocp} console. Enter the following query in the _Expression_ window and sort the query to ascend by the _Volume_ column:
 +
 ----


### PR DESCRIPTION
Syntax error (inconsistent) when there was an asterisk surrounded by code tick (`) make the variable monospaced.
https://github.com/open-cluster-management/backlog/issues/8303

Along with ensuring that variables are italic monospaced according to the IBM Style Guide.