### PR TITLE
update local-cluster example to generate cloud and vendor labels

### DIFF
--- a/multicluster_engine/hypershift/hosted_control_planes_configure.adoc
+++ b/multicluster_engine/hypershift/hosted_control_planes_configure.adoc
@@ -34,6 +34,8 @@ kind: ManagedCluster
 metadata:
   labels:
     local-cluster: "true"
+    cloud: auto-detect
+    vendor: auto-detect
   name: local-cluster
 spec:
   hubAcceptsClient: true


### PR DESCRIPTION
Fix: https://github.com/stolostron/backlog/issues/25054
Signed-off-by: haoqing0110 <qhao@redhat.com>