### PR TITLE
fix ACM-4051 disabling the hypershift feature

### DIFF
--- a/clusters/hosted_control_planes/disable_hosted.adoc
+++ b/clusters/hosted_control_planes/disable_hosted.adoc
@@ -22,7 +22,7 @@ oc get hostedcluster -A
 oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}'
 ----
 +
-*Tip:* You can also disable the hosted control plane feature from the {mce-short} console after disabling the `hypershift-addon`.
+*Tip:* You can also disable the `hypershift-addon` for the `local-cluster` from the {mce-short} console after disabling the `hypershift-addon`.
 
 [#hosted-disable-feature]
 == Disabling the hosted control planes feature

--- a/clusters/hosted_control_planes/disable_hosted.adoc
+++ b/clusters/hosted_control_planes/disable_hosted.adoc
@@ -24,6 +24,36 @@ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"componen
 +
 *Tip:* You can also disable the hosted control plane feature from the {mce-short} console after disabling the `hypershift-addon`.
 
+[#hosted-disable-feature]
+== Disabling the hosted control planes feature
+
+Before disabling the hosted control plane feature, ensure that the hypershift operator is uninstalled first. You can run the following command to disable the feature:
+
+----
+oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": false}]}}}'
+----
+
+Run the following command to verify that the `hypershift-preview` and `hypershift-local-hosting` features are disabled in the `MultiClusterEngine` custom resource.
+
+----
+oc get mce multiclusterengine -o yaml
+----
+
+[source,yaml]
+----
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec:
+  overrides:
+    components:
+    - name: hypershift-preview
+      enabled: false
+    - name: hypershift-local-hosting
+      enabled: false
+----
+
 [#additional-resources-disable]
 == Additional resources
 

--- a/clusters/hosted_control_planes/disable_hosted.adoc
+++ b/clusters/hosted_control_planes/disable_hosted.adoc
@@ -27,18 +27,19 @@ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"componen
 [#hosted-disable-feature]
 == Disabling the hosted control planes feature
 
-Before disabling the hosted control plane feature, ensure that the hypershift operator is uninstalled first. You can run the following command to disable the feature:
+You must first uninstall the HyperShift Operator before disabling the hosted control planes feature. Run the following command to disable the hosted control planes feature:
 
 ----
 oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": false}]}}}'
 ----
 
-Run the following command to verify that the `hypershift-preview` and `hypershift-local-hosting` features are disabled in the `MultiClusterEngine` custom resource.
+You can verify that the `hypershift-preview` and `hypershift-local-hosting` features are disabled in the `MultiClusterEngine` custom resource by running the following command:
 
 ----
 oc get mce multiclusterengine -o yaml
 ----
 
+See the following example where `hypershift-preview` and `hypershift-local-hosting` have their `enabled:` flags set to `false`:
 [source,yaml]
 ----
 apiVersion: multicluster.openshift.io/v1


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/ACM-4051. The doc is missing a step to disable the hosted control plane feature.