### PR TITLE
Upgrade grafana to version 8.1.3

### DIFF
--- a/observability/observe_environments.adoc
+++ b/observability/observe_environments.adoc
@@ -33,7 +33,7 @@ When observability is enabled in a hub cluster, metrics are collected by handlin
   
 *Note*: In {product-title-short} the `metrics-collector` is only supported for {ocp} 4.x clusters. 
 
-The observability service deploys an instance of Prometheus AlertManager, which enables alerts to be forwarded with third-party applications. It also includes an instance of Grafana to enable data visualization with dashboards (static) or data exploration. {product-title-short} supports version 7.4.2 of Grafana. You can also design your Grafana dashboard. For more information, see xref:../observing_environments/design_grafana.adoc#designing-your-grafana-dashboard[Designing your Grafana dashboard].
+The observability service deploys an instance of Prometheus AlertManager, which enables alerts to be forwarded with third-party applications. It also includes an instance of Grafana to enable data visualization with dashboards (static) or data exploration. {product-title-short} supports version 8.1.3 of Grafana. You can also design your Grafana dashboard. For more information, see xref:../observing_environments/design_grafana.adoc#designing-your-grafana-dashboard[Designing your Grafana dashboard].
 
 You can customize the observability service by creating custom https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/[recording rules] or https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules].
 


### PR DESCRIPTION
In ACM 2.4, we are using Grafana 8.1.3. so update the document to reflect this change.

Signed-off-by: clyang82 <chuyang@redhat.com>