### PR TITLE
Updating the cluster book in Pantheon

### DIFF
--- a/clusters_mce/docinfo.xml
+++ b/clusters_mce/docinfo.xml
@@ -1,5 +1,5 @@
 <productname>{mce}</productname>
-<productnumber>2.06</productnumber>
+<productnumber>2.2.0</productnumber>
 <subtitle>Read more to learn how to create and manage the multicluster engine for Kubernetes.</subtitle>
 <abstract>
     <para>Read more to learn how to create and manage the multicluster engine for Kubernetes.</para>

--- a/clusters_mce/docinfo.xml
+++ b/clusters_mce/docinfo.xml
@@ -1,5 +1,5 @@
 <productname>{mce}</productname>
-<productnumber>{mce}</productnumber>
+<productnumber>2.06</productnumber>
 <subtitle>Read more to learn how to create and manage the multicluster engine for Kubernetes.</subtitle>
 <abstract>
     <para>Read more to learn how to create and manage the multicluster engine for Kubernetes.</para>


### PR DESCRIPTION
No issue, fixing book

We currently do not use conrefs for mce versions, but in other docinfo.xml file we use the conref variable for rhacm versions