### PR TITLE
Updates for TOC in Backup and restore

### DIFF
--- a/backup_restore/main.adoc
+++ b/backup_restore/main.adoc
@@ -3,4 +3,4 @@ include::modules/common-attributes.adoc[]
 = Backup and restore
 
 include::backup_intro.adoc[leveloffset=+1]
-include::manage_backup_restore.adoc[leveloffset=+2]
+include::manage_backup_restore.adoc[leveloffset=+1]


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/25895

After reviewing the stage environment, I noticed the table of contents (TOC) needed to be updated. 
<img width="376" alt="Screen Shot 2022-10-20 at 12 00 49 PM" src="https://user-images.githubusercontent.com/60616885/197001231-9a72d564-4694-4fa3-9567-4a53dedb1b81.png">
<img width="407" alt="Screen Shot 2022-10-20 at 12 00 58 PM" src="https://user-images.githubusercontent.com/60616885/197001238-0216c7a3-6274-48dd-b35f-a80978b65eb6.png">

Moving the topic "Managing backup and restore operator". The TOC is expected to be displayed in the following order:

1. Backup and restore
2. Managing backup and restore operator (@birsanv should this be renamed to backup and restore component? I remember we changed some references in the last live review)