### PR TITLE
Fix typo on autoImportRetry

### DIFF
--- a/clusters/import_cli.adoc
+++ b/clusters/import_cli.adoc
@@ -70,7 +70,7 @@ metadata:
   name: auto-import-secret
   namespace: <cluster_name>
 stringData:
-  autoImportRetry: 5
+  autoImportRetry: "5"
   # If you are using the kubeconfig file, add the following value for the kubeconfig file
   # that has the current context set to the cluster to import:
   kubeconfig: |- <kubeconfig_file>


### PR DESCRIPTION
This avoids the following error on import:

  This will fail to apply because the value of autoImportRetry needs to
  be quoted as a string. The error will be: Error from server
  (BadRequest): error when creating "/tmp/foo.yaml": Secret in version
  "v1" cannot be handled as a Secret: v1.Secret.StringData: ReadString:
  expects " or n, but found 5, error found in #10 byte of
  ...|rtRetry":5,"server":|..., bigger context
  ...|pace":"default"},"stringData":{"autoImportRetry":5,"server":"foo.bar.example.com","token":123},"type|...
