### PR TITLE
Restructure install-disconnected doc to improve consumability [Defunct]

### DIFF
--- a/install/install_disconnected.adoc
+++ b/install/install_disconnected.adoc
@@ -5,47 +5,51 @@ You might need to install {product-title} on {ocp} clusters that are not connect
 
 You must download copies of the packages to access them during the installation, rather than accessing them directly from the network during the installation.
 
-Before you get started, review the xref:../install/requirements.adoc#requirements-and-recommendations[Requirements and recommendations] section, then see the following documentation:
-
 * <<disconnect-prerequisites,Prerequisites>>
 * <<confirm-ocp-installation-2,Confirm your {ocp-short} installation>>
-* <<installing-in-a-disconnected-environment,Installing in a disconnected environment>>
+* <<installing-on-infra-node,Preparing to install the hub cluster on an infrastructure node>>
 
 [#disconnect-prerequisites]
 == Prerequisites 
 
 You must meet the following requirements before you install {product-title}:
 
-* {ocp} version 4.8 or later must be deployed in your environment, and you must be logged in with the command line interface (CLI). 
+* {ocp} version 4.6 or later must be deployed in your environment, and you must be logged in with the command line interface (CLI). 
 
 * You need access to the https://catalog.redhat.com/software/containers/search?p=1&application_categories_list=Container%20Platform%20%2F%20Management[catalog.redhat.com].
 +
-*Note:* For managing bare metal clusters, you must have {ocp-short} version 4.8 or later.
+*Note:* For managing bare metal clusters, you must have {ocp-short} version 4.6 or later.
 +
-See the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/installing/index[{ocp-short} version 4.10], https://docs.openshift.com/container-platform/4.10/welcome/index.html[{ocp-short} version 4.10].
+See the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/installing/index[{ocp-short} version 4.8], https://docs.openshift.com/container-platform/4.6/welcome/index.html[{ocp-short} version 4.6].
 
-* Your {ocp} CLI must be version 4.8 or later, and configured to run `oc` commands. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the Red Hat OpenShift CLI.
-* Your {ocp} permissions must allow you to create a namespace. Installation fails without a namespace.
+* Your {ocp} CLI must be version 4.6 or later, and configured to run `oc` commands. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the Red Hat OpenShift CLI.
+* Your {ocp} permissions must allow you to create a namespace.
 * You must have a workstation with Internet connection to download the dependencies for the operator.
 
 [#confirm-ocp-installation-2]
 == Confirm your {ocp-short} installation
 
-* You must have a supported {ocp-short} version, including the registry and storage services, installed and working in your cluster. For information about {ocp-short} version 4.10, see the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/[{ocp-short} Documentation].
+* You must have a supported {ocp-short} version, including the registry and storage services, installed and working in your cluster. For information about {ocp-short} version 4.8, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/[{ocp-short} Documentation].
 
-* When and if you are connected, run the `kubectl -n openshift-console get route` command to access the {ocp-short} web console. See the following example output:
+* When and if you are connected, you can ensure that the {ocp-short} cluster is set up correctly. Access the {ocp-short} web console.
+
++
+Run the `kubectl -n openshift-console get route` command to access the {ocp-short} web console.
+See the following example output:
+
 +
 ----
 openshift-console          console             console-openshift-console.apps.new-coral.purple-chesterfield.com                       console              https   reencrypt/Redirect     None
 ----
 
 +
-The console URL in this example is: `https:// console-openshift-console.apps.new-coral.purple-chesterfield.com`. Open the URL in your browser and check the result.
+The console URL in this example is: `https:// console-openshift-console.apps.new-coral.purple-chesterfield.com`.
+Open the URL in your browser and check the result.
 
 +
 If the console URL displays `console-openshift-console.router.default.svc.cluster.local`, set the value for `openshift_master_default_subdomain` when you install {ocp-short}.
 
-See xref:../install/cluster_size.adoc#sizing-your-cluster[Sizing your cluster] to learn about setting up capacity for your hub cluster.
+See xref:../install/plan_capacity.adoc#sizing-your-cluster[Sizing your cluster] to learn about setting up capacity for your hub cluster.
 
 [#installing-in-a-disconnected-environment]
 == Installing in a disconnected environment
@@ -54,28 +58,17 @@ See xref:../install/cluster_size.adoc#sizing-your-cluster[Sizing your cluster] t
 
 Follow these steps to install {product-title-short} in a disconnected environment:
 
-. Create a mirror registry. If you do not already have a mirror registry, create one by completing the procedure in the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/installing/disconnected-installation-mirroring#mirroring-images-disconnected-install[Mirroring images for a disconnected installation] topic of the {ocp} documentation.
+. Create a mirror registry. If you do not already have a mirror registry, create one by completing the procedure in the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/installing/installing-mirroring-installation-images[Mirroring images for a disconnected installation] topic of the {ocp} documentation.
 
 +
 If you already have a mirror registry, you can configure and use your existing one.
 
-+
-**Note:** Ensure you follow the steps in the {ocp-short} documentation at https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/post-installation_configuration/index#post-install-mirrored-catalogs[Populating OperatorHub from mirrored Operator catalogs].
-
-. Mirror operator catalogs. Ensure that the operator catalogs are mirrored by following the procedure in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/installing/disconnected-installation-mirroring#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
-
-**Notes:** 
-
-- If you are pruning packages from the existing Red Hat Operators index image, ensure that both the `advanced-cluster-management` and `multicluster-engine` packages are pruned. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html-single/operators/index#olm-pruning-index-image_olm-restricted-networks[Filtering a SQLite-based index image] for more information.
-
-- During the process for https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/installing/disconnected-installation-mirroring#olm-mirror-catalog-manifests_installing-mirroring-installation-images[Generated manifests], you will generate a `catalogSource.yaml` file in the manifest directory. You will use this sample file when you configure the disconnected {olm}.
-
-- For bare metal only, you need to provide the certificate information for the disconnected registry in your `install-config.yaml` file. To access the image in a protected disconnected registry, you must provide the certificate information so {product-title-short} can access the registry.
+. *Note:* For bare metal only, you need to provide the certificate information for the disconnected registry in your `install-config.yaml` file. To access the image in a protected disconnected registry, you must provide the certificate information so {product-title-short} can access the registry.
 
 .. Copy the certificate information from the registry.
 .. Open the `install-config.yaml` file in an editor.
 .. Find the entry for `additionalTrustBundle: |`.
-.. Add the certificate information after the `additionalTrustBundle` line. The content result is similar to the following example:
+.. Add the certificate information after the `additionalTrustBundle` line. The resulting content should look similar to the following example:
 
 +
 [source,yaml]
@@ -88,14 +81,13 @@ sshKey: >-
 ----
 
 + 
-*Important:* Additional mirrors for disconnected image registries are needed if the following Governance policies are required:
+. *Important:* Additional mirrors for disconnected image registries are needed if the following Governance policies are required:
 
-+
- ** Container security operator policy: The images are located in the source `registry.redhat.io/quay`.
+- Container Security Operator policy: The images are located in the source `registry.redhat.io/quay`.
 
- ** Compliance operator policy: The images are located in the source `registry.redhat.io/compliance`.
+- Compliance operator policy: The images are located in the source `registry.redhat.io/compliance`
 
- ** Gatekeeper operator policy: The images are located in the source `registry.redhat.io/rhacm2`.
+- Gatekeeper operator policy: The images are located in the source `registry.redhat.io/rhacm2`
 
 +
 See the following example of mirrors lists for all three operators:
@@ -117,7 +109,6 @@ See the following example of mirrors lists for all three operators:
 . Save the `install-config.yaml` file.
 
 . Create a YAML file that contains the `ImageContentSourcePolicy` with the name `rhacm-policy.yaml`. *Note:* If you modify this on a running cluster, it causes a rolling restart of all nodes.
-
 +
 [source,yaml]
 ----
@@ -132,32 +123,18 @@ spec:
     source: registry.redhat.io/rhacm2
 ----
 
-. Apply the `ImageContentSourcePolicy` file by entering the following command:
+. Apply the ImageContentSourcePolicy file by entering the following command:
 +
 ----
 oc apply -f rhacm-policy.yaml
 ----
 
-. Enable the disconnected {olm} Red Hat Operators and Community Operators. {product-title-short} is included in the {olm} Red Hat Operator catalog.
-
-. Configure the disconnected {olm} for the Red Hat Operator catalog. Follow the steps in the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/operators/administrator-tasks#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] topic of the {ocp} documentation.
-
+. Enable the disconnected {olm} Red Hat Operators and Community Operators.
 +
-* For the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.10/html/operators/administrator-tasks#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster] step, use the `catalogSource.yaml` file that you created when mirroring the operator catalog.
+{product-title-short} is included in the {olm} Red Hat Operator catalog.
 
-+
-* If you use your own `catalogSource.yaml` file and the catalog source name is different from the expected `redhat-operator-index`, you will need to add the following annotation to the `MultiClusterHub` custom resource with your catalog source in place of `my-operator-catalog`.
+. Configure the disconnected {olm} for the Red Hat Operator catalog. Follow the steps in the https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/operators/administrator-tasks#{olm}-restricted-networks[Using Operator Lifecycle Manager on restricted networks] topic of the {ocp} documentation.
 
-+
-[source,yaml]
-----
-apiVersion: operator.open-cluster-management.io/v1
-kind: MultiClusterHub
-metadata:
-  annotations:
-    installer.open-cluster-management.io/mce-subscription-spec: '{"source": "my-operator-catalog"}'
-----
+. Now that you have the image in the disconnected {olm}, continue to install {product-title-short} for Kubernetes from the {olm} catalog.
 
-Now that you have the image in the disconnected {olm}, continue to install {product-title-short} for Kubernetes from the {olm} catalog.
-
-See xref:../install/install_connected.adoc#installing-while-connected-online[Installing while connected online] for the required steps, or return to the xref:../install/install_overview.adoc#installing[Installing] overview.
+See xref:../install/install_connected.adoc#installing-while-connected-online[Installing while connected online] for the required steps.


### PR DESCRIPTION
**NB Superseded by** #4167

Initial draft of a significant restructure of the "install when disconnected" doc to hopefully improve commensurability. 

This was approached as a major rework of the section vs. any attempt at surgical updates.  Some material that seemed out of place or just didn't make sense to me was removed for this draft.

Part of stolostron/backlog#24630

To-Dos leading to this being marked Do Not Merge for now:

- Needs review and rework from review.
- The material I added on upgrade from 2.4 is probably out of place in the install section considering we have a separate upgrade section.  Probably should move it.
- Need to  disposition (probably via separate issue worked later) the material that used to be here regarding install considerations for some GRC policies.  Since that is not likely a day-1 or day-2 worry, it probably needs to go in another section.  And the material that was presented was quite incomplete.  (Already engaged with @gparvin on need for future work here.)
