### PR TITLE
Fix design_grafana typo

### DIFF
--- a/observability/design_grafana.adoc
+++ b/observability/design_grafana.adoc
@@ -60,7 +60,7 @@ If you do not have permissions to run the previously mentioned script, complete 
 +
 .. Select a dashboard and click the *Dashboard settings* icon. 
 .. Click the *JSON Model* icon from the navigation panel.
-.. Copy the dashboard JSON data and paste it in the `_metadata_` section.
+.. Copy the dashboard JSON data and paste it in the `_data_` section.
 .. Modify the `_name_` and replace `_$your-dashboard-name_`. Your ConfigMap might resemble the following file:
 +
 ----
@@ -72,7 +72,7 @@ metadata:
   labels:
     grafana-custom-dashboard: "true"
 data:
-  $your-dashboard-name.json: |
+  $your-dashboard-name.json: |-
     $your_dashboard_json
 ----
 +


### PR DESCRIPTION
The dashboard JSON data should be copied to `data` not `metadata`