### PR TITLE
Add sku while creating public-ip and note about removal of g/w node.

### DIFF
--- a/add-ons/submariner/submariner_prepare_hosts.adoc
+++ b/add-ons/submariner/submariner_prepare_hosts.adoc
@@ -17,7 +17,7 @@ kubectl label nodes <worker-node-name> "submariner.io/gateway=true" --overwrite
 . Create a public IP and assign it to the VM of the node that was tagged as gateway node by running the following commands:
 +
 ----
-az network public-ip create --name <public-ip-name> --resource-group <res-group>
+az network public-ip create --name <public-ip-name> --resource-group <res-group> -sku Standard
 az network nic ip-config update --name <name>  --nic-name <gw-vm-nic> --resource-group <res-group>  --public-ip-address <public-ip-name>
 ----
 +

--- a/add-ons/submariner/submariner_prepare_hosts.adoc
+++ b/add-ons/submariner/submariner_prepare_hosts.adoc
@@ -65,8 +65,7 @@ az network nsg rule create --resource-group <res-group> \
 --protocol udp --destination-port-ranges <vxlan-port>
 ----
 
-**Important:** Ensure that a new gateway node is tagged as a gateway node when trying a reinstall of Submariner. Reusing the current gateway after uninstalling of submariner can lead the connections to go to an error state.
-This is applicable only to {product-title}, where manual cloud preperation steps are used.
+*Important:* Ensure that a new gateway node is tagged as a gateway node when you reinstall Submariner. Reusing the current gateway after uninstalling Submariner result in the connections displaying an error state. This requirement is only applicable when you are using {product-title} with manual cloud preparation steps.
 
 [#preparing-ibm]
 == Preparing IBM Cloud for Submariner

--- a/add-ons/submariner/submariner_prepare_hosts.adoc
+++ b/add-ons/submariner/submariner_prepare_hosts.adoc
@@ -65,6 +65,9 @@ az network nsg rule create --resource-group <res-group> \
 --protocol udp --destination-port-ranges <vxlan-port>
 ----
 
+**Important:** Ensure that a new gateway node is tagged as a gateway node when trying a reinstall of Submariner. Reusing the current gateway after uninstalling of submariner can lead the connections to go to an error state.
+This is applicable only to {product-title}, where manual cloud preperation steps are used.
+
 [#preparing-ibm]
 == Preparing IBM Cloud for Submariner
 


### PR DESCRIPTION
1) The Azure CLI creates a public IP of type basic which conflicts
with the load balance type (Standard) created by the Openshift installer. 
Changed the doc to specify the SKU type as Standard explicitly

2) Add note for Azure g/w node deletion after uninstallation

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>