### PR TITLE
Instruct the user to set the version when installing the PG

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -430,7 +430,7 @@ oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
 
-Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with `2.6` or your desired {product-title-short} version:
+Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with {product-version} or your desired {product-title-short} version:
 
 [source,yaml]
 ----

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -430,7 +430,7 @@ oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
 
-Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{product-version}` image used by the Init Container to a newer tag. View the following example:
+Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with `{product-version}` or your desired {product-title-short} version:
 
 [source,yaml]
 ----
@@ -452,7 +452,7 @@ spec:
         /policy-generator/PolicyGenerator
       command:
       - /bin/bash
-      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v{product-version}
+      image: registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8:v<version>
       name: policy-generator-install
       volumeMounts:
       - mountPath: /policy-generator

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -430,7 +430,7 @@ oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
 
-Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with `{product-version}` or your desired {product-title-short} version:
+Then modify the OpenShift GitOps `argocd` object to contain the following additional YAML. When a new major version of {product-title-short} is released and you want to update the policy generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel8` image used by the Init Container to a newer tag. View the following example and replace `<version>` with `2.6` or your desired {product-title-short} version:
 
 [source,yaml]
 ----


### PR DESCRIPTION
The `{product-version}` variable does not get replaced in the source
YAML, so instruct the user to replace the version.

Relates:
https://github.com/stolostron/backlog/issues/24747