### PR TITLE
Updating the verb remove vs delete

### DIFF
--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -136,10 +136,10 @@ oc apply -n open-cluster-management-observability -f observability-metrics-custo
 
 Data from your custom metric is collected.
 
-[#deleting-default-metrics]
-== Deleting default metrics
+[#removing-default-metrics]
+== Remove default metrics
 
-If you want to delete some metrics from the default metrics. You can add the metric name to the `metrics_list.yaml` file and end it with the hyphen `-`.
+If you want data to not be collected for a specific metric, you can remove the metric from the `observability-metrics-custom-allowlist.yaml` file. You can add the metric name to the `metrics_list.yaml` file and end it with the hyphen `-`.
 
 Complete the following steps to delete default metrics:
 
@@ -175,7 +175,7 @@ oc apply -n open-cluster-management-observability -f observability-metrics-custo
 
 . From the Grafana search bar, enter the metric that you want to check.
 
-Data from your default metric is deleted.
+Data from your default metric is no longer being collected.
 
 [#viewing-and-exploring-data]
 == Viewing and exploring data

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -139,7 +139,7 @@ Data from your custom metric is collected.
 [#removing-default-metrics]
 == Remove default metrics
 
-If you want data to not be collected for a specific metric, you can remove the metric from the `observability-metrics-custom-allowlist.yaml` file. You can add the metric name to the `metrics_list.yaml` file and end it with the hyphen `-`.
+If you want data to not be collected for a specific metric, you can remove the metric from the `observability-metrics-custom-allowlist.yaml` file. When you remove a metric, you are also deleting the metric. You can add the metric name to the `metrics_list.yaml` file and end it with the hyphen `-`.
 
 Complete the following steps to delete default metrics:
 

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -8,8 +8,9 @@ Collect logs about new information that is created for observability resources w
 * <<creating-custom-rules,Creating custom rules>>
 * <<configuring-rules-for-alertmanager,Configuring rules for AlertManager>>
 * <<adding-custom-metrics, Adding custom metrics>>
+* <<removing-default-metrics,Removing default metrics>>
 * <<viewing-and-exploring-data,Viewing and exploring data>>
-* <<disable-metrics-collector,Disable _metrics-collector_>>
+* <<disable-metrics-collector,Disabling _metrics-collector_>>
 
 [#creating-custom-rules]
 == Creating custom rules
@@ -137,7 +138,7 @@ oc apply -n open-cluster-management-observability -f observability-metrics-custo
 Data from your custom metric is collected.
 
 [#removing-default-metrics]
-== Remove default metrics
+== Removing default metrics
 
 If you want data to not be collected for a specific metric, you can remove the metric from the `observability-metrics-custom-allowlist.yaml` file. When you remove a metric, you are also deleting the metric. You can add the metric name to the `metrics_list.yaml` file and end it with the hyphen `-`.
 
@@ -189,12 +190,12 @@ You can also  access Grafana dashboards from the _Clusters_ page. From the navig
 . Access the Prometheus metric explorer by selecting the *Explore* icon from the Grafana navigation menu.
 
 [#disable-metrics-collector]
-== Disable _metrics-collector_
+== Disabling _metrics-collector_
 
 You can disable the `metrics-collector`, which stops it from collecting the data and sending the collection data to the observability service. 
 
 [#disable-metrics-collector-on-all-clusters]
-=== Disable _metrics-collector_ on all clusters
+=== Disabling _metrics-collector_ on all clusters
 
 Disable the `metrics-collector` pod to stop data from being collected and sent to the observability service on the {product-title-short} hub cluster. 
 
@@ -211,7 +212,7 @@ spec:
 ----
 
 [#disable-metrics-collector-on-a-single-cluster]
-=== Disable _metrics-collector_ on a single cluster
+=== Disabling _metrics-collector_ on a single cluster
 
 You can disable the `metrics-collector` on specific managed clusters by completing one of the following procedures:
 

--- a/release_notes/whats_new.adoc
+++ b/release_notes/whats_new.adoc
@@ -32,7 +32,7 @@ You can now define the storage settings for search persistence. Persistence is e
 //10937 adding this comment to verify which issue are related to the entries, this comment will be deleted before GA
 * {product-title-short} observability service supports 7.4.2 of Grafana. See the link:../observability/observe_environments.adoc#observability-service[Observability service section] to learn more information.
 
-* You can now remove default metrics. For more information, see link:../observability/customize_observability.adoc#deleting-default-metrics[Deleting default metrics].
+* You can now remove default metrics. For more information, see link:../observability/customize_observability.adoc#removing-default-metrics[Removing default metrics].
 
 [#cluster-management]
 == Cluster management


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/12106
https://github.com/open-cluster-management/backlog/issues/12336

After rereading a few times, I thought it would be best to change delete to remove. @songleo are metrics deleted (no longer existing) when it is not in the allowlist or is data no longer being collected for that metric, but still existing as a metric?  