### PR TITLE
Update docs on additional trust bundle field

### DIFF
--- a/multicluster_engine/cluster_lifecycle/create_azure.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_azure.adoc
@@ -74,7 +74,7 @@ Proxy information that is provided in the credential is automatically added to t
 
  * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations. 
 
- * Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+ * Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 When you review your information and optionally customize it before creating the cluster, you can click the *YAML* switch *On* to view the `install-config.yaml` file content in the panel. You can edit the YAML file with your custom settings, if you have any updates. 
 

--- a/multicluster_engine/cluster_lifecycle/create_google.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_google.adoc
@@ -75,7 +75,7 @@ Proxy information that is provided in the credential is automatically added to t
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations.
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 When you review your information and optionally customize it before creating the cluster, you can select *YAML: On* to view the `install-config.yaml` file content in the panel. You can edit the YAML file with your custom settings, if you have any updates.
 

--- a/multicluster_engine/cluster_lifecycle/create_hosted.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_hosted.adoc
@@ -44,7 +44,7 @@ Proxy information that is provided in the infrastructure environment is automati
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
   
 When you review your information and optionally customize it before creating the cluster, you can select *YAML: On* to view the YAML content in the panel. You can edit the YAML file with your custom settings, if you have any updates.  
 

--- a/multicluster_engine/cluster_lifecycle/create_ocp_aws.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_ocp_aws.adoc
@@ -79,7 +79,7 @@ Proxy information that is provided in the credential is automatically added to t
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: Specify the contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 When you review your information and optionally customize it before creating the cluster, you can select *YAML: On* to view the `install-config.yaml` file content in the panel. You can edit the YAML file with your custom settings, if you have any updates.
 

--- a/multicluster_engine/cluster_lifecycle/create_openstack.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_openstack.adoc
@@ -76,9 +76,9 @@ Proxy information that is provided in the credential is automatically added to t
 
 * No proxy domains: Define a comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: Specify the contents of the certificate file that is required to access the mirror registry. 
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
-You can define the disconnected installation image by clicking *Disconnected installation*. When creating a cluster by using Red Hat OpenStack Platform provider and disconnected installation, if a certificate is required to access the mirror registry, you must enter it in the _Additional trust bundle_ field of your credential in the _Configuration for disconnected installation section_. If you enter that certificate in the cluster create console editor, it is ignored.
+You can define the disconnected installation image by clicking *Disconnected installation*. When creating a cluster by using Red Hat OpenStack Platform provider and disconnected installation, if a certificate is required to access the mirror registry, you must enter it in the _Additional trust bundle_ field in the _Configuration for disconnected installation_ section when configuring your credential or the _Disconnected installation_ section when creating a cluster.
 
 When you review your information and optionally customize it before creating the cluster, you can click the *YAML* switch *On* to view the `install-config.yaml` file content in the panel. You can edit the YAML file with your custom settings, if you have any updates.  
 

--- a/multicluster_engine/cluster_lifecycle/create_virtualization.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_virtualization.adoc
@@ -92,7 +92,7 @@ Proxy information that is provided in the credential is automatically added to t
 
 * No proxy domains: Provide a comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: Specify the contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 When you review your information and optionally customize it before creating the cluster, you can click the *YAML* switch *On* to view the `install-config.yaml` file content in the panel. You can edit the YAML file with your custom settings, if you have any updates.
 

--- a/multicluster_engine/cluster_lifecycle/create_vm.adoc
+++ b/multicluster_engine/cluster_lifecycle/create_vm.adoc
@@ -24,8 +24,6 @@ See the following prerequisites before creating a cluster on vSphere:
 *** `api.<cluster_name>.<base_domain>` which must point to the static API VIP
 *** `*.apps.<cluster_name>.<base_domain>` which must point to the static IP address for Ingress VIP
 
