### PR TITLE
adding info about replace upgrades and inplace upgrades per osdocs-4180

### DIFF
--- a/multicluster_engine/hosted_control_planes/hosted_control_planes_configure.adoc
+++ b/multicluster_engine/hosted_control_planes/hosted_control_planes_configure.adoc
@@ -348,9 +348,15 @@ spec:
           - <zone-2>
 ----
 
-Replace `zone-1` with the name of the zone in the region.
+Replace `zone-1` with the name of the zone in the region. Replace `zone-2` with the name of the zone in the region. 
 
-Replace `zone-2` with the name of the zone in the region. 
+In the previous example, the `upgradeType` is `Replace`. To upgrade a hosted cluster, you can use a replace upgrade or an in-place upgrade. 
+
+A _replace_ upgrade creates instances in the new version while it removes old instances from the previous version. This upgrade type is a good choice in cloud environments where this level of immutability is cost effective. 
+
+An _in-place_ upgrade directly updates the operating systems of the instances. This type is a good choice for environments where the infrastructure constraints are higher, such as bare metal.
+
+After you create a node pool, you cannot change the upgrade type. If you want to change the upgrade type, create a node pool and delete the other one. Replace upgrades do not preserve any manual changes because the node is re-provisioned entirely. In-place upgrades can preseve manual changes, but will report errors if you made manual changes to any file system or operating system configuration that the cluster directly manages, such as kubelet certificates.
 
 [#hosting-service-cluster-access]
 == Accessing a hosting service cluster


### PR DESCRIPTION
Related OCP doc Jira: https://issues.redhat.com/browse/OSDOCS-4180

This PR adds information about replace upgrades and in-place upgrades for hosted control planes.

I requested review from Yu Qi Zhang in the related Jira. I did not find him in GitHub to add as a reviewer.