### PR TITLE
[2.4_stage] Output from spell check tool

### DIFF
--- a/governance/enable_integrity_shield.adoc
+++ b/governance/enable_integrity_shield.adoc
@@ -9,7 +9,7 @@ Enable integrity shield protection in an {product-title} cluster to protect the 
 The following prerequisites are required to enable integrity shield protection on a {product-title-short} managed cluster:
 
 * Install an {product-title-short} hub cluster that has one or more managed clusters, along with cluster administrator access to the cluster to use the `oc` or `kubectl` commands. 
-* Install integrity shield. Before you instal the integrity shield, you must install an Open Policy Agent or gatekeeper on your cluster. Complete the following steps to install the integrity shield operator:
+* Install integrity shield. Before you install the integrity shield, you must install an Open Policy Agent or gatekeeper on your cluster. Complete the following steps to install the integrity shield operator:
 +
 .. Install the integrity shield operator in a namespace for integrity shield by running the following command:
 +

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -33,7 +33,7 @@ Monitor the health of your managed clusters with the observability service (`mul
 
 Enable the observability service by creating a `MultiClusterObservability` custom resource (CR) instance. Before you enable observability, see xref:../observability/observe_environments.adoc#observability-pod-capacity-requests[Observability pod capacity requests] for more information. 
 
-*Note*: When observability is enabled or disabled on {ocp-short} managed clusters that are managed by {product-title-short}, the observability endpoint operator updates the `cluster-monitoring-config` `ConfigMap` by adding addtional alertmanager configuration that restarts the local Prometheus automatically.
+*Note*: When observability is enabled or disabled on {ocp-short} managed clusters that are managed by {product-title-short}, the observability endpoint operator updates the `cluster-monitoring-config` `ConfigMap` by adding additional alertmanager configuration that restarts the local Prometheus automatically.
 
 Complete the following steps to enable the observability service: 
 

--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -151,7 +151,7 @@ Check the role permissions and update appropriately. See link:../access_control/
 
 By default, Prometheus on OpenShift uses ephemeral storage. Prometheus loses all metrics data whenever it is restarted.
 
-When observability is enabled or disabled on {ocp-short} managed clusters that are managed by {product-title-short}, the observability endpoint operator updates the `cluster-monitoring-config` `ConfigMap` by adding addtional alertmanager configuration that restarts the local Prometheus automatically. 
+When observability is enabled or disabled on {ocp-short} managed clusters that are managed by {product-title-short}, the observability endpoint operator updates the `cluster-monitoring-config` `ConfigMap` by adding additional alertmanager configuration that restarts the local Prometheus automatically. 
 
 [#cluster-management-issues]
 == Cluster management known issues


### PR DESCRIPTION
Trying out this tool: https://github.com/client9/misspell. I found it from this [kubernetes repo](https://github.com/kubernetes/website/pull/26228).
Installed with `go get -u github.com/client9/misspell/cmd/misspell` since I already had go installed.
Cloned rhacm-docs repo and ran with command: misspell -w -locale US rhacm-docs/**/*
Same as [PR#2775](https://github.com/open-cluster-management/rhacm-docs/pull/2775)
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>