### PR TITLE
Update credential_ocm.adoc

### DIFF
--- a/credentials/credential_ocm.adoc
+++ b/credentials/credential_ocm.adoc
@@ -8,7 +8,7 @@ Add an {ocm} credential so that you can discover clusters.
 [#prerequisites-discovery]
 == Prerequisites
 
-You need access to a https://cloud.redhat.com/[cloud.redhat.com] account. Enter the {ocm} API Token.  This value can be obtained from https://cloud.redhat.com/openshift/token[cloud.redhat.com/openshift/token].
+You need access to a https://console.redhat.com/[console.redhat.com] account. Enter the {ocm} API Token.  This value can be obtained from https://console.redhat.com/openshift/token[console.redhat.com/openshift/token].
 
 
 [#add-credential]
@@ -24,8 +24,6 @@ You need to add your credential to discover clusters. If you have no credentials
 
 . Choose the {ocm} credential _type_, then click *Next*.
 
-. Obtain the token value from https://cloud.redhat.com/openshift/token[cloud.redhat.com/openshift/token].
-
 . Enter the following basic information for your credential: 
 
   - Enter any unique name for your credential.
@@ -33,7 +31,7 @@ You need to add your credential to discover clusters. If you have no credentials
 
 . Click *Next*.
 
-. Obtain, copy, and enter your {ocm} API token.
+. Enter your {ocm} API token. This can be obtained from https://console.redhat.com/openshift/token[console.redhat.com/openshift/token].
 
 . Click *Next* to review your selections or return to a step.
 

--- a/credentials/credential_ocm.adoc
+++ b/credentials/credential_ocm.adoc
@@ -8,7 +8,7 @@ Add an {ocm} credential so that you can discover clusters.
 [#prerequisites-discovery]
 == Prerequisites
 
-You need access to a https://console.redhat.com/[console.redhat.com] account. Enter the {ocm} API Token.  This value can be obtained from https://console.redhat.com/openshift/token[console.redhat.com/openshift/token].
+You need access to a https://console.redhat.com/[console.redhat.com] account. Enter the {ocm} API Token. This value can be obtained from https://console.redhat.com/openshift/token[console.redhat.com/openshift/token].
 
 
 [#add-credential]
@@ -31,7 +31,7 @@ You need to add your credential to discover clusters. If you have no credentials
 
 . Click *Next*.
 
-. Enter your {ocm} API token. This can be obtained from https://console.redhat.com/openshift/token[console.redhat.com/openshift/token].
+. Enter your {ocm} API token, which can be obtained from https://console.redhat.com/openshift/token[console.redhat.com/openshift/token].
 
 . Click *Next* to review your selections or return to a step.
 


### PR DESCRIPTION
Replace `cloud.redhat.com` with `console.redhat.com` and remove redundant step.

Issue: https://github.com/open-cluster-management/backlog/issues/13208