### PR TITLE
Expand and revise Submariner doc in 2.6

### DIFF
--- a/add-ons/submariner/submariner_customizations.adoc
+++ b/add-ons/submariner/submariner_customizations.adoc
@@ -135,3 +135,22 @@ spec:
 
 *Note:* The name of the `SubmarinerConfig` must be `submariner`, as shown in the example.
 
+[#cable-driver]
+== Cable driver
+
+The Submariner gateway engine component creates secure tunnels to other clusters. You can use the Libreswan or VXLAN implementations for the cable engine component for your `cableDriver` configuration. See the following example:
+
+[source,yaml]
+----
+apiVersion: submarineraddon.open-cluster-management.io/v1alpha1
+kind: SubmarinerConfig
+metadata:
+name: submariner
+namespace:
+spec:
+credentialsSecret:
+name: --creds
+cableDriver: 
+----
+
+*Best practice:* Only use unencrypted VXLAN connections in on-premises enviroments.

--- a/add-ons/submariner/submariner_customizations.adoc
+++ b/add-ons/submariner/submariner_customizations.adoc
@@ -138,7 +138,7 @@ spec:
 [#cable-driver]
 == Cable driver
 
-The Submariner gateway engine component creates secure tunnels to other clusters. You can use the Libreswan or VXLAN implementations for the cable engine component for your `cableDriver` configuration. See the following example:
+The Submariner gateway engine component creates secure tunnels to other clusters. You can use the Libreswan or VXLAN implementations for the `cableDriver` configuration of the cable engine component. See the following example:
 
 [source,yaml]
 ----

--- a/add-ons/submariner/submariner_customizations.adoc
+++ b/add-ons/submariner/submariner_customizations.adoc
@@ -145,12 +145,12 @@ The Submariner gateway engine component creates secure tunnels to other clusters
 apiVersion: submarineraddon.open-cluster-management.io/v1alpha1
 kind: SubmarinerConfig
 metadata:
-name: submariner
-namespace:
+   name: submariner
+   namespace:
 spec:
-credentialsSecret:
-name: --creds
-cableDriver: 
+   credentialsSecret:
+     name: --creds
+   cableDriver: 
 ----
 
 *Best practice:* Only use unencrypted VXLAN connections in on-premises enviroments.

--- a/add-ons/submariner/submariner_deploy_mcaddon_api.adoc
+++ b/add-ons/submariner/submariner_deploy_mcaddon_api.adoc
@@ -49,6 +49,23 @@ Replace `<managed-cluster-name>` with the name of the managed cluster that you w
 +
 Replace `<managed-cluster-set-name>` with the name of the `ManagedClusterSet` to which you want to add the managed cluster. 
 
+. Customize and apply YAML content that is similar to the following example:
++
+[source,yaml]
+----
+apiVersion: submarineraddon.open-cluster-management.io/v1alpha1
+kind: SubmarinerConfig
+metadata:
+    name: submariner
+    namespace: <managed-cluster-namespace>
+spec:{}
+----
++
+Replace `managed-cluster-namespace` with the namespace of your managed cluster.
++
+*Note:* The name of the `SubmarinerConfig` must be `submariner`, as shown in the example.
++
+
 .  Deploy Submariner on the managed cluster by customizing and applying YAML content that is similar to the following example:
 +
 [source,yaml]

--- a/add-ons/submariner/submariner_uninstall.adoc
+++ b/add-ons/submariner/submariner_uninstall.adoc
@@ -50,7 +50,7 @@ Replace `managed-cluster-namespace` with the namespace of your managed cluster.
 . Delete the cluster set to remove the broker details by running the following command:
 +
 ----
-oc delete <managedclusterset>
+oc delete managedclusterset <managedclusterset>
 ----
 +
 Replace `managedclusterset` with the name of your managed cluster set.

--- a/add-ons/submariner/submariner_uninstall.adoc
+++ b/add-ons/submariner/submariner_uninstall.adoc
@@ -50,8 +50,10 @@ Replace `managed-cluster-namespace` with the namespace of your managed cluster.
 . Delete the cluster set to remove the broker details by running the following command:
 +
 ----
-oc delete managedclusterset 
+oc delete <managedclusterset>
 ----
++
+Replace `managedclusterset` with the name of your managed cluster set.
 
 If the version of Submariner that you are removing is earlier than version 0.12, continue with <<uninstalling-submariner-manual,Manual removal steps for early versions of Submariner>>. If the Submariner version is 0.12, or later, Submariner is removed. 
 

--- a/add-ons/submariner/submariner_uninstall.adoc
+++ b/add-ons/submariner/submariner_uninstall.adoc
@@ -44,7 +44,7 @@ oc -n delete submarinerconfig submariner
 ----
 
 . Delete the cluster set to remove the broker details by running the following command:
-
++
 ----
 oc delete managedclusterset 
 ----

--- a/add-ons/submariner/submariner_uninstall.adoc
+++ b/add-ons/submariner/submariner_uninstall.adoc
@@ -16,6 +16,8 @@ To uninstall Submariner from a cluster by using the console, complete the follow
 
 . In the _Actions_ menu for the cluster that you want to uninstall Submariner, select *Uninstall Add-on*. 
 
+. In the _Actions_ menu for the cluster that you want to uninstall Submariner, select *Delete cluster sets*. 
+
 . Repeat those steps for other clusters from which you are removing Submariner.
 +
 *Tip:* You can remove the Submariner add-on from multiple clusters in the same cluster set by selecting multiple clusters and clicking *Actions*. Select *Uninstall Submariner add-ons*. 
@@ -29,23 +31,23 @@ If the version of Submariner that you are removing is earlier than version 0.12,
 
 To uninstall Submariner by using the command line, complete the following steps:
 
-. Locate the clusters that contain the Submariner add-on by entering the following command:
+. Remove the Submariner deployment for the cluster by running the following command:
 +
 ----
-oc get resource submariner-addon -n open-cluster-management
+oc -n get managedclusteraddon submariner
 ----
 
-. Run a command similar to the following example to uninstall Submariner from the cluster:
+. Remove the cloud resources of the cluster by running the following command:
 +
 ----
-oc delete resource submariner-addon -n <CLUSTER_NAME>
+oc -n delete submarinerconfig submariner
 ----
-+
-Replace `CLUSTER_NAME` with the name of the cluster.
 
-. Confirm that you want to remove all of the Submariner components from the cluster. 
+. Delete the cluster set to remove the broker details by running the following command:
 
-. Repeat the steps for each cluster to remove Submariner.
+----
+oc delete managedclusterset 
+----
 
 If the version of Submariner that you are removing is earlier than version 0.12, continue with <<uninstalling-submariner-manual,Manual removal steps for early versions of Submariner>>. If the Submariner version is 0.12, or later, Submariner is removed. 
 

--- a/add-ons/submariner/submariner_uninstall.adoc
+++ b/add-ons/submariner/submariner_uninstall.adoc
@@ -34,14 +34,18 @@ To uninstall Submariner by using the command line, complete the following steps:
 . Remove the Submariner deployment for the cluster by running the following command:
 +
 ----
-oc -n get managedclusteraddon submariner
+oc -n <managed-cluster-namespace> delete managedclusteraddon submariner
 ----
++
+Replace `managed-cluster-namespace` with the namespace of your managed cluster.
 
 . Remove the cloud resources of the cluster by running the following command:
 +
 ----
-oc -n delete submarinerconfig submariner
+oc -n <managed-cluster-namespace> delete submarinerconfig submariner
 ----
++
+Replace `managed-cluster-namespace` with the namespace of your managed cluster.
 
 . Delete the cluster set to remove the broker details by running the following command:
 +


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/26051

I ended up disagreeing with changing the command to a manifest example as there are plenty of commands throughout the doc and there is no reason to use a longer manifest example when a shorter command does the same thing. We also don't do central manifests as far as I know. I did implement the other suggestions. Everybody please help review, thanks!