### PR TITLE
Organize the structure of observe_environment

### DIFF
--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -6,6 +6,7 @@ Monitor the health of your managed clusters with the observability service (`mul
 *Required access:* Cluster administrator or the `open-cluster-management:cluster-manager-admin` role.
 
 * <<prerequisites-observability,Prerequisites>>
+* <<observability-pod-capacity-requests,Observability pod capacity requests>>
 * <<enabling-observability,Enabling observability>>
 * <<creating-mco-cr,Creating the _MultiClusterObservability_ CR>>
 * <<disabling-observability-resource,Disabling observability>>
@@ -17,6 +18,135 @@ Monitor the health of your managed clusters with the observability service (`mul
 - You must configure an object store to create a storage solution. {product-title-short} only supports cloud providers with stable object stores, such as Amazon S3 (or other S3 compatible object stores like Ceph), Google Cloud Storage, Azure storage, and Red Hat OpenShift Data Foundation.
 +
 *Important*: When you configure your object store, ensure that you meet the encryption requirements necessary when sensitive data is persisted. For a complete list of the supported object stores, see https://thanos.io/tip/thanos/storage.md/#object-storage[Thanos documentation].
+
+[#observability-pod-capacity-requests]
+== Observability pod capacity requests
+
+Observability components require 2636mCPU and 11388Mi memory to install the observability service. View the following table of the pod capacity requests that is for five managed clusters with `observability-addons` enabled:
+
+.Observability pod capacity requests
+|===
+| Container name  | CPU (mCPU) | Memory (Mi) | Replicas | Pod total CPU | Pod total memory 
+
+| alertmanager
+| 4
+| 200
+| 3
+| 12
+| 600
+
+| config-reloader
+| 4
+| 25
+| 3
+| 12
+| 75
+
+| grafana
+| 4
+| 100
+| 2
+| 8
+| 200
+
+| grafana-dashboard-loader
+| 4
+| 50
+| 2
+| 8
+| 100
+
+| observatorium-api
+| 20
+| 128
+| 2
+| 40
+| 256
+
+| thanos-compact
+| 100
+| 512
+| 1
+| 100
+| 512
+
+| thanos-query
+| 300
+| 1024
+| 2
+| 600
+| 2048
+
+| thanos-query-frontend
+| 100
+| 256
+| 2
+| 200
+| 512
+
+| thanos-receive-controller
+| 4
+| 32
+| 1
+| 4
+| 32
+
+| thanos-receive
+| 300
+| 512
+| 3
+| 900
+| 1536
+
+| thanos-rule
+| 50
+| 512
+| 3
+| 150
+| 1536
+
+| configmap-reloader
+| 4
+| 25
+| 3
+| 12
+| 75
+
+| memcached
+| 45
+| 128
+| 3
+| 135
+| 384
+
+| exporter
+| 5
+| 50
+| 3
+| 15
+| 150
+
+| thanos-store
+| 100
+| 1024
+| 3
+| 300
+| 3072
+
+| observatorium-operator
+| 100
+| 100
+| 1
+| 100
+| 100
+
+| rbac-query-proxy
+| 20
+| 100
+| 2
+| 40
+| 200
+|===
 
 [#enabling-observability]
 == Enabling observability

--- a/observability/observe_environments.adoc
+++ b/observability/observe_environments.adoc
@@ -8,10 +8,7 @@ image:../images/RHACM-ObservabilityArch.png[Multicluster observability architect
 *Note*: The _on-demand log_ provides access for engineers to get logs for a given pod in real-time. Logs from the hub cluster are not aggregated. These logs can be accessed with the search service and other parts of the console.
 
 * <<observability-service,Observability service>>
-* <<observability-certificates,Observability certificates>>
 * <<metric-types,Metric types>>
-* <<observability-pod-capacity-requests,Observability pod capacity requests>>
-* <<overview-page-observe,Observe environments Overview page>>    
 
 [#observability-service]
 == Observability service
@@ -39,17 +36,6 @@ You can customize the observability service by creating custom https://prometheu
 
 For more information about enabling observability, see xref:../observability/observability_enable.adoc#enable-observability[Enable observability service].
 
-[#observability-certificates]
-== Observability certificates
-
-Observability certificates are automatically renewed upon expiration. View the following list to understand the effects when certificates are automatically renewed:
-
-* Components on your hub cluster automatically restart to retrieve the renewed certificate.
-* {product-title-short} sends the renewed certificates to managed clusters.
-* The `metrics-collector` restarts to mount the renewed certificates.
-+
-*Note:* `metrics-collector` can push metrics to the hub cluster before and after certificates are removed. For more information about refreshing certificates across your clusters, see link:../risk_compliance/certificates.adoc#refresh-a-managed-certificate[Refresh a managed certificate].
-
 [#metric-types]
 == Metric types
 
@@ -59,146 +45,3 @@ By default, {ocp-short} sends metrics to Red Hat using the Telemetry service. Th
 - The `acm_managed_cluster_info` is collected on each managed cluster and sent to the hub cluster.
 
 Learn from the {ocp-short} documentation what types of metrics are collected and sent using telemetry. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html-single/support/index#about-remote-health-monitoring[Information collected by Telemetry] for information. 
-
-[#observability-pod-capacity-requests]
-== Observability pod capacity requests
-
-Observability components require 2636mCPU and 11388Mi memory to install the observability service. View the following table of the pod capacity requests that is for five managed clusters with `observability-addons` enabled:
-
-.Observability pod capacity requests
-|===
-| Container name  | CPU (mCPU) | Memory (Mi) | Replicas | Pod total CPU | Pod total memory 
-
-| alertmanager
-| 4
-| 200
-| 3
-| 12
-| 600
-
-| config-reloader
-| 4
-| 25
-| 3
-| 12
-| 75
-
-| grafana
-| 4
-| 100
-| 2
-| 8
-| 200
-
-| grafana-dashboard-loader
-| 4
-| 50
-| 2
-| 8
-| 100
-
-| observatorium-api
-| 20
-| 128
-| 2
-| 40
-| 256
-
-| thanos-compact
-| 100
-| 512
-| 1
-| 100
-| 512
-
-| thanos-query
-| 300
-| 1024
-| 2
-| 600
-| 2048
-
-| thanos-query-frontend
-| 100
-| 256
-| 2
-| 200
-| 512
-
-| thanos-receive-controller
-| 4
-| 32
-| 1
-| 4
-| 32
-
-| thanos-receive
-| 300
-| 512
-| 3
-| 900
-| 1536
-
-| thanos-rule
-| 50
-| 512
-| 3
-| 150
-| 1536
-
-| configmap-reloader
-| 4
-| 25
-| 3
-| 12
-| 75
-
-| memcached
-| 45
-| 128
-| 3
-| 135
-| 384
-
-| exporter
-| 5
-| 50
-| 3
-| 15
-| 150
-
-| thanos-store
-| 100
-| 1024
-| 3
-| 300
-| 3072
-
-| observatorium-operator
-| 100
-| 100
-| 1
-| 100
-| 100
-
-| rbac-query-proxy
-| 20
-| 100
-| 2
-| 40
-| 200
-|===
-
-[#overview-page-observe]
-== Observe environments Overview page
-
-You can view the following information about your clusters on the _Overview_ dashboard:
-
-* Metric data from your managed clusters by selecting the Grafana link 
-* Cluster, node, and pod counts across all clusters and for each provider
-* Cluster status
-* Cluster compliance
-* Pod status
-
-Many clickable elements on the dashboard open a search for related resources. Click on a provider card to view information for clusters from a single provider.
-


### PR DESCRIPTION
Ref https://github.com/open-cluster-management/backlog/issues/13367

* move observability-pod-capacity-requests to observability_enable.adoc page. 
Users should know the resource consuming before enabling the service, so move it to this page makes more sense.
* remove observability-certificates,Observability certificates .
Should we have a new page about observability cert?  @marcolan018
* remove overview-page-observe,Observe environments Overview page, it should be coverd by https://github.com/open-cluster-management/rhacm-docs/blob/2.3_stage/console/console.adoc#home . @jlpadilla