### PR TITLE
open-cluster-management/backlog#14012 (also add to 2.2 after review)

### DIFF
--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -24,16 +24,18 @@ Before you install {product-title-short}, see the following requirements:
 
 * You must have an Internet connection to access the dependencies for the operator.
 
-* To install in a Red Hat OpenShift Dedicated environment, see the following:
+* To install in a {ocp-short} Dedicated environment, see the following:
 
-** You must have the Red Hat OpenShift Dedicated environment configured and running.
+** You must have the {ocp-short} Dedicated environment configured and running.
 
-** You must have `cluster-admin` authority to the Red Hat OpenShift Dedicated environment where you are installing the hub cluster.
+** You must have `cluster-admin` authority to the {ocp-short} Dedicated environment where you are installing the hub cluster.
 
 [#confirm-ocp-installation]
 == Confirm your installation
 
-You must have a supported {ocp} version, including the registry and storage services, installed and working in your cluster. For more information about installing {ocp-short}, see the {ocp-short} documentation.
+You must have a supported {ocp-short} version, including the registry and storage services, installed and working in your cluster. For more information about installing {ocp-short}, see the {ocp-short} documentation.
+
+. Verify that a hub cluster is not already installed on your {ocp-short} cluster. {product-title-short} allows only one single hub cluster installation on each {ocp-short} cluster. Continue with the following steps if there is no hub cluster installed.
 
 . To ensure that the {ocp-short} cluster is set up correctly, access the {ocp-short} web console.
 +
@@ -56,7 +58,7 @@ The console URL in this example is: `https://console-openshift-console.apps.new-
 
 By using `tolerations`, the {product-title} hub cluster allows hub cluster components to be installed on an infrastructure node. To install the hub cluster on an infrastructure node, complete the following steps to prepare:
 
-. Configure your infrastructure nodes as infrastructure machine sets according to the procedure in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp} documentation.
+. Configure your infrastructure nodes as infrastructure machine sets according to the procedure in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp-short} documentation.
 
 +
 See the following example of the `toleration`:
@@ -93,7 +95,7 @@ spec:
 
 **Best practice:** Install by using the OperatorHub that is provided with {ocp-short}. 
 
-**Note:** For Red Hat OpenShift Dedicated environment only, log in to your Red Hat OpenShift Dedicated environment with `cluster-admin` permissions.
+**Note:** For {ocp-short} Dedicated environment only, log in to your {ocp-short} Dedicated environment with `cluster-admin` permissions.
 
 . From the _Administrator_ view in your {ocp-short} navigation, select *Operators* > *OperatorHub* to access the list of available operators.
 
@@ -198,7 +200,7 @@ After the hub cluster is created, the status for the operator is _Running_ on th
 [#installing-from-the-cli]
 == Installing from the CLI
 
-**Red Hat OpenShift Dedicated environment only required access:** Cluster administrator, as the default `dedicated-admin` role does not have the required permissions to create namespaces in the Red Hat OpenShift Dedicated environment. You must have `cluster-admin` permissions.
+**{ocp-short} Dedicated environment only required access:** Cluster administrator, as the default `dedicated-admin` role does not have the required permissions to create namespaces in the {ocp-short} Dedicated environment. You must have `cluster-admin` permissions.
 
 . Create a hub cluster namespace where the operator requirements are contained. Run the following command, where `namespace` is the name for your hub cluster namespace. The value for `namespace` might be referred to as _Project_ in the {ocp-short} environment:
 


### PR DESCRIPTION
Document that there can only be a single ACM Hub instance on an OCP cluster