### PR TITLE
(SAVE FOR 2.6 PLANNING SPRINT) Add GHA to test AsciiDoc builds on each PR

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,26 @@
+---
+name: Linting
+
+on:
+  pull_request:
+
+jobs:
+  asciidoc:
+    name: 'Build AsciiDocs'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - name: Build each .adoc with Asciidoctor, fail on WARN or above
+        run: |
+          FAILED=0
+          for doc in $(find $(pwd) -name '*.adoc' -printf "%P\n"); do
+            echo "Building $doc"
+            if ! docker run -v $(pwd):/rhacm-docs/ asciidoctor/docker-asciidoctor@sha256:59a7e165ed6375dd5dfb930cb90019f1ccaee39787dc97a3918d7022a7503543 asciidoctor --failure-level WARN --trace --verbose --warnings /rhacm-docs/$doc; then
+                FAILED=$((FAILED+1))
+            fi
+          done
+          if (( FAILED > 0 )); then
+            echo "Build errors were detected in $FAILED file(s), see per-file details above."
+            exit 1
+          fi

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,13 +14,7 @@ jobs:
       - name: Build each .adoc with Asciidoctor, fail on WARN or above
         run: |
           FAILED=0
-          for doc in $(find $(pwd) -name '*.adoc' -printf "%P\n"); do
-            echo "Building $doc"
-            if ! docker run -v $(pwd):/rhacm-docs/ asciidoctor/docker-asciidoctor@sha256:59a7e165ed6375dd5dfb930cb90019f1ccaee39787dc97a3918d7022a7503543 asciidoctor --failure-level WARN --trace --verbose --warnings /rhacm-docs/$doc; then
-                FAILED=$((FAILED+1))
-            fi
-          done
-          if (( FAILED > 0 )); then
-            echo "Build errors were detected in $FAILED file(s), see per-file details above."
+          if ! docker run --rm -v $(pwd):/rhacm-docs/ asciidoctor/docker-asciidoctor@sha256:59a7e165ed6375dd5dfb930cb90019f1ccaee39787dc97a3918d7022a7503543 find /rhacm-docs/ -name \*.adoc -exec asciidoctor --failure-level WARN --trace --verbose --warnings {} +; then
+            echo "Build errors were detected, see per-file details above."
             exit 1
           fi


### PR DESCRIPTION
Add a GitHub action that builds each .adoc file on each PR, failing if
there are any errors WARN-level or above. All issues are shown in the
logs before failing.

Subsequent PRs could lower the threshold for failing to INFO and fix
additional issues.

This could eventually be extracted to a stand-alone GitHub action,
perhaps moved to a different repo, and shared with the rest of the
AsciiDoc ecosystem.

Shared automated testing infra makes the contribution process more
comfortable for developers and the code review process easier for
owners. It also guarantees consistent standards across the project.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>