### PR TITLE
remove objectstore support in allow deny list feature

### DIFF
--- a/applications/allow_deny.adoc
+++ b/applications/allow_deny.adoc
@@ -1,7 +1,7 @@
 [#creating-allow-deny-list]
 = Creating an allow and deny list as subscription administrator
  
-As a subscription administrator, you can create an application from a Git repository or Object storage application subscription that contains an `allow` list to allow deployment of only specified Kubernetes `kind` resources. You can also create a `deny` list in the application subscription to deny deployment of specific Kubernetes `kind` resources.
+As a subscription administrator, you can create an application from a Git repository application subscription that contains an `allow` list to allow deployment of only specified Kubernetes `kind` resources. You can also create a `deny` list in the application subscription to deny deployment of specific Kubernetes `kind` resources.
 
 By default, `policy.open-cluster-management.io/v1` resources are not deployed by an application subscription. To avoid this default behavior, application subscription needs deployed by a subscription administrator.
 


### PR DESCRIPTION
Signed-off-by: Roke Jung <roke@redhat.com>

https://github.com/stolostron/backlog/issues/22763

The subscription allow, deny list feature is not supported for object storage subscription. Remove it from the doc.