### PR TITLE
added space to correct formatting

### DIFF
--- a/clusters/backup_and_restore.adoc
+++ b/clusters/backup_and_restore.adoc
@@ -73,7 +73,7 @@ spec:
     - name: default
       velero:
         provider: aws
-       config:
+        config:
           region: us-west-2
           profile: "default"
 ----


### PR DESCRIPTION
`config` needs one more space in order to be formatted correctly