-*Note:* When creating a cluster by using the VMware vSphere or Red Hat OpenStack Platform providers and disconnected installation, if a certificate is required to access the mirror registry, you must enter it in the _Additional trust bundle_ field of your credential in the _Configuration for disconnected installation section_. You cannot enter them in the cluster creation console editor.
-
 [#vsphere_creating-your-cluster-with-the-console]
 == Creating your cluster with the console
 
@@ -82,9 +80,9 @@ Proxy information that is provided in the credential is automatically added to t
 
 * No proxy domains: Provide a comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add an asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: Specify the contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
-You can define the disconnected installation image by clicking *Disconnected installation*. When creating a cluster by using the VMware vSphere provider and disconnected installation, if a certificate is required to access the mirror registry, you must enter it in the _Additional trust bundle_ field of your credential in the _Configuration for disconnected installation section_. If you enter that certificate in the cluster create console editor, it is ignored.
+You can define the disconnected installation image by clicking *Disconnected installation*. When creating a cluster by using Red Hat OpenStack Platform provider and disconnected installation, if a certificate is required to access the mirror registry, you must enter it in the _Additional trust bundle_ field in the _Configuration for disconnected installation_ section when configuring your credential or the _Disconnected installation_ section when creating a cluster.
 
 You can click *Add automation template* to create a template. 
  

--- a/multicluster_engine/credentials/credential_aws.adoc
+++ b/multicluster_engine/credentials/credential_aws.adoc
@@ -38,7 +38,7 @@ You can optionally add a _Base DNS domain_ for your credential. If you add the b
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add and asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 . Enter your _Red Hat OpenShift pull secret_. You can download your pull secret from https://cloud.redhat.com/openshift/install/pull-secret[Pull secret].
 . Add your _SSH private key_ and _SSH public key_, which allows you to connect to the cluster. You can use an existing key pair, or create a new one with key generation program.
 

--- a/multicluster_engine/credentials/credential_azure.adoc
+++ b/multicluster_engine/credentials/credential_azure.adoc
@@ -59,7 +59,7 @@ az account show
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add and asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 . Enter your _Red Hat OpenShift pull secret_. You can download your pull secret from https://cloud.redhat.com/openshift/install/pull-secret[Pull secret].
 

--- a/multicluster_engine/credentials/credential_google.adoc
+++ b/multicluster_engine/credentials/credential_google.adoc
@@ -41,7 +41,7 @@ Log in to https://console.cloud.google.com/apis/credentials/serviceaccountkey[GC
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add and asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 . Enter your _Red Hat OpenShift pull secret_. You can download your pull secret from https://cloud.redhat.com/openshift/install/pull-secret[Pull secret].
 . Add your _SSH private key_ and _SSH public key_ so you can access the cluster. You can use an existing key pair, or create a new pair using a key generation program.
 

--- a/multicluster_engine/credentials/credential_openstack.adoc
+++ b/multicluster_engine/credentials/credential_openstack.adoc
@@ -73,7 +73,7 @@ imageContentSources:
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add and asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 . Enter your Red Hat OpenShift Pull Secret.
 You can download your pull secret from https://cloud.redhat.com/openshift/install/pull-secret[Pull secret].

--- a/multicluster_engine/credentials/credential_vm.adoc
+++ b/multicluster_engine/credentials/credential_vm.adoc
@@ -91,7 +91,7 @@ imageContentSources:
 
 * No proxy domains: A comma-separated list of domains that should bypass the proxy. Begin a domain name with a period `.` to include all of the subdomains that are in that domain. Add and asterisk `*` to bypass the proxy for all destinations. 
 
-* Additional trust bundle: The contents of the certificate file that is required to access the mirror registry.
+* Additional trust bundle: One or more additional CA certificates that are required for proxying HTTPS connections.
 
 . Enter your _Red Hat OpenShift pull secret_. You can download your pull secret from https://cloud.redhat.com/openshift/install/pull-secret[Pull secret].
 

--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -226,20 +226,6 @@ Recreate the instance with the following command:
 
 See the following known issues and limitations for cluster management:
 
-[#create-with-disconnected]
-=== Disconnected installation settings for cluster creation cannot be entered or are ignored if entered
-//2.5:22808
-
-When you create a cluster by using the bare metal provider and a disconnected installation, you must store all your settings in the credential in the _Configuration for disconnected installation_ section. You cannot enter them in the cluster create console editor.
-
-When creating a cluster by using the VMware vSphere or Red Hat OpenStack Platform providers and disconnected installation, if a certificate is required to access the mirror registry, you must enter it in the _Additional trust bundle_ field of your credential in the _Configuration for disconnected installation section_. If you enter that certificate in the cluster create console editor, it is ignored.
-
-[#create-credential-multiple]
-=== Credential with disconnected installer does not distinguish between the certificates
-//2.5:22808
-
-When creating a credential for the bare metal, VMware vSphere, or Red Hat OpenStack Platform provider, note that the _Additional trust bundle_ field in the _Proxy and Configuration for disconnected installation_ contains the same value since the installer does not distinguish between the certificates. You can still use these features independently, and you can enter multiple certificates in the field if different certificates are required for proxy and disconnected installation.
-
 [#volsync-remove-csv-managed]
 === Manual removal of the VolSync CSV required on managed cluster when removing the add-on
 //2.5:21356


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/22693

Defect has been fixed so that the **Additional trust bundle** field for proxy settings and disconnected installation are separate. Further, the values entered in the create cluster wizard for disconnected installation will now be used. Updating the description of the field and removing known issue.