### PR TITLE
Updating the instructions for E8 scan

### DIFF
--- a/security/create_e8_scan_pol.adoc
+++ b/security/create_e8_scan_pol.adoc
@@ -15,7 +15,7 @@ Complete the following steps to create a E8 scan policy from the console:
 
 . From the navigation menu, select *Govern risk*. 
 
-. Click *Create policy*. As you complete the YAML form, select *E8Scan* from the _Specifications_ field.
+. Click *Create policy*. Select _Custom specification_ from the _Specification_ field. Copy and paste the [`policy-e8-scan`](https://github.com/open-cluster-management/policy-collection/blob/master/stable/CM-Configuration-Management/policy-compliance-operator-e8-scan.yaml) from the policy-collection repository.
 + 
 The following resources are created: ScanSettingBinding (`_ScanSettingBinding_`), a ComplianceSuite (`_compliance-suite-e8_`), and a ComplianceCheckResult (`_compliance-suite-e8-results_`).
 +


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/10654

Is the E8 policy named something different? The last time that I used a cluster to verify the name was E8Scan. Since, the policy was not available as a option for the Specification field, should it still remain in the stable folder?
