### PR TITLE
fix alertforward support version.

### DIFF
--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -268,7 +268,7 @@ The observability service is enabled. After you enable the observability service
 * All the alert managers from the managed clusters are forwarded to the {product-title-short} hub cluster.
 * All the managed clusters that are connected to the {product-title-short} hub cluster are enabled to send alerts back to the {product-title-short} observability service. You can configure the {product-title-short} Alertmanager to take care of deduplicating, grouping, and routing the alerts to the correct receiver integration such as email, PagerDuty, or OpsGenie. You can also handle silencing and inhibition of the alerts.
 +
-*Note*: Alert forwarding to the {product-title-short} hub cluster feature is only supported by managed clusters with {ocp} version 4.9 or later. After you install {product-title-short} with observability enabled, alerts from {ocp-short} v4.9 and later are automatically forwarded to the hub cluster.
+*Note*: Alert forwarding to the {product-title-short} hub cluster feature is only supported by managed clusters with {ocp} version 4.8 or later. After you install {product-title-short} with observability enabled, alerts from {ocp-short} v4.8 and later are automatically forwarded to the hub cluster.
 
 See xref:../observability/customize_observability.adoc#forward-alerts[Forwarding alerts] to learn more.
 


### PR DESCRIPTION
The alert forward feature support OCP 4.8 and later, the 2.3 doc is correct, but it is wrong for 2.4 doc.

Signed-off-by: morvencao <lcao@redhat.com>