### PR TITLE
Fix issue with AWS Secret key documentation

### DIFF
--- a/services/deploy_submariner_api.adoc
+++ b/services/deploy_submariner_api.adoc
@@ -18,6 +18,9 @@ You can use the `SubmarinerConfig` API to configure the AWS cluster to integrate
 To create the secret, enter a command that contains information that is similar to the following example:
 +
 ----
+export AWS_ACCESS_KEY_ID=<aws-access-key-id>
+export AWS_SECRET_ACCESS_KEY=<aws-secret-access-key>
+
 cat << EOF | oc apply -f -
 apiVersion: v1
 kind: Secret
@@ -26,8 +29,8 @@ metadata:
     namespace: <managed-cluster-namespace>
 type: Opaque
 data:
-    aws_access_key_id: <aws-access-key-id>
-    aws_secret_access_key: <aws-secret-access-key>
+    aws_access_key_id: $(echo -n ${AWS_ACCESS_KEY_ID} | base64 -w0)
+    aws_secret_access_key: $(echo -n ${AWS_SECRET_ACCESS_KEY} | base64 -w0)
 EOF
 ----
 +


### PR DESCRIPTION
While configuring the AWS secret key, it has to be base64 encoded.
Currently this is missing in the documentation. This PR fixes it.

Signed-Off-by: Sridhar Gaddam <sgaddam@redhat.com>