### PR TITLE
Improve the IAM Policy Documentation

### DIFF
--- a/governance/create_iam_policy.adoc
+++ b/governance/create_iam_policy.adoc
@@ -35,6 +35,7 @@ metadata:
   label:
     category: "System-Integrity"
 spec:
+  clusterRole: cluster-admin
   remediationAction: inform
   disabled: false
   maxClusterRoleBindingUsers: 5

--- a/governance/create_iam_policy.adoc
+++ b/governance/create_iam_policy.adoc
@@ -35,9 +35,6 @@ metadata:
   label:
     category: "System-Integrity"
 spec:
-  namespaceSelector:
-    include: ["default","kube-*"]
-    exclude: ["kube-system"]
   remediationAction: inform
   disabled: false
   maxClusterRoleBindingUsers: 5

--- a/governance/iam_policy_ctrl.adoc
+++ b/governance/iam_policy_ctrl.adoc
@@ -25,9 +25,6 @@ metadata:
   name:
 spec:
   severity:
-  namespaceSelector:
-    include:
-    exclude:
   remediationAction: 
   maxClusterRoleBindingUsers:
 ----
@@ -60,13 +57,6 @@ Add configuration details for your policy.
 | spec.severity
 | Optional.
 Informs the user of the severity when the policy is non-compliant. Use the following parameter values: `low`, `medium`, or `high`.
-
-| spec.namespaceSelector
-| Required.
-The namespaces within the hub cluster that the policy is applied to.
-Enter at least one namespace for the `include` parameter, which are the namespaces you want to apply to the policy to.
-The `exclude` parameter specifies the namespaces you explicitly do not want to apply the policy to.
-*Note*: A namespace that is specified in the object template of a policy controller overrides the namespace in the preceding parameter values.
 
 | spec.remediationAction
 | Optional.

--- a/governance/iam_policy_ctrl.adoc
+++ b/governance/iam_policy_ctrl.adoc
@@ -1,10 +1,10 @@
 [#iam-policy-controller]
 = IAM policy controller
 
-Identity and Access Management (IAM) policy controller can be used to receive notifications about IAM policies that are non-compliant.
+The Identity and Access Management (IAM) policy controller can be used to receive notifications about IAM policies that are non-compliant.
 The compliance check is based on the parameters that you configure in the IAM policy.
 
-The IAM policy controller checks for compliance of the number of cluster administrators that you allow in your cluster. IAM policy controller communicates with the local Kubernetes API server. For more information, see https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/[Extend the Kubernetes API with CustomResourceDefinitions].
+The IAM policy controller monitors for the desired maximum number of users with a particular cluster role (i.e. `ClusterRole`) in your cluster. The default cluster role to monitor is `cluster-admin`. The IAM policy controller communicates with the local Kubernetes API server. For more information, see https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/[Extend the Kubernetes API with CustomResourceDefinitions].
 
 The IAM policy controller runs on your managed cluster. View the following sections to learn more:
 
@@ -24,6 +24,7 @@ kind: IamPolicy
 metadata:
   name:
 spec:
+  clusterRole:
   severity:
   remediationAction: 
   maxClusterRoleBindingUsers:
@@ -53,6 +54,10 @@ The name for identifying the policy resource.
 | spec
 | Required.
 Add configuration details for your policy.
+
+| spec.severity
+| Optional.
+The cluster role (i.e. `ClusterRole`) to monitor. This defaults to `cluster-admin` if not specified.
 
 | spec.severity
 | Optional.


### PR DESCRIPTION
This document the IAMPolicy spec.clusterRole field. This was added in 2.3 in the following commit but was not documented:
https://github.com/open-cluster-management/iam-policy-controller/commit/23b2c7d876ec16bafcb6f65b4b80bd4eb925faa1

This also removes the IamPolicy namespaceSelector field. This field is here for legacy reasons but it does not affect the behavior of the IAM policy controller, as the controller only handles cluster roles (i.e. not namespaced roles). Removing the documentation for this field makes things less confusing to the user.

This also fixes a couple small grammatical errors.