### PR TITLE
Output from spell check tool

### DIFF
--- a/access_control/rbac.adoc
+++ b/access_control/rbac.adoc
@@ -133,7 +133,7 @@ This role has read-only access to the resources in the namespace of the managed 
 oc get managedclusters.clusterview.open-cluster-management.io
 ----
 +
-This command is used by administrators and users without cluster adminstrator privileges.
+This command is used by administrators and users without cluster administrator privileges.
 
 * View a list of the managed cluster sets that you can access by entering the following command:
 +
@@ -141,7 +141,7 @@ This command is used by administrators and users without cluster adminstrator pr
 oc get managedclustersets.clusterview.open-cluster-management.io
 ----
 +
-This command is used by administrators and users without cluster adminstrator privileges.
+This command is used by administrators and users without cluster administrator privileges.
 
 [#cluster-pools-rbac]
 ==== Cluster pools RBAC

--- a/clusters/import_gui.adoc
+++ b/clusters/import_gui.adoc
@@ -23,7 +23,7 @@ To install `kubectl`, see _Install and Set Up kubectl_ in the https://kubernetes
 
 * If you are importing a cluster that was not created by {ocp}, you need a `multiclusterhub.spec.imagePullSecret` defined. This secret might have been created when {product-title} was installed. See link:../install/install_connected.adoc#installing-from-the-operator-hub[Installing from the OperatorHub] for more information about defining the secret.  
 
-* For importing in a Red Hat OpenShift Dedicated enviroment, see the following:
+* For importing in a Red Hat OpenShift Dedicated environment, see the following:
 ** You must have the hub cluster deployed in a Red Hat OpenShift Dedicated environment.
 ** The default permission in Red Hat OpenShift Dedicated is dedicated-admin, but that does not contain all of the permissions to create a namespace. You must have `cluster-admin` permissions to import and manage a cluster with {product-title}.
 

--- a/clusters/proxy.adoc
+++ b/clusters/proxy.adoc
@@ -30,7 +30,7 @@ Replace `password` with the password to access your proxy server.
 +
 Replace `proxy.example.com` with the path of your proxy server.
 +
-Replace `port` with the communciation port with the proxy server.
+Replace `port` with the communication port with the proxy server.
 +
 Replace `wildcard-of-domain` with an entry for domains that should bypass the proxy.
 + 

--- a/governance/custom_template.adoc
+++ b/governance/custom_template.adoc
@@ -121,7 +121,7 @@ The `fromClusterClaim` function returns the value of the `Spec.Value` in the `Cl
 func fromClusterClaim (clusterclaimName string) (value map[string]interface{}, err Error)
 ----
 
-When you use the function, enter the name of a Kubernetes `ClusterClaim` resource. You receive a policy violation if the `ClusterClaim` resource does not exist. View the following example of the configuration policy that enforces a Kubernetes resource on the target managed cluster. The value for the `platform` data key is a template that retrieves the value of the `platform.open-cluster-management.io` cluster claim. Similarily, it retrieves values for `product` and `version` from the `ClusterClaim`:
+When you use the function, enter the name of a Kubernetes `ClusterClaim` resource. You receive a policy violation if the `ClusterClaim` resource does not exist. View the following example of the configuration policy that enforces a Kubernetes resource on the target managed cluster. The value for the `platform` data key is a template that retrieves the value of the `platform.open-cluster-management.io` cluster claim. Similarly, it retrieves values for `product` and `version` from the `ClusterClaim`:
 
 [source,yaml]
 ----

--- a/governance/master.html
+++ b/governance/master.html
@@ -819,7 +819,7 @@ Run the following command:</p>
    prompt = no               # Disables prompting for certificate values so the configuration file values are used.
    default_md = sha256       # Specifies the digest algorithm.
    distinguished_name = dn   # Specifies the section that includes the distinguished name information.
-   x509_extensions = v3_ca   # The extentions to add to the self signed cert
+   x509_extensions = v3_ca   # The extensions to add to the self signed cert
 
    [ dn ]               # Distinguished name settings
    C = US                    # Country
@@ -950,7 +950,7 @@ If you are generating the certificate, include the following settings:</p>
 </li>
 <li>
 <p>Include the route name for Red Hat Advanced Cluster Management for Kubernetes.
-Recieve the route name by running the following command:</p>
+Receive the route name by running the following command:</p>
 <div class="listingblock">
 <div class="content">
 <pre> oc get route -n open-cluster-management</pre>
@@ -2311,7 +2311,7 @@ Enter <code>inform</code>.</p></td>
 <h4 id="policy-samples">Policy samples</h4>
 <div class="paragraph">
 <p>Create and manage policies in Red Hat Advanced Cluster Management for Kubernetes to define rules, processes, and controls on the hub cluster.
-View the following policy samples to view how specfic policies are applied:</p>
+View the following policy samples to view how specific policies are applied:</p>
 </div>
 <div class="ulist">
 <ul>

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -451,11 +451,11 @@ This determines if a single configuration policy should be generated for all the
 
 | policyDefaults.informGatekeeperPolicies
 | Optional.
-When the policy references a violated gatekeeper policy manifest, this determines if an additonal configuration policy should be generated in order to receive policy violations in {product-title-short}. The default value is `true`.
+When the policy references a violated gatekeeper policy manifest, this determines if an additional configuration policy should be generated in order to receive policy violations in {product-title-short}. The default value is `true`.
 
 | policyDefaults.informKyvernoPolicies
 | Optional.
-When the policy references a Kyverno policy manifest, this determines if an additonal configuration policy should be generated to receive policy violations in {product-title-short}, when the Kyverno policy has been violated. The default value is `true`.
+When the policy references a Kyverno policy manifest, this determines if an additional configuration policy should be generated to receive policy violations in {product-title-short}, when the Kyverno policy has been violated. The default value is `true`.
 
 | policyDefaults.namespace
 | Required.

--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -73,7 +73,7 @@ console   https   reencrypt/Redirect     None
 
 . Open the URL in your browser and check the result. If the console URL displays `console-openshift-console.router.default.svc.cluster.local`, set the value for `openshift_master_default_subdomain` when you install {ocp-short}. See the following example of a URL: `https://console-openshift-console.apps.new-coral.purple-chesterfield.com`.
 
-You can procede to install {product-title-short}.
+You can proceed to install {product-title-short}.
 
 [#installing-from-the-operatorhub]
 == Installing from the OperatorHub web console interface

--- a/install/master.html
+++ b/install/master.html
@@ -579,7 +579,7 @@ Your results might vary, depending on your environment, network speed, and chang
 <h4 id="maximum-number-of-managed-clusters">Maximum number of managed clusters</h4>
 <div class="paragraph">
 <p>The Red Hat Advanced Cluster Management for Kubernetes hub cluster provided good performance when managing up to 250 managed clusters.
-The following table shows the configuration information for the clusters on the Amazon Web Services cloud platfrom that were used to determine the cluster maximums:</p>
+The following table shows the configuration information for the clusters on the Amazon Web Services cloud platform that were used to determine the cluster maximums:</p>
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>

--- a/observability/insights_observability.adoc
+++ b/observability/insights_observability.adoc
@@ -12,7 +12,7 @@ When you create or import an OpenShift cluster, anonymized data from your manage
 
 * Ensure that Red Hat Insights is enabled. For more information, see https://docs.openshift.com/container-platform/4.8/support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-new-pull-secret_opting-out-remote-health-reporting[Modifying the global cluster pull secret to disable remote health reporting].
 * Install {ocp-short} version 4.0 or later.
-* Hub cluster user, who is registerd to OpenShift Cluster Manager, must be able to manage all the {product-title-short} managed clusters in OpenShift Cluster Manager.
+* Hub cluster user, who is registered to OpenShift Cluster Manager, must be able to manage all the {product-title-short} managed clusters in OpenShift Cluster Manager.
 
 [#insights-descriptions]
 == Red Hat Insights from the {product-title-short} console
@@ -23,7 +23,7 @@ Continue reading to view functionality descriptions of the integration:
 
 * After you click the number, the _Potential issue_ side panel is displayed. A summary and chart of the total issues are displayed in the panel. You can also use the search feature to search for recommended remediations. The remediation option displays the _Description_ of the vulnerability, _Category_ that vulnerability is associated with, and the _Total risk_.
 
-* From the _Description_ section, you can select the link to the vulnerability. View steps to resolve your vulnerabilty by selecting the _How to remediate_ tab. You can also view why the vulnerability occurred by clicking the _Reason_ tab.
+* From the _Description_ section, you can select the link to the vulnerability. View steps to resolve your vulnerability by selecting the _How to remediate_ tab. You can also view why the vulnerability occurred by clicking the _Reason_ tab.
 
 See xref:../observability/manage_insights.adoc#manage-insights[Managing insight `PolicyReports`] for more information.
 

--- a/services/deploy_submariner_api.adoc
+++ b/services/deploy_submariner_api.adoc
@@ -286,7 +286,7 @@ Replace `managed-cluster-namespace` with the namespace of your managed cluster.
 +
 *Note:* The name of the `SubmarinerConfig` must be `submariner`, as shown in the example.
 +
-This configuration uses the default network address translation - traversal (NATT) port (4500/UDP) for your Submariner and one worker node is labled as the Submariner gateway on your vSphere cluster.
+This configuration uses the default network address translation - traversal (NATT) port (4500/UDP) for your Submariner and one worker node is labeled as the Submariner gateway on your vSphere cluster.
 +
 Submariner uses IP security (IPsec) to establish the secure tunnels between the clusters on the gateway nodes. You can either use the default IPsec NATT port, or you can specify a different port that you configured. When you run this procedure without specifying an IPsec NATT port of 4500/UDP is automatically used for the communication.
 +

--- a/troubleshooting/master.html
+++ b/troubleshooting/master.html
@@ -753,7 +753,7 @@ See the <a href="https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
 <div class="sect3">
 <h4 id="symptom-application-deployment-version">Symptom: Application deployment version</h4>
 <div class="paragraph">
-<p>If one or more of your application resources in the Subscription YAML file uses the deprecated API, you might receive an error similiar to the following error:</p>
+<p>If one or more of your application resources in the Subscription YAML file uses the deprecated API, you might receive an error similar to the following error:</p>
 </div>
 <div class="listingblock">
 <div class="content">

--- a/troubleshooting/trouble_grafana.adoc
+++ b/troubleshooting/trouble_grafana.adoc
@@ -39,7 +39,7 @@ The following timeout settings should be displayed:
 ----
 queryTimeout: 300s
 ----
-. If you verified the default configuration of Grafana has expected timeout settings, then you can configure the `multicloud-console` route in the `open-cluster-management` namespace by running the following commmand:
+. If you verified the default configuration of Grafana has expected timeout settings, then you can configure the `multicloud-console` route in the `open-cluster-management` namespace by running the following command:
 +
 ----
 oc annotate route multicloud-console -n open-cluster-management --overwrite haproxy.router.openshift.io/timeout=300s


### PR DESCRIPTION
Trying out this tool: https://github.com/client9/misspell. I found it from this [kubernetes repo](https://github.com/kubernetes/website/pull/26228).
Installed with `go get -u github.com/client9/misspell/cmd/misspell` since I already had `go` installed.
Cloned rhacm-docs repo and ran with command: `misspell -w -locale US rhacm-docs/**/*`