### PR TITLE
add a note to mention the issue in 14416 the Helmrelease resource can be ignored

### DIFF
--- a/applications/subscription_sample.adoc
+++ b/applications/subscription_sample.adoc
@@ -377,6 +377,10 @@ spec:
 
 In this example subscription, the annotation `apps.open-cluster-management.io/git-path` indicates that the subscription subscribes to all Helm charts and Kubernetes resources within the `sample_app_1/dir1` directory of the Git repository that is specified in the channel. The subscription subscribes to `master` branch by default. In this example subscription, the annotation `apps.open-cluster-management.io/git-branch: branch1` is specified to subscribe to `branch1` branch of the repository.
 
+*Notes:*
+
+* When you are using a Git channel subscription that subscribes to Helm charts, the resource topology view might show an additional `Helmrelease` resource. This resource is an internal application management resource and can be safely ignored.
+
 [#adding-a-file]
 ==== Adding a `.kubernetesignore` file
 


### PR DESCRIPTION
add a note to mention the issue in 14416 the Helmrelease resource can be ignored in the topology diagram for this corncer case scenario

for https://github.com/open-cluster-management/backlog/issues/14416

Signed-off-by: Mike Ng <ming@redhat.com>