### PR TITLE
Updated known issues doc with slo issue

### DIFF
--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -155,7 +155,7 @@ oc edit pvc <storageclassname>-search-redisgraph-0
 === Duplicate local-clusters on Service-level Overview dashboard
 //2.4:16885
 
-When various hub clusters deploy {product-title-short} observability using the same S3 storage, _duplicate_ `local-clusters` can be detected and displayed within the _Kubernetes/Service-Level Overview/API Server_ dashboard. The duplicate clusters affect the results within the following panels: _Top Clusters_, the number of clusters that has exceeded the SLO_, and _the number of clusters that are meeting the SLO_. The `local-clusters` are unique clusters associated with the shared S3 storage. To prevent multiple `local-clusters` from displaying within the dashboard, it is recommended for each unique hub cluster to deploy observability with their own S3 bucket.
+When various hub clusters deploy {product-title-short} observability using the same S3 storage, _duplicate_ `local-clusters` can be detected and displayed within the _Kubernetes/Service-Level Overview/API Server_ dashboard. The duplicate clusters affect the results within the following panels: _Top Clusters_, _# of clusters that has exceeded the SLO_, and _# of clusters that are meeting the SLO_. The `local-clusters` are unique clusters associated with the shared S3 storage. To prevent multiple `local-clusters` from displaying within the dashboard, it is recommended for each unique hub cluster to deploy observability with a S3 bucket specifically for the hub cluster.
 
 [#observability-endpoint-operator-fails-to-pull-image]
 === Observability endpoint operator fails to pull image

--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -151,6 +151,12 @@ oc edit pvc <storageclassname>-search-redisgraph-0
 [#observability-known-issues]
 == Observability known issues
 
+[#duplicate-local-clusters-in-kubernetes-service-level-overview-api-server-dashboard]
+=== Duplicate local-clusters on SLO Dashboard
+//2.4:16885
+
+When various hub clusters deploy {product-title-short} observability using the same s3 storage, "duplicate" local-clusters can be detected and displayed within the `Kubernetes / Service-Level Overview /  API Server` dashboard. The duplicate clusters will affect the results within the panels `Top Clusters`, `# of clusters that has exceeded the SLO`, and `# of cluster that are meeting the SLO` panels. The local-clusters are unique cluster associated with the shared s3 storage. To prevent multiple local-clusters from displaying within the dashboard, it is recommended for each unique hub cluster to deploy observability with their own s3 bucket.
+
 [#observability-endpoint-operator-fails-to-pull-image]
 === Observability endpoint operator fails to pull image
 //2.2:9259

--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -152,10 +152,10 @@ oc edit pvc <storageclassname>-search-redisgraph-0
 == Observability known issues
 
 [#duplicate-local-clusters-in-kubernetes-service-level-overview-api-server-dashboard]
-=== Duplicate local-clusters on SLO Dashboard
+=== Duplicate local-clusters on Service-level Overview dashboard
 //2.4:16885
 
-When various hub clusters deploy {product-title-short} observability using the same s3 storage, "duplicate" local-clusters can be detected and displayed within the `Kubernetes / Service-Level Overview /  API Server` dashboard. The duplicate clusters will affect the results within the panels `Top Clusters`, `# of clusters that has exceeded the SLO`, and `# of cluster that are meeting the SLO` panels. The local-clusters are unique cluster associated with the shared s3 storage. To prevent multiple local-clusters from displaying within the dashboard, it is recommended for each unique hub cluster to deploy observability with their own s3 bucket.
+When various hub clusters deploy {product-title-short} observability using the same S3 storage, _duplicate_ `local-clusters` can be detected and displayed within the _Kubernetes/Service-Level Overview/API Server_ dashboard. The duplicate clusters affect the results within the following panels: _Top Clusters_, the number of clusters that has exceeded the SLO_, and _the number of clusters that are meeting the SLO_. The `local-clusters` are unique clusters associated with the shared S3 storage. To prevent multiple `local-clusters` from displaying within the dashboard, it is recommended for each unique hub cluster to deploy observability with their own S3 bucket.
 
 [#observability-endpoint-operator-fails-to-pull-image]
 === Observability endpoint operator fails to pull image


### PR DESCRIPTION
Updating the known issue doc for 2.4. The issue that is being added is in regards to multiple local clusters being displayed within the fleet level SLO overview dashboard.

Related Issue: https://github.com/open-cluster-management/backlog/issues/16885
Doc Issue: https://github.com/open-cluster-management/backlog/issues/17216

Signed-off-by: dislbenn <lavontae.bennett@gmail.com>