### PR TITLE
Reverting change that was applicable for 2.7 only; adding note back for 2.6

### DIFF
--- a/backup_restore/manage_backup_restore.adoc
+++ b/backup_restore/manage_backup_restore.adoc
@@ -3,7 +3,11 @@
 
 The cluster backup and restore operator is not installed automatically. Enable the backup component by setting the `cluster-backup` parameter to `true`, in the `MultiClusterHub` resource. The OADP Operator is automatically installed, in the same namespace as the backup resource, when you install the cluster backup and restore operator.
 
-*Note*: If you have previously installed and used the OADP Operator on the hub cluster, in a namespace different from the backup component namespace, uninstall this version since the backup component works now with OADP installed in the component namespace. Use the same storage location for the link:https://github.com/openshift/oadp-operator/blob/master/docs/install_olm.md#create-the-dataprotectionapplication-custom-resource[`DataProtectionApplication`] resource owned by the OADP Operator installed with the backup component; it accesses the same backup data as the previous operator. Velero backup resources are now loaded within the new OADP Operator namespace on this hub cluster.
+*Notes*: 
+
+- The OADP Operator 1.0 has disabled building multi-arch builds and only produces `x86_64` builds for the official release. This means that if you are using an architecture other than `x86_64`, the OADP Operator installed by the backup component must be replaced with the correct version. In this case, uninstall the OADP Operator and find the operator matching your architecture, then install it.
+
+- If you have previously installed and used the OADP Operator on the hub cluster, in a namespace different from the backup component namespace, uninstall this version since the backup component works now with OADP installed in the component namespace. Use the same storage location for the link:https://github.com/openshift/oadp-operator/blob/master/docs/install_olm.md#create-the-dataprotectionapplication-custom-resource[`DataProtectionApplication`] resource owned by the OADP Operator installed with the backup component; it accesses the same backup data as the previous operator. Velero backup resources are now loaded within the new OADP Operator namespace on this hub cluster.
 
 link:https://velero.io/[Velero] is installed with the OADP Operator on the {product-title-short} hub cluster; Velero is used to backup and restore {product-title-short} hub cluster resources. 
 

--- a/backup_restore/manage_backup_restore.adoc
+++ b/backup_restore/manage_backup_restore.adoc
@@ -5,7 +5,7 @@ The cluster backup and restore operator is not installed automatically. Enable t
 
 *Notes*: 
 
-- The OADP Operator 1.0 has disabled building multi-arch builds and only produces `x86_64` builds for the official release. This means that if you are using an architecture other than `x86_64`, the OADP Operator installed by the backup component must be replaced with the correct version. In this case, uninstall the OADP Operator and find the operator matching your architecture, then install it.
+- The OADP Operator 1.0 no longer supports multi-arch builds and only produces x86_64 builds for official release. As a result, if you are using an architecture other than `x86_64`, the OADP Operator installed by the backup component must be replaced with the correct version. To replace the version, uninstall the OADP Operator and find the operator matching your architecture, then install it.
 
 - If you have previously installed and used the OADP Operator on the hub cluster, in a namespace different from the backup component namespace, uninstall this version since the backup component works now with OADP installed in the component namespace. Use the same storage location for the link:https://github.com/openshift/oadp-operator/blob/master/docs/install_olm.md#create-the-dataprotectionapplication-custom-resource[`DataProtectionApplication`] resource owned by the OADP Operator installed with the backup component; it accesses the same backup data as the previous operator. Velero backup resources are now loaded within the new OADP Operator namespace on this hub cluster.
 


### PR DESCRIPTION

[Related PR](https://github.com/stolostron/rhacm-docs/pull/4161/files)
[Related issue for 2.7](https://github.com/stolostron/backlog/issues/25978)
[Related issue where I made the incorrect commit](https://github.com/stolostron/backlog/issues/25895)

@birsanv will you confirm that the following notes should be listed for 2.6:

* The OADP Operator 1.0 has disabled building multi-arch builds and only produces `x86_64` builds for the official release. This means that if you are using an architecture other than `x86_64`, the OADP Operator installed by the backup component must be replaced with the correct version. In this case, uninstall the OADP Operator and find the operator matching your architecture, then install it.

* If you have previously installed and used the OADP Operator on the hub cluster, in a namespace different from the backup component namespace, uninstall this version since the backup component works now with OADP installed in the component namespace. Use the same storage location for the link:https://github.com/openshift/oadp-operator/blob/master/docs/install_olm.md#create-the-dataprotectionapplication-custom-resource[`DataProtectionApplication`] resource owned by the OADP Operator installed with the backup component; it accesses the same backup data as the previous operator. Velero backup resources are now loaded within the new OADP Operator namespace on this hub cluster.