### PR TITLE
Update AWS gateway instance type to c5d.large

### DIFF
--- a/services/deploy_submariner.adoc
+++ b/services/deploy_submariner.adoc
@@ -38,7 +38,7 @@ You can deploy Submariner on {ocp} managed clusters that are deployed on Amazon 
 * `AWS Access Key ID` - This field is only visible when you import an AWS cluster.
 * `AWS Secret Access Key` - This field is only visible when you import an AWS cluster.
 * `Google Cloud Platform service account JSON key` - This field is only visible when you import a Google Cloud Platform cluster.
-* `Instance type` - The Amazon Web Services EC2 instance type of the gateway node that is created on the managed cluster. The default value is `m5n.large`. This field is only visible when your managed cluster environment is AWS.
+* `Instance type` - The Amazon Web Services EC2 instance type of the gateway node that is created on the managed cluster. The default value is `c5d.large`. This field is only visible when your managed cluster environment is AWS.
 * `IPsec NAT-T port` - The default value for the IPsec NAT traversal port is port `4500`. If your managed cluster environment is VMware vSphere, ensure that this port is opened on your firewalls.
 * `Gateway count` - The number of worker nodes that are used to deploy the Submariner gateway component on your managed cluster. The default value is `1`. If the value is greater than 1, the Submariner gateway High Availability (HA) is automatically enabled.
 * `Cable driver` - The Submariner gateway cable engine component that maintains the cross-cluster tunnels. The default value is `Libreswan IPsec`.

--- a/services/deploy_submariner_api.adoc
+++ b/services/deploy_submariner_api.adoc
@@ -60,7 +60,7 @@ Replace `managed-cluster-name` with the name of your managed cluster. The value 
 +
 *Note:* The name of the `SubmarinerConfig` must be `submariner`, as shown in the example.
 +
-This configuration automatically opens the Submariner required ports: network address translation - traversal (NATT) port (4500/UDP), virtual extensible LAN (VXLAN) port (4800/UCP), and Submariner metrics port (8080/TCP) on your AWS instance. It also creates one AWS instance as the Submariner gateway with the AWS instance type `m5n.large`.
+This configuration automatically opens the Submariner required ports: network address translation - traversal (NATT) port (4500/UDP), virtual extensible LAN (VXLAN) port (4800/UCP), and Submariner metrics port (8080/TCP) on your AWS instance. It also creates one AWS instance as the Submariner gateway with the AWS instance type `c5d.large`.
 +
 * If you want to customize your NATT port, enter a command that contains information that is similar to the following example:
 +  


### PR DESCRIPTION
We now use c5d.large instanceTypes for Submariner gateway
instances as it is better optimized for CPU and improves
the throughput when using IPsec and wireguard drivers.
This PR updates the corresponding documentation.

Related to: https://github.com/open-cluster-management/submariner-addon/issues/109
Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>