### PR TITLE
Link .0 ext ca certs in 2.5

### DIFF
--- a/credentials/credential_vm.adoc
+++ b/credentials/credential_vm.adoc
@@ -36,11 +36,18 @@ You can optionally add a _Base DNS domain_ for your credential. If you add the b
 . Add your _VMware vCenter root CA certificate_.
 .. You can download your certificate in the `download.zip` package with the certificate from your VMware vCenter server at: `https://<vCenter_address>/certs/download.zip`. Replace _vCenter_address_ with the address to your vCenter server. 
 .. Unpackage the `download.zip`.
-.. Use the certificate from the `certs/<platform>` directory that has a `.0` extension. *Tip:* You can use the `ls certs/<platform>` command to list all of the available certificates for your platform.
+.. Use the certificates from the `certs/<platform>` directory that have a `.0` extension. *Tip:* You can use the `ls certs/<platform>` command to list all of the available certificates for your platform.
 +
 Replace `_<platform>_` with the abbreviation for your platform: `lin`, `mac`, or `win`. 
 +
 For example: `certs/lin/3a343545.0`
++
+*Best practice:* Link together multiple certificates with a `.0` extension using the following command:
++
+----
+cat certs/lin/*.0 > ca.crt
+----
++
 . Add your _VMware vSphere cluster name_.
 . Add your _VMware vSphere datacenter_.
 . Add your _VMware vSphere default datastore_.


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/25246

Same as https://github.com/stolostron/rhacm-docs/pull/3949 but for 2.5