### PR TITLE
Organize structure of observability

### DIFF
--- a/console/console.adoc
+++ b/console/console.adoc
@@ -33,7 +33,8 @@ You can view the following information about your clusters on the _Overview_ das
 * Cluster status
 * Cluster compliance
 * Pod status
-* Many clickable elements on the dashboard open a search for related resources. Click on a provider card to view information for clusters from a single provider.
+
+Additionally, you can view many clickable elements on the dashboard open a search for related resources. Click on a provider card to view information for clusters from a single provider.
 
 - Select *Grafana* to access the Grafana dashboard. 
 

--- a/console/console.adoc
+++ b/console/console.adoc
@@ -25,6 +25,15 @@ To learn about Search, see xref:../console/search.adoc#search-in-the-console[Sea
 From the {product-title} _Home_ page, you get more information about the product and you can access header features, as well as the pages for the major components of the product. 
 
 - Access the _Welcome_ page and the _Overview_, which gives you visibility into your clusters.
++
+You can view the following information about your clusters on the _Overview_ dashboard:
++
+* Metric data from your managed clusters by selecting the Grafana link 
+* Cluster, node, and pod counts across all clusters and for each provider
+* Cluster status
+* Cluster compliance
+* Pod status
+* Many clickable elements on the dashboard open a search for related resources. Click on a provider card to view information for clusters from a single provider.
 
 - Select *Grafana* to access the Grafana dashboard. 
 

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -60,7 +60,7 @@ oc create -f thanos-object-storage.yaml -n open-cluster-management-observability
 ----
 +
 .. View the following examples of secrets for the supported object stores:
-... For {product-title-short}, your secret might resemble the following file:
+*** For {product-title-short}, your secret might resemble the following file:
 +
 ----
 apiVersion: v1
@@ -80,7 +80,7 @@ stringData:
       secret_key: YOUR_SECRET_KEY
 ----
 
-... For Amazon S3 or S3 compatible, your secret might resemble the following file:
+*** For Amazon S3 or S3 compatible, your secret might resemble the following file:
 +
 ----
 apiVersion: v1
@@ -102,7 +102,7 @@ stringData:
 +
 For more details, see https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html[Amazon Simple Storage Service user guide].
 
-... For Google, your secret might resemble the following file: 
+*** For Google, your secret might resemble the following file: 
 +
 ----
 apiVersion: v1
@@ -121,7 +121,7 @@ stringData:
 +
 For more details, see https://cloud.google.com/storage/docs/introduction[Google Cloud Storage].
 
-... For Azure your secret might resemble the following file:
+*** For Azure your secret might resemble the following file:
 +
 ----
 apiVersion: v1
@@ -143,7 +143,7 @@ stringData:
 +
 For more details, see https://docs.microsoft.com/en-us/azure/storage/[Azure Storage documentation].
 
-... For Red Hat OpenShift Data Foundation, your secret might resemble the following file:
+*** For Red Hat OpenShift Data Foundation, your secret might resemble the following file:
 +
 ----
 apiVersion: v1
@@ -165,7 +165,7 @@ stringData:
 +
 For more details, see https://www.openshift.com/products/container-storage/[Red Hat OpenShift Data Foundation].
 
-... You can retrieve the S3 access key and secret key for your cloud providers with the following commands:
+.. You can retrieve the S3 access key and secret key for your cloud providers with the following commands:
 +
 ----
 ACCESS_KEY=$(oc -n open-cluster-management-observability get secret <object-storage-secret> -o jsonpath="{.data.thanos\.yaml}" | base64 --decode | grep access_key | awk '{print $2}')

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -21,7 +21,7 @@ Monitor the health of your managed clusters with the observability service (`mul
 [#enabling-observability]
 == Enabling observability
 
-Enable the observability service by creating a `MultiClusterObservability` custom resource (CR) instance. Complete the following steps to enable the observability service: 
+Enable the observability service by creating a `MultiClusterObservability` custom resource (CR) instance. Before you enable observability, see xref:../observability/observe_environments.adoc#observability-pod-capacity-requests[Observability pod capacity requests] for more information. Complete the following steps to enable the observability service: 
 
 . Log in to your {product-title-short} hub cluster. 
 . Create a namespace for the observability service with the following command:

--- a/observability/observe_environments.adoc
+++ b/observability/observe_environments.adoc
@@ -8,10 +8,8 @@ image:../images/RHACM-ObservabilityArch.png[Multicluster observability architect
 *Note*: The _on-demand log_ provides access for engineers to get logs for a given pod in real-time. Logs from the hub cluster are not aggregated. These logs can be accessed with the search service and other parts of the console.
 
 * <<observability-service,Observability service>>
-* <<observability-certificates,Observability certificates>>
 * <<metric-types,Metric types>>
-* <<observability-pod-capacity-requests,Observability pod capacity requests>>
-* <<overview-page-observe,Observe environments _Overview_ page>>    
+* <<observability-pod-capacity-requests,Observability pod capacity requests>>    
 
 [#observability-service]
 == Observability service
@@ -38,17 +36,6 @@ The observability service deploys an instance of Prometheus AlertManager, which 
 You can customize the observability service by creating custom https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/[recording rules] or https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules].
 
 For more information about enabling observability, see xref:../observability/observability_enable.adoc#enable-observability[Enable observability service].
-
-[#observability-certificates]
-== Observability certificates
-
-Observability certificates are automatically renewed upon expiration. View the following list to understand the effects when certificates are automatically renewed:
-
-* Components on your hub cluster automatically restart to retrieve the renewed certificate.
-* {product-title-short} sends the renewed certificates to managed clusters.
-* The `metrics-collector` restarts to mount the renewed certificates.
-+
-*Note:* `metrics-collector` can push metrics to the hub cluster before and after certificates are removed. For more information about refreshing certificates across your clusters, see link:../risk_compliance/certificates.adoc#refresh-a-managed-certificate[Refresh a managed certificate].
 
 [#metric-types]
 == Metric types
@@ -233,16 +220,5 @@ Observability components require 2791mCPU and 12022Mi memory to install the obse
 | 3072
 |===
 
-[#overview-page-observe]
-== Observe environments _Overview_ page
 
-You can view the following information about your clusters on the _Overview_ dashboard:
-
-* Metric data from your managed clusters by selecting the Grafana link 
-* Cluster, node, and pod counts across all clusters and for each provider
-* Cluster status
-* Cluster compliance
-* Pod status
-
-Many clickable elements on the dashboard open a search for related resources. Click on a provider card to view information for clusters from a single provider.
 


### PR DESCRIPTION
Needed to create a new pr because there was a merge conflict

Ref open-cluster-management/backlog#13367

move observability-pod-capacity-requests to observability_enable.adoc page.
Users should know the resource consuming before enabling the service, so move it to this page makes more sense.
remove observability-certificates,Observability certificates .
Should we have a new page about observability cert? @marcolan018
remove overview-page-observe,Observe environments Overview page, it should be coverd by https://github.com/open-cluster-management/rhacm-docs/blob/2.3_stage/console/console.adoc#home . @jlpadilla