### PR TITLE
Add GRC config policy metric in 2.6

### DIFF
--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -6,6 +6,8 @@ The policy framework exposes metrics that show policy distribution and complianc
 [#metric-overview]
 == Metric overview
 
+See the following topics for an overview of metrics.
+
 [#metric-policy-governance-info]
 === Metric: policy_governance_info
 

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -32,6 +32,6 @@ The `config_policies_evaluation_duration_` histogram tracks the number of second
 
 Use `config_policies_evaluation_duration_` to change the `ConfigurationPolicy` `evaluationInterval` setting when the time to process policies exceeds the default interval of ten seconds. To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:
 
- `rate(config_policies_evaluation_duration_seconds_sum[10m]) / rate (config_policies_evaluation_duration_seconds_count[10m]`
+`rate(config_policies_evaluation_duration_seconds_sum[10m]) / rate (config_policies_evaluation_duration_seconds_count[10m]`
 
 The `config-policy-controller` pod running on managed clusters in the `open-cluster-management-agent-addon` namespaces calculates the metric. The `config-policy-controller` does not send the metric to Observability by default.

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -22,5 +22,16 @@ The `policy_governance_info` metric uses the following labels:
 
 These labels and values enable queries that can show us many things happening in the cluster that might be difficult to track.
 
-*Note:* If the metrics are not needed, and there are any concerns about performance or security, this feature can be disabled. Set the `DISABLE_REPORT_METRICS` environment variable to `true` in the propagator deployment. You can also add `policy_governance_info` metric to the observability allowlist as a custom metric. See link:../observability/customize_observability.adoc#adding-custom-metrics[Adding custom metrics] for more details.
+*Note:* If the metrics are not needed, and there are any concerns about performance or security, this feature can be disabled. Set the `DISABLE_REPORT_METRICS` environment variable to `true` in the propagator deployment. You can also add `policy_governance_info` metric to the observability allowlist as a custom metric. See link:../observability/customize_observability.adoc#adding-custom-metrics[Adding custom metrics] for more details.'
 
+The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies on the cluster. Use the following metrics to implement the histogram:
+
+- `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and above.
+- `config_policies_evaluation_duration_seconds_copunt`: The count of all events.
+- `config_policies_evaluation_duration_seconds_sum`: The sum of all values.
+
+Use `config_policies_evaluation_duration_` to change the `ConfigurationPolicy` `evaluationInterval` setting when the time to process policies exceeds the default interval of ten seconds. To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:
+
+ `rate(config_policies_evaluation_duration_seconds_sum[10m]) / rate (config_policies_evaluation_duration_seconds_count[10m]`
+
+The `config-policy-controller` pod running on managed clusters in the `open-cluster-management-agent-addon` namespaces calculates the metric. The `config-policy-controller` does not send the metric to Observability by default.

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -24,7 +24,7 @@ These labels and values enable queries that can show us many things happening in
 
 *Note:* If the metrics are not needed, and there are any concerns about performance or security, this feature can be disabled. Set the `DISABLE_REPORT_METRICS` environment variable to `true` in the propagator deployment. You can also add `policy_governance_info` metric to the observability allowlist as a custom metric. See link:../observability/customize_observability.adoc#adding-custom-metrics[Adding custom metrics] for more details.
 
-The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies on the cluster. Use the following metrics to implement the histogram:
+The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies that are ready to be evaluated on the cluster. Use the following metrics to query the histogram:
 
 - `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and above.
 - `config_policies_evaluation_duration_seconds_count`: The count of all events.

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -22,7 +22,7 @@ The `policy_governance_info` metric uses the following labels:
 
 These labels and values enable queries that can show us many things happening in the cluster that might be difficult to track.
 
-*Note:* If the metrics are not needed, and there are any concerns about performance or security, this feature can be disabled. Set the `DISABLE_REPORT_METRICS` environment variable to `true` in the propagator deployment. You can also add `policy_governance_info` metric to the observability allowlist as a custom metric. See link:../observability/customize_observability.adoc#adding-custom-metrics[Adding custom metrics] for more details.'
+*Note:* If the metrics are not needed, and there are any concerns about performance or security, this feature can be disabled. Set the `DISABLE_REPORT_METRICS` environment variable to `true` in the propagator deployment. You can also add `policy_governance_info` metric to the observability allowlist as a custom metric. See link:../observability/customize_observability.adoc#adding-custom-metrics[Adding custom metrics] for more details.
 
 The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies on the cluster. Use the following metrics to implement the histogram:
 

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -34,11 +34,11 @@ These labels and values enable queries that can show us many things happening in
 
 The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies that are ready to be evaluated on the cluster. Use the following metrics to query the histogram:
 
-- `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and above.
+- `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and greater.
 - `config_policies_evaluation_duration_seconds_count`: The count of all events.
 - `config_policies_evaluation_duration_seconds_sum`: The sum of all values.
 
-Use `config_policies_evaluation_duration_` to determine if the `ConfigurationPolicy` `evaluationInterval` setting needs to be changed for resource intensive policies that do not need frequent evaluation. You can also increase the concurrency at the cost of higher resource utilization on the Kubernetes API server. See xref:../config_policy_ctrl.adoc##configure-config-policy-controller[Configure the configuration policy controller] for more details.
+Use `config_policies_evaluation_duration_` to determine if the `ConfigurationPolicy` `evaluationInterval` setting needs to be changed for resource intensive policies that do not need frequent evaluation. You can also increase the concurrency at the cost of higher resource utilization on the Kubernetes API server. See xref:../config_policy_ctrl.adoc#configure-config-policy-controller[Configure the configuration policy controller] for more details.
 
 To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:
 

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -27,7 +27,7 @@ These labels and values enable queries that can show us many things happening in
 The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies on the cluster. Use the following metrics to implement the histogram:
 
 - `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and above.
-- `config_policies_evaluation_duration_seconds_copunt`: The count of all events.
+- `config_policies_evaluation_duration_seconds_count`: The count of all events.
 - `config_policies_evaluation_duration_seconds_sum`: The sum of all values.
 
 Use `config_policies_evaluation_duration_` to change the `ConfigurationPolicy` `evaluationInterval` setting when the time to process policies exceeds the default interval of ten seconds. To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -6,6 +6,9 @@ The policy framework exposes metrics that show policy distribution and complianc
 [#metric-overview]
 == Metric overview
 
+[#metric-policy-governance-info]
+=== Metric: policy_governance_info
+
 The `policy_governance_info` is collected by {ocp-short} monitoring, and some aggregate data is collected by {product-title-short} observability, if it is enabled.
 
 *Note:* If observability is enabled, you can enter a query for the metric from the Grafana _Explore_ page. 
@@ -24,13 +27,18 @@ These labels and values enable queries that can show us many things happening in
 
 *Note:* If the metrics are not needed, and there are any concerns about performance or security, this feature can be disabled. Set the `DISABLE_REPORT_METRICS` environment variable to `true` in the propagator deployment. You can also add `policy_governance_info` metric to the observability allowlist as a custom metric. See link:../observability/customize_observability.adoc#adding-custom-metrics[Adding custom metrics] for more details.
 
+[#metric-config-policies-evaluation-duration-]
+=== Metric: config_policies_evaluation_duration_
+
 The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies that are ready to be evaluated on the cluster. Use the following metrics to query the histogram:
 
 - `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and above.
 - `config_policies_evaluation_duration_seconds_count`: The count of all events.
 - `config_policies_evaluation_duration_seconds_sum`: The sum of all values.
 
-Use `config_policies_evaluation_duration_` to change the `ConfigurationPolicy` `evaluationInterval` setting when the time to process policies exceeds the default interval of ten seconds. To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:
+Use `config_policies_evaluation_duration_` to determine if the `ConfigurationPolicy` `evaluationInterval` setting needs to be changed for resource intensive policies that do not need frequent evaluation. You can also increase the concurrency at the cost of higher resource utilization on the Kubernetes API server. See xref:../config_policy_ctrl.adoc##configure-config-policy-controller[Configure the configuration policy controller] for more details.
+
+To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:
 
 `rate(config_policies_evaluation_duration_seconds_sum[10m]) / rate (config_policies_evaluation_duration_seconds_count[10m]`
 

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -40,7 +40,7 @@ The `config_policies_evaluation_duration_` histogram tracks the number of second
 
 Use `config_policies_evaluation_duration_` to determine if the `ConfigurationPolicy` `evaluationInterval` setting needs to be changed for resource intensive policies that do not need frequent evaluation. You can also increase the concurrency at the cost of higher resource utilization on the Kubernetes API server. See xref:../config_policy_ctrl.adoc#configure-config-policy-controller[Configure the configuration policy controller] for more details.
 
-To receive information about the time used to evaluate configuration policies, use a metric that resembles the following expression:
+To receive information about the time used to evaluate configuration policies, perform a Prometheus query that resembles the following expression:
 
 `rate(config_policies_evaluation_duration_seconds_sum[10m]) / rate (config_policies_evaluation_duration_seconds_count[10m]`
 

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -34,7 +34,7 @@ These labels and values enable queries that can show us many things happening in
 
 The `config_policies_evaluation_duration_` histogram tracks the number of seconds it takes to process all configuration policies that are ready to be evaluated on the cluster. Use the following metrics to query the histogram:
 
-- `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 90, 120, 300, 450, 600, and greater.
+- `config_policies_evaluation_duration_seconds_bucket`: The buckets are cumulative and represent seconds with the following possible entries: 1, 3, 9, 10.5, 15, 30, 60, 90, 120, 180, 300, 450, 600, and greater.
 - `config_policies_evaluation_duration_seconds_count`: The count of all events.
 - `config_policies_evaluation_duration_seconds_sum`: The sum of all values.
 

--- a/governance/governance_metric.adoc
+++ b/governance/governance_metric.adoc
@@ -42,4 +42,4 @@ To receive information about the time used to evaluate configuration policies, u
 
 `rate(config_policies_evaluation_duration_seconds_sum[10m]) / rate (config_policies_evaluation_duration_seconds_count[10m]`
 
-The `config-policy-controller` pod running on managed clusters in the `open-cluster-management-agent-addon` namespaces calculates the metric. The `config-policy-controller` does not send the metric to Observability by default.
+The `config-policy-controller` pod running on managed clusters in the `open-cluster-management-agent-addon` namespace calculates the metric. The `config-policy-controller` does not send the metric to Observability by default.

--- a/observability/observe_environments.adoc
+++ b/observability/observe_environments.adoc
@@ -62,6 +62,21 @@ View the following table of metric types that are supported by the framework:
 | Gauge
 | `managed_cluster_id`, `category`, `policy`, `result`, `severity`
 | Stable. See xref:../observability/manage_insights.adoc#manage-insights[Managing insight PolicyReports] for more details.
+
+| `config_policies_evaluation_duration_seconds_bucket`
+| Histogram
+| 
+| Stable. See link:../governance/governance_metric.adoc#gov-metric[Governance metric] for more details.
+
+| `config_policies_evaluation_duration_seconds_count`
+| Histogram
+| 
+| Stable. See link:../governance/governance_metric.adoc#gov-metric[Governance metric] for more details.
+
+| `config_policies_evaluation_duration_seconds_sum`
+| Histogram
+| 
+| Stable. See link:../governance/governance_metric.adoc#gov-metric[Governance metric] for more details.
 |===
 
 Learn from the {ocp-short} documentation what types of metrics are collected and sent using telemetry. See https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html-single/support/index#about-remote-health-monitoring[Information collected by Telemetry] for information. 

--- a/observability/observe_environments.adoc
+++ b/observability/observe_environments.adoc
@@ -65,17 +65,17 @@ View the following table of metric types that are supported by the framework:
 
 | `config_policies_evaluation_duration_seconds_bucket`
 | Histogram
-| 
+| None.
 | Stable. See link:../governance/governance_metric.adoc#gov-metric[Governance metric] for more details.
 
 | `config_policies_evaluation_duration_seconds_count`
 | Histogram
-| 
+| None.
 | Stable. See link:../governance/governance_metric.adoc#gov-metric[Governance metric] for more details.
 
 | `config_policies_evaluation_duration_seconds_sum`
 | Histogram
-| 
+| None.
 | Stable. See link:../governance/governance_metric.adoc#gov-metric[Governance metric] for more details.
 |===
 


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/25514

@gparvin Wasn't sure if a new topic made sense in governance_metric.adoc or not, since that would have required the overview topic name and link and I'm trying to avoid something like that with the link issues we had recently. Still, I'll ask my team and see what they say.