### PR TITLE
Remove mention of deleting ClusterPool namespace

### DIFF
--- a/clusters/cluster_pool_destroy.adoc
+++ b/clusters/cluster_pool_destroy.adoc
@@ -20,6 +20,8 @@ To destroy a cluster pool, complete the following steps:
 . Enter the name of the cluster pool to confirm.
 
 . Select *Destroy* to remove the cluster pool. Any unclaimed clusters in the cluster pool are destroyed. It might take some time for all of the resources to be deleted, and the cluster pool remains visible in the console until all of the resources are deleted. 
++
+The namespace that contained the ClusterPool will not be deleted. Deleting the namespace will destroy any clusters that have been claimed from the ClusterPool, since the ClusterClaim resources for these clusters are created in the same namespace.
 
 *Tip:* You can destroy multiple cluster pools with one action by selecting the box for each of the the cluster pools and using the _Actions_ menu to destroy the selected cluster pools.
 

--- a/clusters/cluster_pool_destroy.adoc
+++ b/clusters/cluster_pool_destroy.adoc
@@ -20,8 +20,6 @@ To destroy a cluster pool, complete the following steps:
 . Enter the name of the cluster pool to confirm.
 
 . Select *Destroy* to remove the cluster pool. Any unclaimed clusters in the cluster pool are destroyed. It might take some time for all of the resources to be deleted, and the cluster pool remains visible in the console until all of the resources are deleted. 
-+
-If you created the cluster pool in a new namespace using the console, the namespace is deleted afer the last cluster pool in it is deleted.
 
 *Tip:* You can destroy multiple cluster pools with one action by selecting the box for each of the the cluster pools and using the _Actions_ menu to destroy the selected cluster pools.
 


### PR DESCRIPTION
Signed-off-by: Kevin Cormier <kcormier@redhat.com>

As part of https://github.com/open-cluster-management/backlog/issues/16764, the functionality to delete a ClusterPool namespace under certain conditions is completely removed.