### PR TITLE
Updating duplicate anchor

### DIFF
--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -599,7 +599,7 @@ For more information about the `LoadBalancer` types, see the _Service_ page in t
 [#application-management-known-issues]
 == Application management known issues
 
-[#policy-needs-subscription-admin]
+[#application-topology-displays-wrong-application]
 === Application topology displays wrong application 
 //2.5.0: 22677
 


### PR DESCRIPTION
No issue, fixing Release note book
<img width="878" alt="Screen Shot 2022-05-27 at 10 18 34 AM" src="https://user-images.githubusercontent.com/60616885/170717846-486f552c-7897-45b3-9c09-741d62082bca.png">
 