### PR TITLE
Fix the OpenShift GitOps init command

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -430,7 +430,7 @@ oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
 
-Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.5` image used by the Init Container to a newer tag. View the following example:
+Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{product-version}` image used by the Init Container to a newer tag. View the following example:
 
 [source,yaml]
 ----
@@ -447,12 +447,12 @@ spec:
       value: /etc/kustomize/plugin
     initContainers:
     - args:
+      - -c
       - cp /etc/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
         /policy-generator/PolicyGenerator
       command:
-      - sh
-      - -c
-      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v2.5
+      - /bin/bash
+      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{product-version}
       name: policy-generator-install
       volumeMounts:
       - mountPath: /policy-generator

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -430,7 +430,7 @@ oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
 
-Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{product-version}` image used by the Init Container to a newer tag. View the following example:
+Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with `{product-version}` or your desired {product-title-short} version:
 
 [source,yaml]
 ----
@@ -452,7 +452,7 @@ spec:
         /policy-generator/PolicyGenerator
       command:
       - /bin/bash
-      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{product-version}
+      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v<version>
       name: policy-generator-install
       volumeMounts:
       - mountPath: /policy-generator

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -430,7 +430,7 @@ oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
 
-Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with `{product-version}` or your desired {product-title-short} version:
+Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example, and replace `<version>` with `{product-version}` or your desired {product-title-short} version:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Some users report that the other command didn't work. This new approach
seems to work for everyone.

This also changes it so that the image tags use the `{product-version}`
variable.

Relates:
https://github.com/stolostron/backlog/issues/24747