### PR TITLE
updates for search related to the Overview page

### DIFF
--- a/console/console.adoc
+++ b/console/console.adoc
@@ -15,7 +15,6 @@ image:../images/nav-2.0.png[Navigation]
 * <<observe-environment-details,Observe environment details>>
 * <<automate-infrastructure,Automate Infrastructure>>
 * <<manage-applications,Manage applications>>
-* <<topology-page,Topology page>>
 * <<governance-and-risk-dashboard,Governance and risk dashboard>>
 
 To learn about Search, see xref:../console/search.adoc#search-in-the-console[Search in the console]
@@ -48,12 +47,6 @@ When you select _Create resource_, you can create a YAML file or JSON file for a
 
 You can gain insight to optimize your managed clusters by viewing cluster and pod information from Grafana dashboards. For more details, see link:../observability/observe_intro.adoc#observing-environments[Observing environments].
 
-
-[#filtering-your-results]
-=== Filtering your results
-
-You can personalize your view of the page by using the filtering feature. Click *Filter results* to specify what information is displayed on your page.
-
 [#automate-infrastructure]
 == Automate infrastructure
 
@@ -67,14 +60,9 @@ Click *New application* to edit a `.yaml` file and create your application. Clic
 [#viewing-your-pod-health]
 === Viewing your pod health
 
-View the pod health for all of your clusters by expanding the Heatmap.
+View the pod health for all of your clusters by expanding the Heat map.
 
 Click *Show details* to view the map. The size of the color-coordinated boxes represents the number of nodes on your cluster. Hover your cursor over the box to view the response time of your cluster.
-
-[#topology-page]
-== Topology page
-
-Use the Topology page to display Kubernetes objects and associated objects within a cluster. For more information, see the link:../observability/observe_intro.adoc#topology-page[Topology page section] in _Observing environments_.
 
 [#governance-and-risk-dashboard]
 == Governance and risk dashboard


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/8601

I removed the Topology section based on the deprecation mentioned here: https://github.com/open-cluster-management/backlog/issues/8498