### PR TITLE
Update leader election configuration instructions

### DIFF
--- a/applications/config_leader_election.adoc
+++ b/applications/config_leader_election.adoc
@@ -18,26 +18,31 @@ To configure `LeaderElection`, you change the following default values:
 
 See the following steps to change the `multicluster-operators-application`, `multicluster-operators-channel`, `multicluster-operators-standalone-subscription`, or `multicluster-operators-hub-subscription` controllers:
 
-. Run the following command to locate the {product-title-short} `csv` file:
+. Run the following command to pause your `multiclusterhub`:
 +
 ----
-oc get csv -n open-cluster-management
+oc annotate mch -n open-cluster-management multiclusterhub mch-pause=true --overwrite=true
 ----
 
-. Edit the `csv` file by adding the `advanced-cluster-management` name to the `oc edit` command. See the following example command:
+. Edit the `deployment` file by adding the controller's name to the `oc edit` command. See the following example command:
 
 +
 ----
-oc edit csv -n open-cluster-management advanced-cluster-management.v2.7.0
+oc edit deployment -n open-cluster-management multicluster-operators-hub-subscription
 ----
 
-. Locate controller by searching for `- name: <controller>`.
+. Locate the controller's command flags by searching for `- command`.
 
 . From the containers section in the controller, insert a `- command` flag. For instance, insert `RetryPeriod`.
 
 . Save the file. The controller automatically restarts to apply the flag. 
 
 . Repeat this procedure for each controller that you want to change.
+
+. Run the following command to resume your `multiclusterhub`:
+----
+oc annotate mch -n open-cluster-management multiclusterhub mch-pause=false --overwrite=true
+----
 
 See the following example output of a successful edit to the `-command`, where the `retryPeriod` flag doubles the previously mentioned default time to `52`, which is allotted to retry acquiring `leaderElection`:
 

--- a/applications/config_leader_election.adoc
+++ b/applications/config_leader_election.adoc
@@ -31,7 +31,7 @@ oc annotate mch -n open-cluster-management multiclusterhub mch-pause=true --over
 oc edit deployment -n open-cluster-management multicluster-operators-hub-subscription
 ----
 
-. Locate the controller's command flags by searching for `- command`.
+. Locate the controller command flags by searching for `- command`.
 
 . From the containers section in the controller, insert a `- command` flag. For instance, insert `RetryPeriod`.
 

--- a/applications/config_leader_election.adoc
+++ b/applications/config_leader_election.adoc
@@ -24,7 +24,7 @@ See the following steps to change the `multicluster-operators-application`, `mul
 oc annotate mch -n open-cluster-management multiclusterhub mch-pause=true --overwrite=true
 ----
 
-. Edit the `deployment` file by adding the controller's name to the `oc edit` command. See the following example command:
+. Edit the `deployment` file by adding the controller name to the `oc edit` command. See the following example command:
 
 +
 ----


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

This change is to update the instructions for applying the leader election command flags. This wasn't caught earlier as I was unaware about the installer squad's removal of our components deployment from the csv.


Related: https://github.com/stolostron/backlog/issues/25868