### PR TITLE
Making updates for Observability 2.2

### DIFF
--- a/observing_environments/customize_observability.adoc
+++ b/observing_environments/customize_observability.adoc
@@ -19,7 +19,7 @@ You can create custom rules for the observability installation by adding Prometh
 ** Recording rules provide you the ability to precalculate, or computate expensive expressions as needed. The results are saved as a new set of time series.
 ** Alerting rules provide you the ability to specify the alert conditions based on how an alert should be sent to an external service.
 
-Define custom rules with Prometheus to create alert conditions, and send notifications to an external messaging service. *Note*: When you update your custom rules, `observability-thanos-rule` pods are restarted automatically.
+Define custom rules with Prometheus to create alert conditions, and send notifications to an external messaging service. *Note*: When you update your custom rules, `observability-observatorium-thanos-rule` pods are restarted automatically.
 
 Complete the following steps to create a custom rule: 
 

--- a/observing_environments/customize_observability.adoc
+++ b/observing_environments/customize_observability.adoc
@@ -16,14 +16,17 @@ Collect logs about new information that is created for observability resources w
 
 You can create custom rules for the observability installation by adding Prometheus https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/[recording rules] and https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules] to the observability resource. For more information, see https://prometheus.io/docs/prometheus/latest/configuration/configuration/[Prometheus configuration].
 
-Define custom rules with Prometheus to create alert conditions, and send notifications to an external messaging service. *Note*: When you update your custom rules, `observability-observatorium-thanos-rule` pods are restarted automatically.
+** Recording rules provide you the ability to precalculate, or computate expensive expressions as needed. The results are saved as a new set of time series.
+** Alerting rules provide you the ability to specify the alert conditions based on how an alert should be sent to an external service.
+
+Define custom rules with Prometheus to create alert conditions, and send notifications to an external messaging service. *Note*: When you update your custom rules, `observability-thanos-rule` pods are restarted automatically.
 
 Complete the following steps to create a custom rule: 
 
 . Log in to your {product-title-short} hub cluster.
 . Create a ConfigMap named `thanos-ruler-custom-rules` in the `open-cluster-management-observability` namespace. The key must be named, `custom_rules.yaml`, as shown in the following example. You can create multiple rules in the configuration:
 +
-By default, the out-of-the-box alert rules are defined in the ConfigMap in the `open-cluster-management-observability` namespace. 
+* By default, the out-of-the-box alert rules are defined in the `thanos-ruler-default-rules` ConfigMap in the  `open-cluster-management-observability` namespace. 
 +
 For example, you can create a custom alert rule that notifies you when your CPU usage passes your defined value: 
 +
@@ -44,6 +47,20 @@ data:
             cluster: "{{ $labels.cluster }}"
             prometheus: "{{ $labels.prometheus }}"
             severity: critical
+----
++
+* You can also create a custom recording rule within the `thanos-ruler-custom-rules` ConfigMap.
++
+For example, you can create a recording rule that provides you the ability to get the sum of the container memory cache of a pod. Your YAML might resemble the following content:
++
+----
+data:
+  custom_rules.yaml: |
+    groups:
+      - name: container-memory
+        rules:
+        - record: pod:container_memory_cache:sum
+          expr: sum(container_memory_cache{pod!=""}) BY (pod, container)
 ----
 +
 *Note*: If this is the first new custom rule, it is created immediately. For changes to the ConfigMap, you must restart the observability pods with the following command: `kubectl rollout restart statefulset observability-observatorium-thanos-rule -n open-cluster-management-observability`.


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/13367
https://github.com/open-cluster-management/backlog/issues/13376

@dislbenn may you confirm that my updates are correct for this version. The only thing that I did not change in 2.2 was the instruction to run a command to restart the pods. It is mentioned in the note on line 66