### PR TITLE
update doc for metrics deleted

### DIFF
--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -158,7 +158,7 @@ Complete the following steps to delete default metrics:
 oc get mco observability -o yaml
 ----
 
-. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter with a hyphen `-` at the end. For example, add `rest_client_requests_total-` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter with a hyphen `-` at the start. For example, add `-rest_client_requests_total` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap
@@ -169,7 +169,7 @@ data:
   metrics_list.yaml: |
     names:
       - node_memory_MemTotal_bytes
-      - rest_client_requests_total-
+      - -rest_client_requests_total
 ----
 
 . Create the `observability-metrics-custom-allowlist` ConfigMap in the 

--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -158,7 +158,7 @@ Complete the following steps to delete default metrics:
 oc get mco observability -o yaml
 ----
 
-. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter with a hyphen `-` at the start. For example, add `-rest_client_requests_total` to the metric list. Your YAML for the ConfigMap might resemble the following content:
+. In the `observability-metrics-custom-allowlist.yaml` file, add the name of the default metric to the `metrics_list.yaml` parameter with a hyphen `-` at the start of the metric name. For example, add `-rest_client_requests_total` to the metric list. Your YAML for the ConfigMap might resemble the following content:
 +
 ----
 kind: ConfigMap


### PR DESCRIPTION
- To add the hyphen "-" before the metric
name. it should be easily sorted and see which metrics are removed
- https://github.com/open-cluster-management/backlog/issues/12106

Signed-off-by: Song Song Li <ssli@redhat.com>