### PR TITLE
open-cluster-management/backlog/issues/8329 

### DIFF
--- a/manage_cluster/prov_conn_vm.adoc
+++ b/manage_cluster/prov_conn_vm.adoc
@@ -1,7 +1,7 @@
 [#creating-a-provider-connection-for-vmware-vsphere]
 = Creating a provider connection for VMware vSphere
 
-You need a provider connection to use {product-title} console to deploy and manage a {ocp} cluster on VMware vSphere. *Note:* Only {ocp-short} versions 4.5.x, and later, are supported.
+You need a provider connection to use {product-title} console to deploy and manage a {ocp} cluster on VMware vSphere. *Note:* Only {ocp-short} versions 4.5.x and later, are supported.
 
 *Note:* This procedure must be done before you can create a cluster with {product-title-short}.
 
@@ -13,7 +13,7 @@ You must have the following prerequisites before you create a provider connectio
 * A deployed {product-title-short} hub cluster on {ocp-short} version 4.5, or later.
 * Internet access for your {product-title-short} hub cluster so it can create the Kubernetes cluster on VMware vSphere.
 * VMware vSphere login credentials and vCenter requirements configured for {ocp-short} when using installer-provisioned infrastructure.
-See https://docs.openshift.com/container-platform/4.5/installing/installing_vsphere/installing-vsphere-installer-provisioned.html[Installing a cluster on vSphere]. These credentials include the following information:
+See https://docs.openshift.com/container-platform/4.7/installing/installing_vsphere/installing-vsphere-installer-provisioned.html[Installing a cluster on vSphere]. These credentials include the following information:
 ** vCenter account privileges.
 ** Cluster resources.
 ** DHCP available.
@@ -34,31 +34,29 @@ Existing provider connections are displayed.
 . Add a name for your provider connection.
 . Select a namespace for your provider connection from the list.
 +
-*Tip:* Create a namespace specifically to host your provider connections, for both convenience and added security.
+*Tip:* Create a namespace specifically to host your provider connections for both convenience and added security.
 
-. You can optionally add a _Base DNS domain_ for your provider connection. If you add the base DNS domain to the provider connection, it is automatically populated in the correct field when you create a cluster with this provider connection.
-. Add your _VMware vCenter server fully-qualified host name or IP address_. The value must be defined in the vCenter server root CA certificate. If possible, use the fully-qualified host name.
-. Add your _VMware vCenter username_.
-. Add your _VMware vCenter password_.
-. Add your _VMware vCenter root CA certificate_.
-.. You can download your certificate in the `download.zip` package with the certificate from your VMware vCenter server at: `https://<vCenter_address>/certs/download.zip`. Replace _vCenter_address_ with the address to your vCenter server. 
-.. Unpackage the `download.zip`.
+. You can optionally add a Base DNS domain for your provider connection. If you add the base DNS domain to the provider connection, it is automatically populated in the correct field when you create a cluster with this provider connection.
+. Add your VMware vCenter server fully-qualified host name or IP address. The value must be defined in the vCenter server root CA certificate. If possible, use the fully-qualified host name.
+. Add your VMware vCenter username.
+. Add your VMware vCenter password.
+. Add your VMware vCenter root CA certificate.
+.. You can download your certificate in the `download.zip` package with the certificate from your VMware vCenter server at: `https://<vCenter_address>/certs/download.zip`. Replace `vCenter_address` with the address to your vCenter server. 
+.. Unpackage the `download.zip` file.
 .. Use the certificate from the `certs/<platform>` directory that has a `.0` extension. *Tip:* You can use the `ls certs/<platform>` command to list all of the available certificates for your platform.
 +
-Replace `_<platform>_` with the abbreviation for your platform: `lin`, `mac`, or `win`. 
+Replace `platform` with the abbreviation for your platform: `lin`, `mac`, or `win`. 
 +
 For example: `certs/lin/3a343545.0`
-. Add your _VMware vSphere cluster name_.
-. Add your _VMware vSphere datacenter_.
-. Add your _VMware vSphere default datastore_.
+. Add your VMware vSphere cluster name.
+. Add your VMware vSphere datacenter.
+. Add your VMware vSphere default datastore.
 
-. Enter your _Red Hat OpenShift pull secret_.
+. Enter your {ocp-short} pull secret.
 You can download your pull secret from https://cloud.redhat.com/openshift/install/pull-secret[Pull secret].
-. Add your _SSH private key_ and _SSH public key_, which allows you to connect to the cluster.
-You can use an existing key pair, or create a new one with key generation program.
-See https://docs.openshift.com/container-platform/4.5/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default[Generating an SSH private key and adding it to the agent] for more information.
-. Click *Create*.
-When you create the provider connection, it is added to the list of provider connections.
+. Add your SSH private key and your SSH public key, which allows you to connect to the cluster. You can use an existing key pair, or create a new one with key generation program.
+See https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default[Generating an SSH private key and adding it to the agent] for more information.
+. Click *Create*. When you create the provider connection, it is added to the list of provider connections.
 
 You can create a cluster that uses this provider connection by completing the steps in xref:../manage_cluster/create_vm.adoc#creating-a-cluster-on-vmware-vsphere[Creating a cluster on VMware vSphere].
 
@@ -69,5 +67,5 @@ When you are no longer managing a cluster that is using a provider connection, d
 
 . From the navigation menu, navigate to *Automate infrastructure* > *Clusters*.
 . Select *Provider connections*.
-. Select the options menu beside the provider connection that you want to delete.
+. Select the options menu for the provider connection that you want to delete.
 . Select *Delete connection*.


### PR DESCRIPTION
Searching for answers for the credentials doc and did a quick peer review. 

1. Italics not needed for general terms, and for code in text, as we discussed a few times, changed those so please double check.
2. `Beside` is replaced since non-directional for accessibility.
3. `File` after example of a file.

Maybe other small changes but:

I am not sure what line 50 is an example of so I could not edit. Maybe what it is an example of and why a list follows it can help... when I read it, I was confused.

Still did not find what I need for rotation topic so I will have to comment out what we don't have for 2.2 in this issue.