### PR TITLE
Update DR4Hub samples in 2.7

### DIFF
--- a/backup_restore/manage_backup_restore.adoc
+++ b/backup_restore/manage_backup_restore.adoc
@@ -293,7 +293,7 @@ There are also cases where you want to restore the data on the same hub cluster 
 After you create a `restore.cluster.open-cluster-management.io` resource on the hub cluster, you can run the following command to get the status of the restore operation: 
 
 ----
-`oc get restore -n open-cluster-management-backup`
+oc get restore -n open-cluster-management-backup
 ----
 
 You should also be able to verify that the backed up resources that are contained by the backup file are created.

--- a/backup_restore/manage_backup_restore.adoc
+++ b/backup_restore/manage_backup_restore.adoc
@@ -193,7 +193,7 @@ View the following descriptions of the `backupschedule.cluster.open-cluster-mana
 . Check the status of your `backupschedule.cluster.open-cluster-management.io` resource, which displays the definition for the three `schedule.velero.io` resources. Run the following command:
 +
 ----
-oc get bsch -n <oadp-operator-ns>
+oc get bsch -n open-cluster-management-backup
 ----
 
 . As a reminder, the restore operation is run on a different hub cluster for restore scenarios. To initiate a restore operation, create a `restore.cluster.open-cluster-management.io` resource on the hub cluster where you want to restore backups.
@@ -254,6 +254,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: BackupSchedule
 metadata:
   name: schedule-acm
+  namespace: open-cluster-management-backup
 spec:
   veleroSchedule: 0 */2 * * *
   veleroTtl: 120h
@@ -262,10 +263,10 @@ spec:
 After you create a `backupschedule.cluster.open-cluster-management.io` resource, run the following command to get the status of the scheduled cluster backups:
 
 ----
-oc get bsch -n <oadp-operator-ns>
+oc get bsch -n open-cluster-management-backup
 ----
 
-The `<oadp-operator-ns>` parameter in the previous command is the namespace where the `BackupSchedule` is created, which is the same namespace where the OADP Operator is installed. The `backupschedule.cluster.open-cluster-management.io` resource creates six `schedule.velero.io` resources, which are used to generate backups. Run the following command to view the list of the backups that are scheduled:
+The `backupschedule.cluster.open-cluster-management.io` resource creates six `schedule.velero.io` resources, which are used to generate backups. Run the following command to view the list of the backups that are scheduled:
 
 ----
 os get schedules -A | grep acm
@@ -289,7 +290,13 @@ In a usual restore scenario, the hub cluster where the backups are run becomes u
 
 There are also cases where you want to restore the data on the same hub cluster where the backup was collected, so the data from a previous snapshot can be recovered. In this case, both restore and backup operations are run on the same hub cluster.
 
-After you create a `restore.cluster.open-cluster-management.io` resource on the hub cluster, you can run the following command to get the status of the restore operation: `oc get restore -n <oadp-operator-ns>`. You should also be able to verify that the backed up resources that are contained by the backup file are created.
+After you create a `restore.cluster.open-cluster-management.io` resource on the hub cluster, you can run the following command to get the status of the restore operation: 
+
+----
+`oc get restore -n open-cluster-management-backup`
+----
+
+You should also be able to verify that the backed up resources that are contained by the backup file are created.
 
 **Note:** The `restore.cluster.open-cluster-management.io` resource runs once, unless you use the `syncRestoreWithNewBackups` option and set it to `true`, as mentioned in the <<restore-passive-resources,Restore passive resources>> section. If you want to run the same restore operation again after the restore operation is complete, you must create a new `restore.cluster.open-cluster-management.io` resource with the same `spec` options.
 
@@ -443,7 +450,7 @@ You have some options to restore activation resources, depending on how you rest
 Use the `restore-acm` sample if you want to restore all data at once and make the hub cluster manage the managed clusters in one step. After you create a `restore.cluster.open-cluster-management.io` resource on the hub cluster, run the following command to get the status of the restore operation:
 
 ----
-oc get restore -n <oadp-operator-ns>
+oc get restore -n open-cluster-management-backup
 ----
 
 Your sample might resemble the following resource:
@@ -509,6 +516,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: BackupSchedule
 metadata:
   name: schedule-acm-msa
+  namespace: open-cluster-management-backup
 spec:
   veleroSchedule:
   veleroTtl: 120h
@@ -523,6 +531,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: BackupSchedule
 metadata:
   name: schedule-acm-msa
+  namespace: open-cluster-management-backup
 spec:
   veleroSchedule:
   veleroTtl: 120h
@@ -549,6 +558,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta1
 kind: BackupSchedule
 metadata:
   name: schedule-acm-msa
+  namespace: open-cluster-management-backup
 spec:
   veleroSchedule:
   veleroTtl: 120h


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/26605

I think I got all instances. Does `open-cluster-management-backup` need `<>` around it?