### PR TITLE
Revert "Update the generator docs"

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -535,7 +535,7 @@ roleRef:
 [#policy-gen-yaml-table]
 == Policy generator configuration reference table
 
-Note that all the fields in the `policyDefaults` section except for `namespace` can be overridden for each policy, and all the fields in the `policySetDefaults` section can be overridden for each policy set.
+Note that all the fields in the `policyDefaults` section except for `namespace` can be overridden for each policy.
 
 .Parameter table
 |===
@@ -689,10 +689,6 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | Array of policy sets that the policy joins. Policy set details can be defined in the `policySets` section. When a policy is part of a policy set, a placement binding is not generated for the policy since one is generated for the set. Set `policies[].generatePlacementWhenInSet` or `policyDefaults.generatePlacementWhenInSet` to override `policyDefaults.policySets`.
 
-| `policyDefaults.generatePolicyPlacement`
-| Optional
-| Whether to generate placement manifests for policies. Setting to `false` will skip placement manifest generation, even if a placement is specified. This defaults to `true`.
-
 | `policyDefaults.generatePlacementWhenInSet`
 | Optional
 | When a policy is part of a policy set, by default, the generator does not generate the placement for this policy since a placement is generated for the policy set. Set `generatePlacementWhenInSet` to `true` to deploy the policy with both policy placement and policy set placement. The default value is `false`.
@@ -729,18 +725,6 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | Specify a placement rule by defining a cluster selector in the following format, `key:value`. See `placementRulePath` to specify an existing file.
 
-| `policySetDefaults`
-| Optional
-| Any default value listed here is overridden by an entry in the `policySets` array.
-
-| `policySetDefaults.placement`
-| Optional
-| The placement configuration for the policies. This defaults to a placement configuration that matches all clusters. (See `policyDefaults.placement` for description of this field.)
-
-| `policySetDefaults.generatePolicySetPlacement`
-| Optional
-| Whether to generate placement manifests for policy sets. Setting to "false" will skip placement manifest generation, even if a placement is specified. This defaults to "true".
-
 | `policies`
 | Required. 
 | The list of policies to create along with overrides to either the default values, or the values that are set in `policyDefaults`. See `policyDefaults` for additional fields and descriptions.
@@ -763,7 +747,7 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 
 | `policySets`
 | Optional
-| The list of policy sets to create along with overrides to either the default values, or the values that are set in `policySetDefaults`. To include a policy in a policy set, use `policyDefaults.policySets`, `policies[].policySets`,  or `policySets.policies`. See `policySetDefaults` for additional fields and descriptions.
+| The list of policy sets to create. To include a policy in a policy set, use `policyDefaults.policySets`, `policies[].policySets`,  or `policySets.policies`.
 
 | `policySets[].name`
 | Required
@@ -777,6 +761,9 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | The list of policies to be included in the policy set. If `policyDefaults.policySets` or `policies[].policySets` is also specified, the lists are merged.
 
+| `policySets[].placement`
+| Optional
+| The placement configuration for the policy set. This defaults to a placement configuration that matches all clusters. See `policyDefaults.placement` for placement documentation, however `policyDefaults.placement` settings do not apply to policy sets.
 |===
 
 Return to the xref:../governance/third_party_policy.adoc#integrate-third-party-policy-controllers[Integrate third-party policy controllers] documentation, or refer to the xref:../governance/grc_intro.adoc#governance[Governance] documentation for more topics.


### PR DESCRIPTION
This reverts commit 3997e90f29dc37da790879a5acad86c275ddd781 from:
- #4586 

The changes in the original PR were intended for `2.8` (sorry for confusion caused by submitting a `2.8` PR during `2.7` 🙁), but I've preserved the Doc refinements made in the original PR and reverted the content that doesn't apply to `2.7`, and I'll open a new PR once the `2.8` docs open.

Signed-off-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>