### PR TITLE
service account as subscription admin

### DIFF
--- a/applications/subscription_admin.adoc
+++ b/applications/subscription_admin.adoc
@@ -5,7 +5,7 @@ Learn how to grant subscription administrator access. A _subscription_ administr
 
 . From the console, log in to your {ocp} cluster.
 
-. Create one or more users. See https://docs.openshift.com/container-platform/4.9/post_installation_configuration/preparing-for-users.html[Preparing for users] for information about creating users.
+. Create one or more users. See https://docs.openshift.com/container-platform/4.9/post_installation_configuration/preparing-for-users.html[Preparing for users] for information about creating users. You can also prepare groups or service accounts.
 
 +
 Users that you create are administrators for the `app.open-cluster-management.io/subscription` application. With {ocp-short}, a _subscription_ administrator can change default behavior. You can group these users to represent a subscription administrative group, which is demonstrated in later examples.
@@ -50,4 +50,11 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: example-group-name
+- kind: ServiceAccount
+  name: my-service-account
+  namespace: my-service-account-namespace
+# Service Account can be used as a user subject as well
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: 'system:serviceaccount:my-service-account-namespace:my-service-account'
 ----


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/stolostron/backlog/issues/21309

Add doc to show that a service account can be used in cluster role binding for subscription admin.