### PR TITLE
Update the Policy Generator documentation

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -500,11 +500,15 @@ The list of Kubernetes object manifests to include in the policy.
 | Required.
 The name of the policy to create.
 
-| policies[ ].manifests[ ].path
+| policies[ ].manifests[ ].complianceType
 | Optional.
+Determines the policy controller behavior when comparing the manifest to objects on the cluster. The parameter values are `musthave`, `mustonlyhave`, or `mustnothave`. The default value is `musthave`.
+
+| policies[ ].manifests[ ].path
+| Required.
 Path to a single file or a flat directory of files relative to the `kustomization.yaml` file.
 
 | policies[ ].manifests[ ].patches
 | Optional.
-A Kustomize patch to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so Kustomize can identify the manifest that the patch applies to.
+A Kustomize patch to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so Kustomize can identify the manifest that the patch applies to. If there is a single manifest, the `metadata.name` and `metadata.namespace` fields can be patched.
 |===


### PR DESCRIPTION
The Policy Generator was updated to 1.3.0 in RHACM 2.4, so these
documentation updates account for the changes in that version.

Relates:
https://github.com/open-cluster-management/backlog/issues/17187