### PR TITLE
Document Broker object in the managedClusterSet broker ns

### DIFF
--- a/services/deploy_submariner_api.adoc
+++ b/services/deploy_submariner_api.adoc
@@ -418,6 +418,25 @@ Replace `managed-cluster-set-name` with a name for the `ManagedClusterSet` that 
 +
 After the `ManagedClusterSet` is created, the `submariner-addon` creates a namespace called `<managed-cluster-set-name>-broker` and deploys the Submariner broker to it.
 
+. Create the Broker Configuration on the hub cluster in the `<managed-cluster-set-name>-broker` namespace by entering the following command:
++
+----
+cat << EOF | oc apply -f -
+----
++
+[source,yaml]
+----
+apiVersion: submariner.io/v1alpha1
+kind: Broker
+metadata:
+     name: submariner-broker
+     namespace: <managed-cluster-set-name>-broker
+spec:
+     globalnetEnabled: false
+EOF
+----
+Replace `<managed-cluster-set-name>` with the name of the managed cluster. Also, to enable Submariner Globalnet in the ManagedClusterSet, configure the value of `globalnetEnabled` to true.
+
 . Add one managed cluster to the `ManagedClusterSet` by entering the following command:
 +
 ----
@@ -456,7 +475,7 @@ After the `ManagedClusterAddOn` is created, the `submariner-addon` deploys Subma
 +
 *Note:* The name of `ManagedClusterAddOn` must be `submariner`.
 
-. Repeat steps 2 and 3 for all of the managed clusters that you want to enable Submariner.
+. Repeat steps three and four for all of the managed clusters that you want to enable Submariner on.
 
 . After Submariner is deployed on the managed cluster, you can verify the Submariner deployment status by checking the status of submariner `ManagedClusterAddOn` by entering the following command: 
 +


### PR DESCRIPTION
Submariner Globalnet feature will be supported in ACM 2.5
The required changes on the submariner-addon are already merged.
This PR updates the corresponding documentation on how to enable
the feature.

Related to: https://github.com/stolostron/backlog/issues/19403
Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>