### PR TITLE
Update observability customizing-certificates section

### DIFF
--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -358,12 +358,25 @@ You can customize certificates for accessing the object store. Edit the `http_co
       http_config:
         tls_config:
           ca_file: /etc/minio/certs/ca.crt
+          insecure_skip_verify: false
+----
+
+You must provide a secret in the `open-cluster-management-observability` namespace. The secret must contain the `ca.crt` that you defined in the previous secret example.
+If you want to enable Mutual TLS, you need to provide `public.crt`, and `private.key` in the previous secret. View the following example:
+
+[source,yaml]
+----
+ thanos.yaml: |
+    type: s3
+    config:
+      ...
+      http_config:
+        tls_config:
+          ca_file: /etc/minio/certs/ca.crt
           cert_file: /etc/minio/certs/public.crt
           key_file: /etc/minio/certs/private.key
           insecure_skip_verify: false
 ----
-
-You must provide a secret in the `open-cluster-management-observability` namespace. The secret must contain the `ca.crt`, `public.crt`, and `private.key` that you defined in the previous secret example. 
 
 You can also configure the secret name, the `TLSSecretName` parameter in the `MultiClusterObservability` CR. View the following example where the secret name is `tls-certs-secret`:
 


### PR DESCRIPTION
We support 2 cases for customize certificate:
1. mutual TLS support. that means user needs providing ca.crt/public.crt/private.key
2. SSL support. the user only need to provide ca.crt. the authenticate is still use access_key and secret_key.

Signed-off-by: clyang82 <chuyang@redhat.com>