### PR TITLE
Removing 2.3+ notice with refreshing 2.5 notice (all in one)

### DIFF
--- a/release_notes/deprecate_remove.adoc
+++ b/release_notes/deprecate_remove.adoc
@@ -160,12 +160,6 @@ A _deprecated_ component, feature, or service is supported, but no longer recomm
 | None
 | None
 
-| klusterlet operator
-| `release-2.4`, `release-2.3` channels do not receive updates
-| 2.4, 2.3
-| To import and manage OpenShift dedicated, you must upgrade to 2.5 to receive updates.
-| See link:../install/upgrade_hub.adoc#upgrading-by-using-the-operator[Upgrading by using the operator].
-
 | Governance and risk
 | Custom policy controller 
 | 2.3


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/21400 

Since I am updating the deprecation for 2.5 and earlier, I went ahead and confirmed that for 2.6 that this would be removed.