### PR TITLE
update know issues for app lifecycle in ACM 2.6 release

### DIFF
--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -753,12 +753,12 @@ A user performing in an `Editor` role should only have `read` or `update` author
 === Application not deployed after an updated placement rule
 // 1.0.0:1449
 
-If applications are not deploying after an update to a placement rule, verify that the `klusterlet-addon-appmgr` pod is running.
-The `klusterlet-addon-appmgr` is the subscription container that needs to run on endpoint clusters.
+If applications are not deploying after an update to a placement rule, verify that the `application-manager` pod is running.
+The `application-manager` is the subscription container that needs to run on managed clusters.
 
-You can run `oc get pods -n open-cluster-management-agent-addon` to verify.
+You can run `oc get pods -n open-cluster-management-agent-addon |grep application-manager` to verify.
 
-You can also search for `kind:pod cluster:yourcluster` in the console and see if the `klusterlet-addon-appmgr` is running.
+You can also search for `kind:pod cluster:yourcluster` in the console and see if the `application-manager` is running.
 
 If you cannot verify, attempt to import the cluster again and verify again.
 


### PR DESCRIPTION
Signed-off-by: Xiangjing Li <xiangli@redhat.com>

The `klusterlet-addon-appmgr` pod name has renamed to `application-manager`. 