### PR TITLE
[2.4_stage] Update policy generator link to upstream

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -120,7 +120,7 @@ spec:
         severity: low
 ----
 
-See the link:https://github.com/stolostron/policy-generator-plugin[`policy-generator-plugin`] repository for more details.
+See the link:https://github.com/open-cluster-management-io/policy-generator-plugin[`policy-generator-plugin`] repository for more details.
 
 [#policy-gen-install-operator]
 == Generating a policy to install an Operator


### PR DESCRIPTION
We've moved the policy generator upstream for https://issues.redhat.com/browse/ACM-2598