### PR TITLE
Update MCH Uninstall Doc instructions

### DIFF
--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -135,17 +135,23 @@ Replace `<namespace>` in the script with the name of the namespace where {produc
 +
 *Note:* If you plan to reinstall the same {product-title-short} version, you can skip the next steps in this procedure and reinstall the custom resource. Proceed for a complete operator uninstall.
 
-. Enter the following command to remove all of the related components and subscriptions:
 +
+. Enter the following commands to delete the Advanced Cluster Management `ClusterServiceVersion` and `Subscription` in the namespace it is installed in:
 ----
-oc delete subs --all
+❯ oc get csv
+NAME                                 DISPLAY                                      VERSION   REPLACES   PHASE
+advanced-cluster-management.v2.4.0   Advanced Cluster Management for Kubernetes   2.4.0                Succeeded
+
+❯ oc delete clusterserviceversion advanced-cluster-management.v2.4.0
+
+❯ oc get sub
+NAME                        PACKAGE                       SOURCE                CHANNEL
+acm-operator-subscription   advanced-cluster-management   acm-custom-registry   release-2.4
+
+❯ oc delete sub acm-operator-subscription
 ----
 
-. Enter the following command to delete the `ClusterServiceVersion`:
-+
-----
-oc delete clusterserviceversion --all
-----
+Please note that the name of the subscription and version of the CSV may differ.
 
 [#deleting-the-components-by-using-the-console]
 == Deleting the components by using the console

--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -1,16 +1,16 @@
 [#uninstalling]
 = Uninstalling
 
-When you uninstall {product-title}, you see two different levels of the process: A _custom resource removal_ and a _complete operator uninstall_. It might take up to 20 minutes to complete the uninstall process.
+When you uninstall {product-title}, you see two different levels of the uninstall process: A _custom resource removal_ and a _complete operator uninstall_. The uninstall process can take up to 20 minutes.
 
-- The custom resource removal is the most basic type of uninstall that removes the custom resource of the `MultiClusterHub` instance but leaves other required operator resources. This level of uninstall is helpful if you plan to reinstall using the same settings and components.
+- The first level is the custom resource removal, which is the most basic type of uninstall that removes the custom resource of the `MultiClusterHub` instance, but leaves other required operator resources. This level of uninstall is helpful if you plan to reinstall using the same settings and components.
 
 - The second level is a more complete uninstall that removes most operator components, excluding components such as custom resource definitions. When you continue with this step, it removes all of the components and subscriptions that were not removed with the custom resource removal. After this uninstall, you must reinstall the operator before reinstalling the custom resource.
 
 [#prerequisite-detach]
 == Prerequisite: Detach enabled services
 
-Before you uninstall the {product-title-short} hub cluster, you must detach all of the clusters that are managed by that hub cluster. To avoid errors, detach all clusters that are still managed by the hub cluster, then try to uninstall again.
+Before you uninstall the {product-title-short} hub cluster, you must detach all of the clusters that are managed by that hub cluster. To resolve errors, detach all clusters that are still managed by the hub cluster, then try to uninstall again.
 
 * If you use Discovery, you might see the following error when you attempt uninstall:
 +
@@ -21,7 +21,7 @@ Cannot delete MultiClusterHub resource because DiscoveryConfig resource(s) exist
 +
 To disable Discovery, complete the following steps:
 
-- From the console Navigate to the `Discovered Clusters` table and click *Disable cluster discovery*. Confirm that you want to remove the service. 
+- From the console, navigate to the `Discovered Clusters` table and click *Disable cluster discovery*. Confirm that you want to remove the service. 
 
 - You can also use the terminal. Run the following command to disable Discover:
 
@@ -30,9 +30,8 @@ To disable Discovery, complete the following steps:
 $ oc delete discoveryconfigs --all --all-namespaces
 ----
 
-* If you have managed clusters attached, you might see the following message. *Note* This does not include the `local-cluster`, which is your self-managed hub cluster.
-* 
-
+* If you have managed clusters attached, you might see the following message. *Note:* This does not include the `local-cluster`, which is your self-managed hub cluster:
+ 
 +
 ----
 Cannot delete MultiClusterHub resource because ManagedCluster resource(s) exist
@@ -105,8 +104,6 @@ oc get mch -o yaml
 ----
 
 . Remove any potential remaining artifacts by running the clean-up script. 
-+
-*Note*: If `cert-manager` was manually installed in your cluster, be sure to review the commands in the clean-up script and remove commands that are specific to `cert-manager`.
 
 .. Install the Helm CLI binary version 3.2.0, or later, by following the instructions at https://helm.sh/docs/intro/install/[Installing Helm].
 
@@ -136,7 +133,7 @@ Replace `<namespace>` in the script with the name of the namespace where {produc
 *Note:* If you plan to reinstall the same {product-title-short} version, you can skip the next steps in this procedure and reinstall the custom resource. Proceed for a complete operator uninstall.
 
 +
-. Enter the following commands to delete the Advanced Cluster Management `ClusterServiceVersion` and `Subscription` in the namespace it is installed in:
+. Enter the following commands to delete the {product-title-short} `ClusterServiceVersion` and `Subscription` in the namespace it is installed in:
 ----
 ❯ oc get csv
 NAME                                 DISPLAY                                      VERSION   REPLACES   PHASE
@@ -151,7 +148,7 @@ acm-operator-subscription   advanced-cluster-management   acm-custom-registry   
 ❯ oc delete sub acm-operator-subscription
 ----
 
-Please note that the name of the subscription and version of the CSV may differ.
+*Note:* The name of the subscription and version of the CSV might differ.
 
 [#deleting-the-components-by-using-the-console]
 == Deleting the components by using the console


### PR DESCRIPTION
Signed-off-by: Zachary Kayyali <zkayyali@redhat.com>

Update MCH uninstall instructions to be more specific, instead of guiding user to delete all sub/csv resources in namespace.

https://github.com/open-cluster-management/backlog/issues/17332