### PR TITLE
Fixing broken link

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted.adoc
+++ b/clusters/hosted_control_planes/configure_hosted.adoc
@@ -287,7 +287,7 @@ You must have the following prerequisites to configure a hosting cluster:
 
 * {mce} 2.2 and later installed on an {ocp-short} cluster. When you install {product-title-short}, {mce-short} is automatically installed. You can also install {mce-short} without {product-title-short} as an Operator from the {ocp-short} OperatorHub.
 
-* The hosted control planes command line interface (CLI) as a plugin for `oc` to create and manage the hosted cluster in {mce}. To install the CLI, follow the instructions in xref:../hosted_control_planes/configure_hosted.adoc#hosted-install-cli[Installing the hosted control plane CLI.
+* The hosted control planes command line interface (CLI) as a plugin for `oc` to create and manage the hosted cluster in {mce}. To install the CLI, follow the instructions in xref:../hosted_control_planes/configure_hosted.adoc#hosted-install-cli[Installing the hosted control plane CLI].
 
 * {mce} must have at least one managed {ocp-short} cluster. The `local-cluster` is automatically imported in {mce} 2.2 and later. See xref:../install_upgrade/adv_config_install.adoc#advanced-config-engine[Advanced configuration] for more information about the `local-cluster`. You can check the status of your hub cluster by running the following command:
 +


### PR DESCRIPTION
I found a broken link in the prerequisites for configuring hosted control planes on bare metal. The xref was missing a closing square bracket.