### PR TITLE
remove availabilityConfig and update storageConfig related doc

### DIFF
--- a/apis/observability.json.adoc
+++ b/apis/observability.json.adoc
@@ -310,9 +310,9 @@ __optional__|The amount of storage applied to the thanos compact stateful sets. 
 |**metricObjectStorage** +
 __required__|Object store to configure secrets for metrics.|<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_smetricobjectstorage,metricObjectStorage>>
 |**receiveStorageSize** +
-__optional__|The amount of storage applied to the thanos receive stateful sets. Default value is `100Gi`.|string
+__optional__|The amount of storage applied to thanos receive stateful sets. Default value is `100Gi`.|string
 |**ruleStorageSize** +
-__optional__|The amount of storage applied to the thanos rule stateful sets. Default value is `1Gi`.|string
+__optional__|The amount of storage applied to thanos rule stateful sets. Default value is `1Gi`.|string
 |**storageClass** +
 __optional__|Specify the `storageClass` stateful sets. This storage is used for the object storage if `metricObjectStorage` is configured for your operating system to create storage. Default value is `gp2`.|string
 |**storeStorageSize** +

--- a/apis/observability.json.adoc
+++ b/apis/observability.json.adoc
@@ -264,11 +264,8 @@ __required__|<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobserv
 [options="header", cols=".^2a,.^6a,.^4a"]
 |===
 |Name|Description|Schema
-|**availabilityConfig** +
-__optional__|The parameter used to select high-availability support. This provides support in the case of a failover, and consumes more resources. +
- Options: `Basic` and `High`| string
 |**enableDownSampling** +
-__optional__| Enable or disable the downsample. Default value is `false`. If there is no downsample data, the query is unavailable.| boolean
+__optional__| Enable or disable the downsample. Default value is `true`. If there is no downsample data, the query is unavailable.| boolean
 |**imagePullPolicy** +
 __optional__| Pull policy for the Observability images.|string
 |**imagePullSecret** +

--- a/apis/observability.json.adoc
+++ b/apis/observability.json.adoc
@@ -304,17 +304,17 @@ __optional__|Interval for when the observability add-on sends metrics to the hub
 |===
 |Name|Description|Schema
 |**alertmanagerStorageSize** +
-__optional__|The amount of storage applied to alertmanager stateful sets. Default value is `1Gi`.|string
+__optional__|The amount of storage applied to the alertmanager stateful sets. Default value is `1Gi`.|string
 |**compactStorageSize** +
-__optional__|The amount of storage applied to thanos compact stateful sets. Default value is `100Gi`.|string
+__optional__|The amount of storage applied to the thanos compact stateful sets. Default value is `100Gi`.|string
 |**metricObjectStorage** +
 __required__|Object store to configure secrets for metrics.|<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_smetricobjectstorage,metricObjectStorage>>
 |**receiveStorageSize** +
-__optional__|The amount of storage applied to thanos receive stateful sets. Default value is `100Gi`.|string
+__optional__|The amount of storage applied to the thanos receive stateful sets. Default value is `100Gi`.|string
 |**ruleStorageSize** +
-__optional__|The amount of storage applied to thanos rule stateful sets. Default value is `1Gi`.|string
+__optional__|The amount of storage applied to the thanos rule stateful sets. Default value is `1Gi`.|string
 |**storageClass** +
-__optional__|Specify the `storageClass` StatefulSets. This storage is used for the object storage if `metricObjectStorage` is configured for your operating system to create storage. Default value is `gp2`.|string
+__optional__|Specify the `storageClass` stateful sets. This storage is used for the object storage if `metricObjectStorage` is configured for your operating system to create storage. Default value is `gp2`.|string
 |**storeStorageSize** +
 __optional__|The amount of storage applied to thanos store stateful sets. Default value is `10Gi`.|string
 |===

--- a/apis/observability.json.adoc
+++ b/apis/observability.json.adoc
@@ -264,7 +264,7 @@ __required__|<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobserv
 [options="header", cols=".^2a,.^6a,.^4a"]
 |===
 |Name|Description|Schema
