### PR TITLE
fix subscription for acm-operator and KlusterletAddonConfig (2.4) 

### DIFF
--- a/clusters/import_cli.adoc
+++ b/clusters/import_cli.adoc
@@ -140,7 +140,7 @@ spec:
     enabled: true
   searchCollector:
     enabled: true
-  version: 2.2.0
+  version: 2.4.0
 ----
 
 . Save the file as `klusterlet-addon-config.yaml`.

--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -190,7 +190,7 @@ metadata:
 spec:
   sourceNamespace: openshift-marketplace
   source: redhat-operators
-  channel: release-2.3
+  channel: release-2.4
   installPlanApproval: Automatic
   name: advanced-cluster-management
 ----


### PR DESCRIPTION
The [docs](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html/install/installing) incorrectly show the `.spec.channel` in the 2.4 `acm-operator-subscription` as `release-2.3`. It should be `release-2.4`. This has been thoroughly tested in my side.

Please accept this pull request to fix.