### PR TITLE
Format subctl per guidelines, descriptive link text

### DIFF
--- a/add-ons/submariner/submariner.adoc
+++ b/add-ons/submariner/submariner.adoc
@@ -107,7 +107,7 @@ After adding the utility to your path, view the following table for a brief desc
 |===
 //This is an example of a verticle table versus the tables based on the ascii changes. We will need to decide which to continue with but the majority is the vertical input for the same output. It's best to see the rest of the doc and all of us to have a source that looks the same. We can see what the ascii guide at Red Hat asks for. Please always start with our source to create new content. --bcs
 
-For more information about the `subctl` utility and its commands, see https://submariner.io/operations/deployment/subctl/[SUBCTL] in the Submariner documentation. 
+For more information about the `subctl` utility and its commands, see https://submariner.io/operations/deployment/subctl/[`subctl` in the Submariner documentation].
 
 [#submariner-globalnet]
 == Globalnet


### PR DESCRIPTION
Small style issue that came up during a Submariner docs scrub.

Reference:
submariner.io/development/website/style-guide/#submarinerio-word-list
https://kubernetes.io/docs/contribute/style/style-guide/#links

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>