-|**enableDownSampling** +
+|**enableDownsampling** +
 __optional__| Enable or disable the downsample. Default value is `true`. If there is no downsample data, the query is unavailable.| boolean
 |**imagePullPolicy** +
 __optional__| Pull policy for the Observability images.|string

--- a/apis/observability.json.adoc
+++ b/apis/observability.json.adoc
@@ -104,7 +104,7 @@ __required__|Parameters describing the MultiClusterObservability resource to be 
     "name": "example"
   },
   "spec": {
-    "storageConfigObject": {
+    "storageConfig": {
       "metricObjectStorage": {
         "name": "thanos-object-storage",
         "key": "thanos.yaml"
@@ -280,8 +280,8 @@ __optional__|The amount of time to retain samples of resolution 2 (1 hour) in a 
 __optional__|The amount of time to retain samples of resolution 1 (5 minutes) in a bucket. Default value is 14 days (`14d`).|string
 |**retentionResolutionRaw** +
 __optional__|The amount of time to retain raw samples of resolution in a bucket.|string
-|**storageConfigObject** +
-__required__|Specifies the storage to be used by Observability. |<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_storageconfigobject,storageConfigObject>>
+|**storageConfig** +
+__required__|Specifies the storage to be used by Observability. |<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_storageconfig,storageConfig>>
 |===
 
 [[_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_observabilityaddonspec]]
@@ -293,22 +293,30 @@ __required__|Specifies the storage to be used by Observability. |<<_rhacm-docs_a
 |**enableMetrics** +
 __optional__|Indicates if the observability add-on sends metrics to the hub cluster. Default value is `true`.| boolean
 |**interval** +
-__optional__|Interval for when the observability add-on sends metrics to the hub cluster. Default value is 60 seconds (`60s`). |integer
+__optional__|Interval for when the observability add-on sends metrics to the hub cluster. Default value is 30 seconds (`30s`). |integer
 |===
 
 
-[[_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_storageconfigobject]]
-**storageConfigObject**
+[[_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_storageconfig]]
+**storageConfig**
 
 [options="header", cols=".^2a,.^3a,.^4a"]
 |===
 |Name|Description|Schema
+|**alertmanagerStorageSize** +
+__optional__|The amount of storage applied to alertmanager stateful sets. Default value is `1Gi`.|string
+|**compactStorageSize** +
+__optional__|The amount of storage applied to thanos compact stateful sets. Default value is `100Gi`.|string
 |**metricObjectStorage** +
 __required__|Object store to configure secrets for metrics.|<<_rhacm-docs_apis_multiclusterobservability_jsonmulticlusterobservability_smetricobjectstorage,metricObjectStorage>>
-|**statefulSetSize** +
-__optional__|The amount of storage that is applied to the Observability StatefulSets, i.e. Thanos store, rule, compact, and receiver. Default value is `10Gi`.|string
-|**statefulSetStorageClass** +
-__optional__|Specify the `storageClass` StatefulSets. This storage is used for the object storage if `MetricObjectStorage` is configured for your operating system to create storage. Default value is `gp2`.|string
+|**receiveStorageSize** +
+__optional__|The amount of storage applied to thanos receive stateful sets. Default value is `100Gi`.|string
+|**ruleStorageSize** +
+__optional__|The amount of storage applied to thanos rule stateful sets. Default value is `1Gi`.|string
+|**storageClass** +
+__optional__|Specify the `storageClass` StatefulSets. This storage is used for the object storage if `metricObjectStorage` is configured for your operating system to create storage. Default value is `gp2`.|string
+|**storeStorageSize** +
+__optional__|The amount of storage applied to thanos store stateful sets. Default value is `10Gi`.|string
 |===
 
 

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -169,7 +169,6 @@ Update the `multicluster-observability-operator` resource by setting `enableMetr
 
 ----
 spec:
-  availabilityConfig: High # Available values are High or Basic
   imagePullPolicy: Always
   imagePullSecret: multiclusterhub-operator-pull-secret
   observabilityAddonSpec: # The ObservabilityAddonSpec defines the global settings for all managed clusters which have observability add-on enabled

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -130,7 +130,6 @@ kind: MultiClusterObservability
 metadata:
   name: observability # Your customized name of MulticlusterObservability CR
 spec:
-  availabilityConfig: High # Available values are High or Basic
   enableDownSampling: true # The default value is true. This is recommended as querying long-time ranges downsampled data is efficient and useful.
   imagePullPolicy: Always
   imagePullSecret: multiclusterhub-operator-pull-secret

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -130,7 +130,7 @@ kind: MultiClusterObservability
 metadata:
   name: observability # Your customized name of MulticlusterObservability CR
 spec:
-  enableDownSampling: true # The default value is true. This is recommended as querying long-time ranges downsampled data is efficient and useful.
+  enableDownsampling: true # The default value is true. This is recommended as querying long-time ranges downsampled data is efficient and useful.
   imagePullPolicy: Always
   imagePullSecret: multiclusterhub-operator-pull-secret
   observabilityAddonSpec: # The ObservabilityAddonSpec defines the global settings for all managed clusters which have observability add-on enabled

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -135,7 +135,7 @@ spec:
   imagePullSecret: multiclusterhub-operator-pull-secret
   observabilityAddonSpec: # The ObservabilityAddonSpec defines the global settings for all managed clusters which have observability add-on enabled
     enableMetrics: true # EnableMetrics indicates the observability addon push metrics to hub server
-    interval: 60 # Interval for the observability addon push metrics to hub server
+    interval: 30 # Interval for the observability addon push metrics to hub server
   retentionConfig:
     blockDuration: 2h # Block duration for TSDB block
     cleanupInterval: 5m # How often we should clean up partially uploaded blocks and blocks with deletion mark in the background when --wait has been enabled
@@ -146,14 +146,14 @@ spec:
     retentionResolutionRaw: 5d # How long to retain raw samples in bucket
   storageConfig: # Specifies the storage to be used by Observability
     alertmanagerStorageSize: 1Gi # The amount of storage applied to alertmanager stateful sets
-    compactStorageSize: 4Gi # The amount of storage applied to thanos compact stateful sets
+    compactStorageSize: 100Gi # The amount of storage applied to thanos compact stateful sets
     metricObjectStorage: # Configuring access to object storage
       key: thanos.yaml
       name: thanos-object-storage
-    receiveStorageSize: 4Gi # The amount of storage applied to thanos receive stateful sets
+    receiveStorageSize: 100Gi # The amount of storage applied to thanos receive stateful sets
     ruleStorageSize: 1Gi # The amount of storage applied to thanos rule stateful sets
     storageClass: gp2 # Specify the storage class for stateful sets
-    storeStorageSize: 1Gi # The amount of storage applied to thanos store stateful sets,
+    storeStorageSize: 10Gi # The amount of storage applied to thanos store stateful sets,
 ----
 +
 You might want to modify the value for the `retentionConfig` parameter. For more information, see https://thanos.io/v0.8/components/compact/#downsampling-resolution-and-retention[Thanos Downsampling resolution and retention]. Depending on the number of managed clusters, you might want to update the amount of storage for stateful sets, see link:../apis/observability.json.adoc#observability-api[Observability API] for more information.

--- a/troubleshooting/trouble_observability.adoc
+++ b/troubleshooting/trouble_observability.adoc
@@ -6,7 +6,7 @@ After you install the observability component, the component might be stuck and 
 [#symptom-observability-status-stuck]
 == Symptom: MultiClusterObservability resource status stuck
 
-If the observability status is stuck in an `Installing` status after you install and create the Observability custom resource definition (CRD), it is possible that there is no value defined for the `spec:storageConfigObject:statefulSetStorageClass` parameter. Alternatively, the observability component automatically finds the default `storageClass`, but if there is no value for the storage, the component remains stuck with the `Installing` status. 
+If the observability status is stuck in an `Installing` status after you install and create the Observability custom resource definition (CRD), it is possible that there is no value defined for the `spec:storageConfig:storageClass` parameter. Alternatively, the observability component automatically finds the default `storageClass`, but if there is no value for the storage, the component remains stuck with the `Installing` status.
 
 [#resolving-observability-status-stuck]
 == Resolving the problem: MultiClusterObservability resource status stuck


### PR DESCRIPTION
we do not support `availabilityConfig` config in the observability service. so we need to remove this config.
Signed-off-by: Song Song Li <ssli@redhat.com>