### PR TITLE
add deleted metrics doc

### DIFF
--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -150,7 +150,7 @@ Complete the following steps to delete default metrics:
 oc get mco observability -o yaml
 ----
 
-. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter with a hyphen `-` at the end. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -150,7 +150,7 @@ Complete the following steps to delete default metrics:
 oc get mco observability -o yaml
 ----
 
-. Add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -110,7 +110,7 @@ Complete the following steps to add custom metrics:
 oc get mco observability -o yaml
 ----
 
-. Create a new file `observability-metrics-custom-allowlist.yaml` with the following content. Add the name of the custom metric to the `metrics_list.yaml` parameter. For example, add `node_memory_MemTotal_bytes` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. Create a file named `observability-metrics-custom-allowlist.yaml` with the following content. Add the name of the custom metric to the `metrics_list.yaml` parameter. For example, add `node_memory_MemTotal_bytes` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap
@@ -150,7 +150,7 @@ Complete the following steps to delete default metrics:
 oc get mco observability -o yaml
 ----
 
-. Create a new file `observability-metrics-custom-allowlist.yaml` with the following content. Add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. Add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -110,13 +110,7 @@ Complete the following steps to add custom metrics:
 oc get mco observability -o yaml
 ----
 
-. Create a YAML file for the `observability-metrics-custom-allowlist` ConfigMap by running the following command:
-+
-----
-touch observability-metrics-custom-allowlist.yaml
-----
-
-. Add the name of the name of the custom metric to the `metrics_list.yaml` parameter. For example, add `node_memory_MemTotal_bytes` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. Create a new file `observability-metrics-custom-allowlist.yaml` with the following content. Add the name of the custom metric to the `metrics_list.yaml` parameter. For example, add `node_memory_MemTotal_bytes` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -142,6 +142,53 @@ oc apply -n open-cluster-management-observability -f observability-metrics-custo
 
 Data from your custom metric is collected.
 
+[#deleting-default-metrics]
+== Deleting default metrics
+
+If you want to delete some metrics from the default metrics. You can add the metric name to the `metrics_list.yaml` file and end it with the hyphen `-`.
+
+Complete the following steps to delete default metrics:
+
+. Log in to your cluster.
+. Verify that `mco observability` is enabled. Check for the following message in the `status.conditions.message` reads: `Observability components are deployed and running`. Run the following command:
++
+----
+oc get mco observability -o yaml
+----
+
+. Create a YAML file for the `observability-metrics-custom-allowlist` ConfigMap by running the following command:
++
+----
+cat observability-metrics-custom-allowlist.yaml
+----
+
+. Add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
++
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: observability-metrics-custom-allowlist
+data:
+  metrics_list.yaml: |
+    names:
+      - node_memory_MemTotal_bytes
+      - rest_client_requests_total-
+----
+
+. Create the `observability-metrics-custom-allowlist` ConfigMap in the 
+`open-cluster-management-observability` namespace by running the following command:
++
+----
+oc apply -n open-cluster-management-observability -f observability-metrics-custom-allowlist.yaml
+----
+
+. Verify that your default metric is not being collected from your managed clusters by viewing the metric on the Grafana dashboard. From your hub cluster, select the **Grafana dashboard** link.
+
+. From the Grafana search bar, enter the metric that you want to check.
+
+Data from your default metric is deleted.
+
 [#viewing-and-exploring-data]
 == Viewing and exploring data
 

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -113,7 +113,7 @@ oc get mco observability -o yaml
 . Create a YAML file for the `observability-metrics-custom-allowlist` ConfigMap by running the following command:
 +
 ----
-cat observability-metrics-custom-allowlist.yaml
+touch observability-metrics-custom-allowlist.yaml
 ----
 
 . Add the name of the name of the custom metric to the `metrics_list.yaml` parameter. For example, add `node_memory_MemTotal_bytes` to the metric list. Your YAML for the ConfigMap might resemble the following content:
@@ -156,13 +156,7 @@ Complete the following steps to delete default metrics:
 oc get mco observability -o yaml
 ----
 
-. Create a YAML file for the `observability-metrics-custom-allowlist` ConfigMap by running the following command:
-+
-----
-cat observability-metrics-custom-allowlist.yaml
-----
-
-. Add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. Create a new file `observability-metrics-custom-allowlist.yaml` with the following content. Add the name of the default metric to the `metrics_list.yaml` parameter and end it with the hyphen `-`. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap


### PR DESCRIPTION
if a metric name ending in `-`,  we will delete this metric from the default allowlist.

https://github.com/open-cluster-management/backlog/issues/12106

Signed-off-by: Song Song Li <ssli@redhat.com>