### PR TITLE
Enable assisted on AWS in 2.6

### DIFF
--- a/multicluster_engine/cluster_lifecycle/create_infra_env.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_infra_env.adoc
@@ -5,6 +5,7 @@ You can use the console to create an infrastructure environment to manage your h
 
 * <<infra-env-prerequisites,Prerequisites>>
 * <<enable-cim,Enable Central Infrastructure Management service>>
+** <<enable-cim-aws,Enable Central Infrastructure Management on Amazon Web Services>>
 * <<creating-your-infra-env-with-the-console,Creating your infrastructure environment with the console>>
 * <<accessing-your-infra-env,Accessing your infrastructure environment>>
 
@@ -131,6 +132,64 @@ agentserviceconfig.agent-install.openshift.io/agent created
 ----
 
 Your CIM service is configured. You can verify that it is healthy by checking the `assisted-service` and `assisted-image-service` deployments and ensuring that their pods are ready and running. 
+
+[#enable-cim-aws]
+=== Enabling Central Infrastructure Management on Amazon Web Services
+
+If you are running CIM on Amazon Web Services, complete the following additional steps after  <<enable-cim,Enabling CIM>>:
+
+. Create a new `IngressController` with a unique domain using the `NLB` `type` parameter. See the following example:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: ingress-controller-with-nlb
+  namespace: openshift-ingress-operator
+spec:
+  domain: nlb-apps.<domain>.com
+  routeSelector:
+      matchLabels:
+        router-type: nlb
+  endpointPublishingStrategy:
+    type: LoadBalancerService
+    loadBalancer:
+      scope: External
+      providerParameters:
+        type: AWS
+        aws:
+          type: NLB
+----
+
+. Find the unique domain configured on the `assisted-image-service` by running the following command:
++
+----
+oc get routes --all-namespaces | grep assisted-image-service
+----
++
+Your domain might resemble the following example:
+`assisted-image-service-multicluster-engine.apps.<yourdomain>.com`
+
+. Add `<yourdomain>` to the `domain` parameter in `IngressController` by replacing `<domain>` in `nlb-apps.<domain>.com` with `<yourdomain>`.
+
+. Run the following command to edit the `assisted-image-service` route to use the `nlb-apps` location:
++
+----
+oc edit route assisted-image-service -n <namespace>
+----
+
+. Add the following lines to the metadata in the `assisted-image-service` route:
++
+[source,yaml]
+----
+  labels:
+    router-type: nlb
+----
+. In the `assisted-image-service` route, find the URL value of `spec.hosts`. The URL might resemble the following example:
++
+`assisted-image-service-multicluster-engine.apps.<yourdomain>.com`
+. Replace `apps` in the URL with `nlb-apps` to match the domain configured in the new `IngressController`.
 
 [#creating-your-infra-env-with-the-console]
 == Creating your infrastructure environment with the console


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/25693

Same as https://github.com/stolostron/rhacm-docs/pull/4139 but for 2.6, merging right away.