### PR TITLE
Specify min size for assisted installer database

### DIFF
--- a/multicluster_engine/cluster_lifecycle/create_infra_env.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_infra_env.adoc
@@ -108,7 +108,7 @@ spec:
         storage: <img_volume_size>
 ----
 +
-Replace `db_volume_size` with the volume size for the `databaseStorage` field, for example `10G`. This value specifies how much storage is allocated for storing files such as database tables and database views for the clusters. You might need to use a higher value if there are many clusters.
+Replace `db_volume_size` with the volume size for the `databaseStorage` field, for example `1G`. This value specifies how much storage is allocated for storing files such as database tables and database views for the clusters. The minimum value that is required is `1G`. You might need to use a higher value if there are many clusters.
 +
 Replace `fs_volume_size` with the size of the volume for the `filesystemStorage` field, for example `200M` per cluster and `2-3G` per supported {ocp-short} version. The minimum value that is required is `100G`. This value specifies how much storage is allocated for storing logs, manifests, and `kubeconfig` files for the clusters. You might need to use a higher value if there are many clusters. 
 +


### PR DESCRIPTION
This patch documents that the minium size required by the assisted installer is 1G.

Related: https://issues.redhat.com/browse/MGMT-11700
Related: https://github.com/openshift/assisted-service/pull/4463