### PR TITLE
[ACM-3650]: Adding KubeVirt as a provider for hosted control planes

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -25,5 +25,5 @@ For more information about hosted control planes, continue reading the following
 * xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS]
 * xref:../hosted_control_planes/configure_hosted_bm.adoc#hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal (Technology Preview)]
 * xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]
-* xref:../hosted_control_planes/managing_hosted_kubevirt.adoc#hosted-control-planes-manage-kubevirt[Creating hosted control plane clusters on KubeVirt]
+* xref:../hosted_control_planes/managing_hosted_kubevirt.adoc#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on KubeVirt]
 * xref:../hosted_control_planes/disable_hosted.adoc#disable-hosted-control-planes[Disabling the hosted control feature]

--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -3,7 +3,7 @@
 
 With {mce-short} cluster management, you can deploy {ocp-short} clusters by using two different control plane configurations: standalone or hosted control planes. The standalone configuration uses dedicated virtual machines or physical machines to host the {ocp-short} control plane. With hosted control planes for {ocp-short}, you create control planes as pods on a hosting cluster without the need for dedicated physical machines for each control plane.
 
-Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS) and on bare metal or virtual environments. You can host the control planes on {ocp-short} version 4.10.7 and later.
+Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS), bare metal or virtual environments, and KubeVirt. You can host the control planes on {ocp-short} version 4.10.7 and later.
 
 **Note:** Run the hub cluster and workers on the same platform for hosted control planes.
 
@@ -25,4 +25,5 @@ For more information about hosted control planes, continue reading the following
 * xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS]
 * xref:../hosted_control_planes/configure_hosted_bm.adoc#hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal (Technology Preview)]
 * xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]
+* xref:../hosted_control_planes/managing_hosted_kubevirt.adoc#hosted-control-planes-manage-kubevirt[Creating hosted control plane clusters on KubeVirt]
 * xref:../hosted_control_planes/disable_hosted.adoc#disable-hosted-control-planes[Disabling the hosted control feature]

--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -3,7 +3,7 @@
 
 With {mce-short} cluster management, you can deploy {ocp-short} clusters by using two different control plane configurations: standalone or hosted control planes. The standalone configuration uses dedicated virtual machines or physical machines to host the {ocp-short} control plane. With hosted control planes for {ocp-short}, you create control planes as pods on a hosting cluster without the need for dedicated physical machines for each control plane.
 
-Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS), bare metal or virtual environments, and KubeVirt. You can host the control planes on {ocp-short} version 4.10.7 and later.
+Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS), bare metal or virtual environments, and {ocp-virt}. You can host the control planes on {ocp-short} version 4.10.7 and later.
 
 **Note:** Run the hub cluster and workers on the same platform for hosted control planes.
 

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -23,7 +23,7 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 
 You must meet the following prerequisites to create an {ocp-short} cluster on {ocp-virt-short}:
 
-- Administrator access to an {ocp-short} cluster, version 4.12 or later, specified by the `KUBECONFIG` environment variable.
+- You need administrator access to an {ocp-short} cluster, version 4.12 or later, specified by the `KUBECONFIG` environment variable.
 - The management {ocp-short} cluster must have wildcard DNS routes enabled:
 +
 ----
@@ -36,16 +36,10 @@ oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p 
 ----
 oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ----
-- The {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
-- A valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
-- The HyperShift Operator and `hypershift` CLI tool must be installed. To download and install the CLI, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[Installing the hosted control planes CLI].
-+
-After you install the CLI, install the HyperShift Operator by entering the following command:
-+
-----
-hypershift install
-----
-- For your cluster to be provisioned correctly, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
+- You need the {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
+- You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
+- You need to enable the hosted control planes feature. For information, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc##hosted-enable-feature-aws[Enabling the hosted control planes feature].
+- Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]
 === Creating a hosted cluster with the KubeVirt platform
@@ -108,7 +102,7 @@ metadata:
 EOF
 ----
 
-. Create an address pool with an available range of IP addresses within the node network:
+. Create an address pool with an available range of IP addresses within the node network. Replace the following IP address ranges with an unused pool of available IP addresses in your network.
 +
 ----
 oc create -f - <<EOF

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -1,0 +1,274 @@
+[#hosted-control-planes-manage-kubevirt]
+= Creating hosted control plane clusters on KubeVirt (Technology Preview)
+
+You can install a nested {ocp} cluster that runs on KubeVirt virtual machines within a management cluster.
+
+* <<create-hosted-clusters-prereqs-kubevirt,Prerequisites>>
+* <<creating-a-hosted-cluster-kubevirt,Creating a hosted cluster on KubeVirt>>
+* <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>
+* <<create-hosted-clusters-kubevirt-default-ingress-dns,Default Ingress and DNS behavior>>
+* <<create-hosted-clusters-kubevirt-customized-ingress-dns,Customized Ingress and DNS behavior>>
+* <<create-hosted-clusters-kubevirt-scaling-node-pool,Scaling a node pool>>
+* <<create-hosted-clusters-kubevirt-adding-node-pool,Adding node pools>>
+//* <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on KubeVirt>>
+* <<hypershift-cluster-destroy-kubevirt,Destroying a hosted cluster on KubeVirt>>
+
+[#create-hosted-clusters-prereqs-kubevirt]
+== Prerequisites
+
+You must meet the following prerequisites to create a hosting cluster on KubeVirt:
+
+- Administrator access to an {ocp-short} cluster, version 4.12 or later, specified by the `KUBECONFIG` environment variable.
+- The management {ocp-short} cluster must have wildcard DNS routes enabled:
++
+----
+oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
+----
+- The management {ocp-short} cluster must have Red Hat OpenShift Virtualization installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
+- The management {ocp-short} cluster must be configured with OVNKubernetes as the default pod network CNI.
+- The management {ocp-short} cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. This example shows how to set a default storage class:
++
+----
+oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+----
+- The {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
+- A valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
+- The HyperShift Operator and `hypershift` CLI tool must be installed. To build the latest `hypershift` CLI tool and place it in the `/usr/local/bin` directory, enter the following command:
++
+----
+podman run --rm --privileged -it -v \
+$PWD:/output docker.io/library/golang:1.18 /bin/bash -c \
+'git clone https://github.com/openshift/hypershift.git && \
+cd hypershift/ && \
+make hypershift && \
+mv bin/hypershift /output/hypershift'
+
+sudo mv $PWD/hypershift /usr/local/bin
+----
++
+After the `hypershift` CLI tool is installed, enter the following command to install the HyperShift Operator:
++
+----
+hypershift install
+----
+
+[#creating-a-hosted-cluster-kubevirt]
+=== Creating a hosted cluster on KubeVirt
+
+. To create a guest cluster, use environment variables and the `hypershift` CLI tool:
++
+----
+shell linenums="1"
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hypershift create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas=$WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU
+----
++
+Replace values as necessary.
++
+A default node pool is created for the cluster with two virtual machine worker replicas per the `--node-pool-replicas` flag.
++
+A guest cluster that is backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned. 
+
+. To check the status of the guest cluster, see the corresponding HostedCluster resource. The following example output illustrates a fully provisioned HostedCluster object:
++
+.Example output
+----
+shell linenums="1"
+oc get --namespace clusters hostedclusters
+NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+----
+
+. To gain CLI access to the guest cluster, retrieve the guest cluster's kubeconfig environment variable. The following example shows how to retrieve the guest cluster's kubeconfig environment variable by using the `hypershift` CLI:
++
+----
+shell
+hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+----
+
+[#hosting-service-cluster-configure-metallb-config]
+=== Configuring a load balancer
+
+You must use a load balancer, such as MetalLB. The following example shows the steps you can take to configure MetalLB after you install it. For more information about installing MetalLB, see link:https://docs.openshift.com/container-platform/4.12/networking/metallb/metallb-operator-install.html[Installing the MetalLB Operator].
+
+. Create a MetalLB instance:
++
+----
+oc create -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: MetalLB
+metadata:
+  name: metallb
+  namespace: metallb-system
+EOF
+----
+
+. Create an address pool with an available range of IP addresses within the node network:
++
+----
+oc create -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: metallb
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.216.32-192.168.216.122
+EOF
+----
+
+. Advertise the address pool by using L2 protocol:
++
+----
+oc create -f - <<EOF
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+   - metallb
+EOF
+----
+
+[#create-hosted-clusters-kubevirt-default-ingress-dns]
+=== Default Ingress and DNS behavior
+
+Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the Hypershift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
+
+For example, imagine that your {ocp-short} cluster has a default Ingress DNS entry of `*.apps.mgmt-cluster.example.com`. The default Ingress of a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster is `*.apps.guest.apps.mgmt-cluster.example.com`.
+
+**Note:** For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following CLI command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
+
+[#create-hosted-clusters-kubevirt-customized-ingress-dns]
+=== Customized Ingress and DNS behavior
+
+If you do not want to use the default Ingress and DNS behavior, you can configure a KubeVirt guest cluster with a unique base domain at creation time. This option requires manual configuration steps during creation, and it involves three steps.
+
+. Create a KubeVirt cluster with a custom base domain that you control. During cluster creation, use the `--base-domain` CLI argument, as shown in the following example:
++
+----
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export BASE_DOMAIN="example.com"
+
+hypershift create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas=2 \
+--pull-secret $PULL_SECRET \
+--base-domain $BASE_DOMAIN
+----
+
+. Create a load balancer service to route Ingress traffic to the KubeVirt virtual machines that are acting as nodes for the guest cluster.
++
+.. Inspect the guest cluster to learn what port to use as the target port when routing to the KubeVirt virtual machines. You can discover the target port by using the kubeconfig for the new KubeVirt cluster to retrieve the default router's NodePort service. The following CLI commands can automatically detect the target port of the guest cluster and store it in an environment variable:
++
+----
+hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+export EXTERNAL_IP=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o wide --no-headers | sed -E 's|.*443:(.....).*$|\1|' |  tr -d '[:space:])
+----
++
+.. After you discover the target port, create a load balancer service to route traffic to the guest cluster's KubeVirt virtual machines:
++
+----
+export CLUSTER_NAME=example
+export CLUSTER_NAMESPACE=clusters-${CLUSTER_NAME}
+
+cat << EOF > apps-LB-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ${CLUSTER_NAME}
+  name: ${CLUSTER_NAME}
+  namespace: ${CLUSTER_NAMESPACE}
+spec:
+  ports:
+  - name: https-443
+    port: 443
+    protocol: TCP
+    targetPort: ${HTTPS_NODEPORT}
+  selector:
+    kubevirt.io: virt-launcher
+  type: LoadBalancer
+EOF
+
+oc create -f apps-LB-service.yaml
+----
+
+. Configure a wildcard DNS, a record, or CNAME that references external IP of the load balancer service. 
+
+.. To get the external IP of the load balancer, enter this command:
++
+----
+export EXTERNAL_IP=$(oc get service -n $KUBEVIRT_CLUSTER_NAMESPACE $KUBEVIRT_CLUSTER_NAME  | grep $KUBEVIRT_CLUSTER_NAME| awk '{ print $4 }' | tr -d '[:space:]')
+----
+
+.. Configure a `*.apps.<cluster_name>.<base_domain>.` wildcard DNS entry that references the IP that is stored in the $EXTERNAL_IP environment variable that is routable both internally and externally in the cluster.
+
+[#create-hosted-clusters-kubevirt-scaling-node-pool]
+=== Scaling a node pool
+
+You can manually scale a NodePool by using the `oc scale` command:
+
+----
+NODEPOOL_NAME=${CLUSTER_NAME}-work
+NODEPOOL_REPLICAS=5
+
+oc scale nodepool/$NODEPOOL_NAME --namespace clusters --replicas=$NODEPOOL_REPLICAS
+----
+
+[#create-hosted-clusters-kubevirt-adding-node-pool]
+=== Adding node pools
+
+You can create node pools for a guest cluster by specifying a name, number of replicas, and any additional information, such as memory and CPU requirements.
+
+. To create a node pool, enter the following information:
++
+----
+export NODEPOOL_NAME=${CLUSTER_NAME}-workers
+export WORKER_COUNT="2"
+export MEM="6Gi"
+export CPU="2"
+
+hypershift create nodepool kubevirt \
+  --cluster-name $CLUSTER_NAME \
+  --name $NODEPOOL_NAME \
+  --node-count $WORKER_COUNT \
+  --memory $MEM \
+  --cores $CPU
+----
+
+. Check the status of the node pool by listing `nodepool` resources in the `clusters` namespace:
++
+----
+oc get nodepools --namespace clusters
+----
+
+//[#verifying-cluster-creation-kubevirt]
+//== Verifying hosted cluster creation on KubeVirt
+
+//How do we verify cluster creation on KubeVirt?
+
+[#hypershift-cluster-destroy-kubevirt]
+== Destroying a hosted cluster on KubeVirt
+
+To destroy a hosted cluster on KubeVirt, enter the following command on a command line:
+
+----
+hypershift destroy cluster kubevirt --name $CLUSTER_NAME
+----
+
+Replace names where necessary.

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -1,22 +1,22 @@
 [#hosted-control-planes-manage-kubevirt]
-= Creating hosted control plane clusters on KubeVirt (Technology Preview)
+= Creating hosted control plane clusters on {ocp-virt-short} (Technology Preview)
 
-You can install a nested {ocp} cluster that runs on KubeVirt virtual machines within a management cluster.
+With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters with worker nodes that are hosted by KubeVirt virtual machines.
 
 * <<create-hosted-clusters-prereqs-kubevirt,Prerequisites>>
-* <<creating-a-hosted-cluster-kubevirt,Creating a hosted cluster on KubeVirt>>
+* <<creating-a-hosted-cluster-kubevirt,Creating a hosted cluster with the KubeVirt platform>>
 * <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>
 * <<create-hosted-clusters-kubevirt-default-ingress-dns,Default Ingress and DNS behavior>>
 * <<create-hosted-clusters-kubevirt-customized-ingress-dns,Customized Ingress and DNS behavior>>
 * <<create-hosted-clusters-kubevirt-scaling-node-pool,Scaling a node pool>>
 * <<create-hosted-clusters-kubevirt-adding-node-pool,Adding node pools>>
-* <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on KubeVirt>>
-* <<hypershift-cluster-destroy-kubevirt,Destroying a hosted cluster on KubeVirt>>
+* <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on {ocp-virt-short}>>
+* <<hypershift-cluster-destroy-kubevirt,Destroying a hosted cluster on {ocp-virt-short}>>
 
 [#create-hosted-clusters-prereqs-kubevirt]
 == Prerequisites
 
-You must meet the following prerequisites to create a hosting cluster on KubeVirt:
+You must meet the following prerequisites to create an {ocp-short} cluster on {ocp-virt-short}:
 
 - Administrator access to an {ocp-short} cluster, version 4.12 or later, specified by the `KUBECONFIG` environment variable.
 - The management {ocp-short} cluster must have wildcard DNS routes enabled:
@@ -24,7 +24,7 @@ You must meet the following prerequisites to create a hosting cluster on KubeVir
 ----
 oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 ----
-- The management {ocp-short} cluster must have Red Hat OpenShift Virtualization installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
+- The management {ocp-short} cluster must have {ocp-virt-short} installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
 - The management {ocp-short} cluster must be configured with OVNKubernetes as the default pod network CNI.
 - The management {ocp-short} cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. This example shows how to set a default storage class:
 +
@@ -33,27 +33,17 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 ----
 - The {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
 - A valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
-- The HyperShift Operator and `hypershift` CLI tool must be installed. To build the latest `hypershift` CLI tool and place it in the `/usr/local/bin` directory, enter the following command:
+- The HyperShift Operator and `hypershift` CLI tool must be installed. To download and install the CLI, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[Installing the hosted control planes CLI].
 +
-----
-podman run --rm --privileged -it -v \
-$PWD:/output docker.io/library/golang:1.18 /bin/bash -c \
-'git clone https://github.com/openshift/hypershift.git && \
-cd hypershift/ && \
-make hypershift && \
-mv bin/hypershift /output/hypershift'
-
-sudo mv $PWD/hypershift /usr/local/bin
-----
-+
-After the `hypershift` CLI tool is installed, enter the following command to install the HyperShift Operator:
+After you install the CLI, install the HyperShift Operator by entering the following command:
 +
 ----
 hypershift install
 ----
+- For your cluster to be provisioned correctly, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]
-=== Creating a hosted cluster on KubeVirt
+=== Creating a hosted cluster with the KubeVirt platform
 
 . To create a guest cluster, use environment variables and the `hypershift` CLI tool:
 +
@@ -77,7 +67,7 @@ Replace values as necessary.
 +
 A default node pool is created for the cluster with two virtual machine worker replicas per the `--node-pool-replicas` flag.
 +
-A guest cluster that is backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned. 
+A guest cluster that has worker nodes that are backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned. 
 
 . To check the status of the guest cluster, see the corresponding HostedCluster resource. The following example output illustrates a fully provisioned HostedCluster object:
 +
@@ -258,9 +248,9 @@ oc get nodepools --namespace clusters
 ----
 
 [#verifying-cluster-creation-kubevirt]
-== Verifying hosted cluster creation on KubeVirt
+== Verifying hosted cluster creation on {ocp-virt-short}
 
-To verify that your hosted cluster was successfully created on KubeVirt, take the following steps.
+To verify that your hosted cluster was successfully created, take the following steps.
 
 . Verify that the `HostedCluster` resource transitioned to the `completed` state, as shown in the following example:
 +
@@ -278,32 +268,32 @@ hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 
 oc get co --kubeconfig=$CLUSTER_NAME-kubeconfig
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-console                                    4.10.26   True        False         False      2m38s
-csi-snapshot-controller                    4.10.26   True        False         False      4m3s
-dns                                        4.10.26   True        False         False      2m52s
-image-registry                             4.10.26   True        False         False      2m8s
-ingress                                    4.10.26   True        False         False      22m
-kube-apiserver                             4.10.26   True        False         False      23m
-kube-controller-manager                    4.10.26   True        False         False      23m
-kube-scheduler                             4.10.26   True        False         False      23m
-kube-storage-version-migrator              4.10.26   True        False         False      4m52s
-monitoring                                 4.10.26   True        False         False      69s
-network                                    4.10.26   True        False         False      4m3s
-node-tuning                                4.10.26   True        False         False      2m22s
-openshift-apiserver                        4.10.26   True        False         False      23m
-openshift-controller-manager               4.10.26   True        False         False      23m
-openshift-samples                          4.10.26   True        False         False      2m15s
-operator-lifecycle-manager                 4.10.26   True        False         False      22m
-operator-lifecycle-manager-catalog         4.10.26   True        False         False      23m
-operator-lifecycle-manager-packageserver   4.10.26   True        False         False      23m
-service-ca                                 4.10.26   True        False         False      4m41s
-storage                                    4.10.26   True        False         False      4m43s
+console                                    4.12.2   True        False         False      2m38s
+csi-snapshot-controller                    4.12.2   True        False         False      4m3s
+dns                                        4.12.2   True        False         False      2m52s
+image-registry                             4.12.2   True        False         False      2m8s
+ingress                                    4.12.2   True        False         False      22m
+kube-apiserver                             4.12.2   True        False         False      23m
+kube-controller-manager                    4.12.2   True        False         False      23m
+kube-scheduler                             4.12.2   True        False         False      23m
+kube-storage-version-migrator              4.12.2   True        False         False      4m52s
+monitoring                                 4.12.2   True        False         False      69s
+network                                    4.12.2   True        False         False      4m3s
+node-tuning                                4.12.2   True        False         False      2m22s
+openshift-apiserver                        4.12.2   True        False         False      23m
+openshift-controller-manager               4.12.2   True        False         False      23m
+openshift-samples                          4.12.2   True        False         False      2m15s
+operator-lifecycle-manager                 4.12.2   True        False         False      22m
+operator-lifecycle-manager-catalog         4.12.2   True        False         False      23m
+operator-lifecycle-manager-packageserver   4.12.2   True        False         False      23m
+service-ca                                 4.12.2   True        False         False      4m41s
+storage                                    4.12.2   True        False         False      4m43s
 ----
 
 [#hypershift-cluster-destroy-kubevirt]
-== Destroying a hosted cluster on KubeVirt
+== Destroying a hosted cluster on {ocp-virt-short}
 
-To destroy a hosted cluster on KubeVirt, enter the following command on a command line:
+To destroy a hosted cluster on {ocp-virt-short}, enter the following command on a command line:
 
 ----
 hypershift destroy cluster kubevirt --name $CLUSTER_NAME

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -165,6 +165,7 @@ If you do not want to use the default Ingress and DNS behavior, you can configur
 === Deploying a hosted cluster that specifies the base domain
 
 . To create a hosted cluster that specifies the base domain, enter the following commands:
+
 +
 ----
 export CLUSTER_NAME=example <1>
@@ -188,6 +189,7 @@ hypershift create cluster kubevirt \
 The result is a hosted cluster that has an Ingress wildcard that is configured for the cluster name and the base domain, or as shown in this example, `.apps.example.hypershift.lab`. The hosted cluster does not finish the deployment, but remains in `Partial` status. Because you configured a base domain, you must ensure that the required DNS records and load balancer are in place.
 
 . Enter the following command:
+
 +
 ----
 oc get --namespace clusters hostedclusters
@@ -200,14 +202,17 @@ example                   example-admin-kubeconfig         Partial    True      
 ----
 
 . Access the cluster by entering the following commands:
+
 +
 ----
 hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 ----
+
 +
 ----
 oc --kubeconfig $CLUSTER_NAME-kubeconfig get co
 ----
+
 +
 .Example output
 ----
@@ -229,6 +234,7 @@ The next steps fixes the errors in the output.
 Set up the load balancer that routes to the KubeVirt VMs and assign a wildcard DNS entry to the load balancer IP address. To do so, you need to create a load balancer service that routes Ingress traffic to the KubeVirt VMs. A `NodePort` service that exposes the hosted cluster Ingress already exists, so you can export the node ports and create the load balancer service that targets those ports.
 
 . Export the node ports by entering the following commands:
+
 +
 ----
 export HTTP_NODEPORT=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
@@ -236,6 +242,7 @@ export HTTPS_NODEPORT=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n
 ----
 
 . Create the load balancer service by entering the following commands:
+
 +
 ----
 oc apply -f -
@@ -267,6 +274,7 @@ spec:
 Set up up a wildcard DNS record or CNAME that references the external IP of the load balancer service.
 
 . Export the external IP by entering the following command:
+
 +
 ----
 export EXTERNAL_IP=$(oc -n clusters-$CLUSTER_NAME get service $CLUSTER_NAME-apps -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -10,13 +10,13 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 
 * <<create-hosted-clusters-prereqs-kubevirt,Prerequisites>>
 * <<creating-a-hosted-cluster-kubevirt,Creating a hosted cluster with the KubeVirt platform>>
-* <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>
 * <<create-hosted-clusters-kubevirt-default-ingress-dns,Default Ingress and DNS behavior>>
-* <<create-hosted-clusters-kubevirt-customized-ingress-dns,Customized Ingress and DNS behavior>>
+* <<create-hosted-clusters-kubevirt-customized-ingress-dns,Customizing Ingress and DNS behavior>>
 * <<create-hosted-clusters-kubevirt-scaling-node-pool,Scaling a node pool>>
 * <<create-hosted-clusters-kubevirt-adding-node-pool,Adding node pools>>
 * <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on {ocp-virt-short}>>
 * <<hypershift-cluster-destroy-kubevirt,Destroying a hosted cluster on {ocp-virt-short}>>
+* <<hosting-service-cluster-configure-metallb-config,Optional: Configuring MetalLB>>
 
 [#create-hosted-clusters-prereqs-kubevirt]
 == Prerequisites
@@ -38,16 +38,15 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 ----
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
 - You need to enable the hosted control planes feature. For information, see xref:../..//clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature[Enabling the hosted control planes feature].
-- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the hosted control planes (`hypershift`) CLI binary].
+- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the hosted control planes (`hypershift`) command line interface binary].
 - Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]
 === Creating a hosted cluster with the KubeVirt platform
 
-. To create a guest cluster, use environment variables and the `hypershift` CLI tool:
+. To create a guest cluster, use environment variables and the `hypershift` command line interface:
 +
 ----
-shell linenums="1"
 export CLUSTER_NAME=example
 export PULL_SECRET="$HOME/pull-secret"
 export MEM="6Gi"
@@ -56,7 +55,7 @@ export WORKER_COUNT="2"
 
 hypershift create cluster kubevirt \
 --name $CLUSTER_NAME \
---node-pool-replicas=$WORKER_COUNT \
+--node-pool-replicas $WORKER_COUNT \
 --pull-secret $PULL_SECRET \
 --memory $MEM \
 --cores $CPU
@@ -64,9 +63,31 @@ hypershift create cluster kubevirt \
 +
 Replace values as necessary.
 +
-A default node pool is created for the cluster with two virtual machine worker replicas per the `--node-pool-replicas` flag.
+*Note:* You can use the `--release-image` flag to set up the hosted cluster with a specific {ocp-short} release.
 +
-A guest cluster that has worker nodes that are backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned. 
+A default node pool is created for the cluster with two virtual machine worker replicas according to the `--node-pool-replicas` flag.
++
+After a few moments, you can verify that the hosted control plane pods are running by entering the following command:
++
+----
+oc -n clusters-$CLUSTER_NAME get pods
+----
++
+.Example output
+----
+NAME                                                  READY   STATUS    RESTARTS   AGE
+capi-provider-5cc7b74f47-n5gkr                        1/1     Running   0          3m
+catalog-operator-5f799567b7-fd6jw                     2/2     Running   0          69s
+certified-operators-catalog-784b9899f9-mrp6p          1/1     Running   0          66s
+cluster-api-6bbc867966-l4dwl                          1/1     Running   0          66s
+.
+.
+.
+redhat-operators-catalog-9d5fd4d44-z8qqk              1/1     Running   0          66s
+----
++
+A guest cluster that has worker nodes that are backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned.
+
 
 . To check the status of the guest cluster, see the corresponding `HostedCluster` resource. The following example output illustrates a fully provisioned `HostedCluster` object:
 +
@@ -74,17 +95,344 @@ A guest cluster that has worker nodes that are backed by KubeVirt virtual machin
 ----
 oc get --namespace clusters hostedclusters
 NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+clusters    example   4.12.7    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
 ----
 
-. To gain CLI access to the guest cluster, retrieve the guest cluster kubeconfig environment variable. The following example shows how to retrieve the guest cluster kubeconfig environment variable by using the `hypershift` CLI:
+[#access-hosted-cluster-kubevirt]
+=== Accessing the hosted cluster
+
+To gain command line interface access to the guest cluster, retrieve the guest cluster kubeconfig environment variable. 
+
+. To retrieve the guest cluster kubeconfig environment variable by using the `hypershift` command line interface, enter the following command:
 +
 ----
 hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 ----
 
+. Access the cluster by entering the following command:
++
+----
+oc --kubeconfig $CLUSTER_NAME-kubeconfig get nodes
+----
++
+.Example output
+----
+NAME                  STATUS   ROLES    AGE   VERSION
+example-n6prw         Ready    worker   32m   v1.25.4+18eadca
+example-nc6g4         Ready    worker   32m   v1.25.4+18eadca
+----
+
+. Check the cluster version by entering the following command:
++
+----
+oc --kubeconfig $CLUSTER_NAME-kubeconfig get clusterversion
+----
++
+.Example output
+----
+NAME      VERSION       AVAILABLE   PROGRESSING   SINCE   STATUS
+version   4.12.7        True        False         5m39s   Cluster version is 4.12.7
+----
+
+[#create-hosted-clusters-kubevirt-default-ingress-dns]
+=== Default Ingress and DNS behavior
+
+Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the HyperShift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
+
+For example, imagine that your {ocp-short} cluster has a default Ingress DNS entry of `*.apps.mgmt-cluster.example.com`. The default Ingress of a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster is `*.apps.guest.apps.mgmt-cluster.example.com`.
+
+*Note:* For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
+
+[#create-hosted-clusters-kubevirt-customized-ingress-dns]
+=== Customizing Ingress and DNS behavior
+
+If you do not want to use the default Ingress and DNS behavior, you can configure a KubeVirt guest cluster with a unique base domain at creation time. This option requires manual configuration steps during creation. It involves three main steps: cluster creation, load balancer creation, and wildcard DNS configuration.
+
+. Deploy a hosted cluster that specifies the base domain:
+
+.. To create a hosted cluster that specifies the base domain, enter the following commands:
++
+----
+export CLUSTER_NAME=example <1>
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+export BASE_DOMAIN=hypershift.lab <2>
+
+hypershift create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--base-domain $BASE_DOMAIN
+----
+<1> The name of the hosted cluster, which for example purposes, is `example`.
+<2> The base domain, which for example purposes, is `hypershift.lab`.
++
+The result is a hosted cluster that has an Ingress wildcard that is configured for the cluster name and the base domain, or as shown in this example, `.apps.example.hypershift.lab`. The hosted cluster does not finish the deployment, but remains in `Partial` status. Because you configured a base domain, you must ensure that the required DNS records and load balancer are in place.
++
+.. Enter the following command:
++
+----
+oc get --namespace clusters hostedclusters
+----
++
+.Example output
+----
+NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
+example                   example-admin-kubeconfig         Partial    True        False         The hosted control plane is available
+----
++
+.. Access the cluster by entering the following commands:
++
+----
+hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+----
++
+----
+oc --kubeconfig $CLUSTER_NAME-kubeconfig get co
+----
++
+.Example output
+----
+NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+console                                    4.12.7    False       False         False      30m     RouteHealthAvailable: failed to GET route (https://console-openshift-console.apps.example.hypershift.lab): Get "https://console-openshift-console.apps.example.hypershift.lab": dial tcp: lookup console-openshift-console.apps.example.hypershift.lab on 172.31.0.10:53: no such host
+.
+.
+.
+ingress                                    4.12.7    True        False         True       28m     The "default" ingress controller reports Degraded=True: DegradedConditions: One or more other status conditions indicate a degraded state: CanaryChecksSucceeding=False (CanaryChecksRepetitiveFailures: Canary route checks for the default ingress controller are failing)
+----
++
+The next steps fixes the errors in the output.
++
+*Note:* If your cluster is on bare metal, you might need MetalLB so that you can set up load balancer services. For more information, see _Optional: Configuring MetalLB_.
+
+. Set up the load balancer that routes to the KubeVirt VMs and assign a wildcard DNS entry to the load balancer IP address. To do so, you need to create a load balancer service that routes Ingress traffic to the KubeVirt VMs. A `NodePort` service that exposes the hosted cluster Ingress already exists, so you can export the node ports and create the load balancer service that targets those ports.
++
+.. Export the node ports by entering the following commands:
++
+----
+export HTTP_NODEPORT=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
+export HTTPS_NODEPORT=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+----
++
+.. Create the load balancer service by entering the following commands:
++
+----
+oc apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: $CLUSTER_NAME
+  name: $CLUSTER_NAME-apps
+  namespace: clusters-$CLUSTER_NAME
+spec:
+  ports:
+  - name: https-443
+    port: 443
+    protocol: TCP
+    targetPort: ${HTTPS_NODEPORT}
+  - name: http-80
+    port: 80
+    protocol: TCP
+    targetPort: ${HTTP_NODEPORT}
+  selector:
+    kubevirt.io: virt-launcher
+  type: LoadBalancer
+----
+
+. Set up a wildcard DNS record or CNAME that references the external IP of the load balancer service.
++
+.. Export the external IP by entering the following command:
++
+----
+export EXTERNAL_IP=$(oc -n clusters-$CLUSTER_NAME get service $CLUSTER_NAME-apps -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+----
++
+.. Configure a wildcard `*.apps.<hosted-cluster-name\>.<base-domain\>.` DNS entry that references the IP that is stored in the `$EXTERNAL_IP` path. The DNS entry must be able to route inside and outside of the cluster. If you use the example input from step 1, for the cluster that has an external IP value of `192.168.20.30`, the DNS resolutions look like this example:
++
+----
+dig +short test.apps.example.hypershift.lab
+
+192.168.20.30
+----
+
+. Check the hosted cluster status and ensure that it has moved from `Partial` to `Completed` by entering the following command:
++
+----
+oc get --namespace clusters hostedclusters
+----
++
+.Example output
+----
+NAME            VERSION   KUBECONFIG                       PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+example         4.12.7    example-admin-kubeconfig         Completed   True        False         The hosted control plane is available
+----
+
+[#create-hosted-clusters-kubevirt-scaling-node-pool]
+=== Scaling a node pool
+
+. You can manually scale a NodePool by using the `oc scale` command:
+
+----
+NODEPOOL_NAME=${CLUSTER_NAME}-work
+NODEPOOL_REPLICAS=5
+
+oc scale nodepool/$NODEPOOL_NAME --namespace clusters --replicas=$NODEPOOL_REPLICAS
+----
+
+. After a few moments, enter the following command to see the status of the node pool:
++
+----
+oc --kubeconfig $CLUSTER_NAME-kubeconfig get nodes
+----
++
+.Example output
+----
+NAME                  STATUS   ROLES    AGE     VERSION
+example-9jvnf         Ready    worker   97s     v1.25.4+18eadca
+example-n6prw         Ready    worker   116m    v1.25.4+18eadca
+example-nc6g4         Ready    worker   117m    v1.25.4+18eadca
+example-thp29         Ready    worker   4m17s   v1.25.4+18eadca
+example-twxns         Ready    worker   88s     v1.25.4+18eadca
+----
+
+[#create-hosted-clusters-kubevirt-adding-node-pool]
+=== Adding node pools
+
+You can create node pools for a guest cluster by specifying a name, number of replicas, and any additional information, such as memory and CPU requirements.
+
+. To create a node pool, enter the following information. In this example, the node pool has more CPUs assigned to the VMs:
++
+----
+export NODEPOOL_NAME=${CLUSTER_NAME}-extra-cpu
+export WORKER_COUNT="2"
+export MEM="6Gi"
+export CPU="4"
+export DISK="16"
+
+hypershift create nodepool kubevirt \
+  --cluster-name $CLUSTER_NAME \
+  --name $NODEPOOL_NAME \
+  --node-count $WORKER_COUNT \
+  --memory $MEM \
+  --cores $CPU
+  --root-volume-size $DISK
+----
+
+. Check the status of the node pool by listing `nodepool` resources in the `clusters` namespace:
++
+----
+oc get nodepools --namespace clusters
+----
++
+.Example output
+----
+NAME                      CLUSTER         DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
+example                   example         5               5               False         False        4.12.7                                       
+example-extra-cpu         example         2                               False         False                  True              True             Minimum availability requires 2 replicas, current 0 available
+----
+
+. After some time, you can check the status of the node pool by entering the following command:
++
+----
+oc --kubeconfig $CLUSTER_NAME-kubeconfig get nodes
+----
++
+.Example output
+----
+NAME                      STATUS   ROLES    AGE     VERSION
+example-9jvnf             Ready    worker   97s     v1.25.4+18eadca
+example-n6prw             Ready    worker   116m    v1.25.4+18eadca
+example-nc6g4             Ready    worker   117m    v1.25.4+18eadca
+example-thp29             Ready    worker   4m17s   v1.25.4+18eadca
+example-twxns             Ready    worker   88s     v1.25.4+18eadca
+example-extra-cpu-zh9l5   Ready    worker   2m6s    v1.25.4+18eadca
+example-extra-cpu-zr8mj   Ready    worker   102s    v1.25.4+18eadca
+----
+
+. Verify that the node pool is in the stat that you expect by entering this command:
++
+----
+oc get nodepools --namespace clusters
+----
++
+.Example output
+----
+NAME                      CLUSTER         DESIRED NODES   CURRENT NODES   AUTOSCALING   AUTOREPAIR   VERSION   UPDATINGVERSION   UPDATINGCONFIG   MESSAGE
+example                   example         5               5               False         False        4.12.7                                       
+example-extra-cpu         example         2               2               False         False        4.12.7  
+Delete a HostedCluster
+----
+
+[#verifying-cluster-creation-kubevirt]
+== Verifying hosted cluster creation on {ocp-virt-short}
+
+To verify that your hosted cluster was successfully created, take the following steps.
+
+. Verify that the `HostedCluster` resource transitioned to the `completed` state by entering the following command:
++
+----
+oc get --namespace clusters hostedclusters ${CLUSTER_NAME}
+----
++
+.Example output
+----
+NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+----
+
+. Verify that all the cluster operators in the guest cluster are online by entering the following commands:
++
+----
+hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+----
++
+----
+oc get co --kubeconfig=$CLUSTER_NAME-kubeconfig
+----
++
+.Example output
+----
+NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+console                                    4.12.2   True        False         False      2m38s
+csi-snapshot-controller                    4.12.2   True        False         False      4m3s
+dns                                        4.12.2   True        False         False      2m52s
+image-registry                             4.12.2   True        False         False      2m8s
+ingress                                    4.12.2   True        False         False      22m
+kube-apiserver                             4.12.2   True        False         False      23m
+kube-controller-manager                    4.12.2   True        False         False      23m
+kube-scheduler                             4.12.2   True        False         False      23m
+kube-storage-version-migrator              4.12.2   True        False         False      4m52s
+monitoring                                 4.12.2   True        False         False      69s
+network                                    4.12.2   True        False         False      4m3s
+node-tuning                                4.12.2   True        False         False      2m22s
+openshift-apiserver                        4.12.2   True        False         False      23m
+openshift-controller-manager               4.12.2   True        False         False      23m
+openshift-samples                          4.12.2   True        False         False      2m15s
+operator-lifecycle-manager                 4.12.2   True        False         False      22m
+operator-lifecycle-manager-catalog         4.12.2   True        False         False      23m
+operator-lifecycle-manager-packageserver   4.12.2   True        False         False      23m
+service-ca                                 4.12.2   True        False         False      4m41s
+storage                                    4.12.2   True        False         False      4m43s
+----
+
+[#hypershift-cluster-destroy-kubevirt]
+== Destroying a hosted cluster on {ocp-virt-short}
+
+To destroy a hosted cluster on {ocp-virt-short}, enter the following command on a command line:
+
+----
+hypershift destroy cluster kubevirt --name $CLUSTER_NAME
+----
+
+Replace names where necessary.
+
 [#hosting-service-cluster-configure-metallb-config]
-=== Configuring a load balancer
+=== Optional: Configuring MetalLB
 
 You must use a load balancer, such as MetalLB. The following example shows the steps you can take to configure MetalLB after you install it. For more information about installing MetalLB, see link:https://docs.openshift.com/container-platform/4.12/networking/metallb/metallb-operator-install.html[Installing the MetalLB Operator].
 
@@ -126,171 +474,3 @@ spec:
   ipAddressPools:
    - metallb
 ----
-
-[#create-hosted-clusters-kubevirt-default-ingress-dns]
-=== Default Ingress and DNS behavior
-
-Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the HyperShift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
-
-For example, imagine that your {ocp-short} cluster has a default Ingress DNS entry of `*.apps.mgmt-cluster.example.com`. The default Ingress of a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster is `*.apps.guest.apps.mgmt-cluster.example.com`.
-
-*Note:* For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following CLI command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
-
-[#create-hosted-clusters-kubevirt-customized-ingress-dns]
-=== Customized Ingress and DNS behavior
-
-If you do not want to use the default Ingress and DNS behavior, you can configure a KubeVirt guest cluster with a unique base domain at creation time. This option requires manual configuration steps during creation, and it involves three steps.
-
-. Create a KubeVirt cluster with a custom base domain that you control. During cluster creation, use the `--base-domain` CLI argument, as shown in the following example:
-+
-----
-export CLUSTER_NAME=example
-export PULL_SECRET="$HOME/pull-secret"
-export BASE_DOMAIN="example.com"
-
-hypershift create cluster kubevirt \
---name $CLUSTER_NAME \
---node-pool-replicas=2 \
---pull-secret $PULL_SECRET \
---base-domain $BASE_DOMAIN
-----
-
-. Create a load balancer service to route Ingress traffic to the KubeVirt virtual machines that are acting as nodes for the guest cluster.
-
-.. Inspect the guest cluster to learn what port to use as the target port when routing to the KubeVirt virtual machines. You can discover the target port by using the kubeconfig for the new KubeVirt cluster to retrieve the default router's NodePort service. The following CLI commands can automatically detect the target port of the guest cluster and store it in an environment variable:
-+
-----
-hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
-export EXTERNAL_IP=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o wide --no-headers | sed -E 's|.*443:(.....).*$|\1|' |  tr -d '[:space:])
-----
-
-.. After you discover the target port, create a load balancer service to route traffic to the guest cluster KubeVirt virtual machines:
-+
-----
-export CLUSTER_NAME=example
-export CLUSTER_NAMESPACE=clusters-${CLUSTER_NAME}
-
-cat << EOF > apps-LB-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: ${CLUSTER_NAME}
-  name: ${CLUSTER_NAME}
-  namespace: ${CLUSTER_NAMESPACE}
-spec:
-  ports:
-  - name: https-443
-    port: 443
-    protocol: TCP
-    targetPort: ${HTTPS_NODEPORT}
-  selector:
-    kubevirt.io: virt-launcher
-  type: LoadBalancer
-EOF
-
-oc create -f apps-LB-service.yaml
-----
-
-. Configure a wildcard DNS, a record, or CNAME that references external IP of the load balancer service. 
-
-.. To get the external IP of the load balancer, enter this command:
-+
-----
-export EXTERNAL_IP=$(oc get service -n $KUBEVIRT_CLUSTER_NAMESPACE $KUBEVIRT_CLUSTER_NAME  | grep $KUBEVIRT_CLUSTER_NAME| awk '{ print $4 }' | tr -d '[:space:]')
-----
-
-.. Configure a `*.apps.<cluster_name>.<base_domain>.` wildcard DNS entry that references the IP that is stored in the `$EXTERNAL_IP` environment variable that is routable both internally and externally in the cluster.
-
-[#create-hosted-clusters-kubevirt-scaling-node-pool]
-=== Scaling a node pool
-
-You can manually scale a NodePool by using the `oc scale` command:
-
-----
-NODEPOOL_NAME=${CLUSTER_NAME}-work
-NODEPOOL_REPLICAS=5
-
-oc scale nodepool/$NODEPOOL_NAME --namespace clusters --replicas=$NODEPOOL_REPLICAS
-----
-
-[#create-hosted-clusters-kubevirt-adding-node-pool]
-=== Adding node pools
-
-You can create node pools for a guest cluster by specifying a name, number of replicas, and any additional information, such as memory and CPU requirements.
-
-. To create a node pool, enter the following information:
-+
-----
-export NODEPOOL_NAME=${CLUSTER_NAME}-workers
-export WORKER_COUNT="2"
-export MEM="6Gi"
-export CPU="2"
-
-hypershift create nodepool kubevirt \
-  --cluster-name $CLUSTER_NAME \
-  --name $NODEPOOL_NAME \
-  --node-count $WORKER_COUNT \
-  --memory $MEM \
-  --cores $CPU
-----
-
-. Check the status of the node pool by listing `nodepool` resources in the `clusters` namespace:
-+
-----
-oc get nodepools --namespace clusters
-----
-
-[#verifying-cluster-creation-kubevirt]
-== Verifying hosted cluster creation on {ocp-virt-short}
-
-To verify that your hosted cluster was successfully created, take the following steps.
-
-. Verify that the `HostedCluster` resource transitioned to the `completed` state, as shown in the following example:
-+
-----
-oc get --namespace clusters hostedclusters ${CLUSTER_NAME}
-NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
-clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
-----
-
-. Verify that all the cluster operators in the guest cluster are online:
-+
-----
-# get the guest cluster's kubeconfig
-hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
-
-oc get co --kubeconfig=$CLUSTER_NAME-kubeconfig
-NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-console                                    4.12.2   True        False         False      2m38s
-csi-snapshot-controller                    4.12.2   True        False         False      4m3s
-dns                                        4.12.2   True        False         False      2m52s
-image-registry                             4.12.2   True        False         False      2m8s
-ingress                                    4.12.2   True        False         False      22m
-kube-apiserver                             4.12.2   True        False         False      23m
-kube-controller-manager                    4.12.2   True        False         False      23m
-kube-scheduler                             4.12.2   True        False         False      23m
-kube-storage-version-migrator              4.12.2   True        False         False      4m52s
-monitoring                                 4.12.2   True        False         False      69s
-network                                    4.12.2   True        False         False      4m3s
-node-tuning                                4.12.2   True        False         False      2m22s
-openshift-apiserver                        4.12.2   True        False         False      23m
-openshift-controller-manager               4.12.2   True        False         False      23m
-openshift-samples                          4.12.2   True        False         False      2m15s
-operator-lifecycle-manager                 4.12.2   True        False         False      22m
-operator-lifecycle-manager-catalog         4.12.2   True        False         False      23m
-operator-lifecycle-manager-packageserver   4.12.2   True        False         False      23m
-service-ca                                 4.12.2   True        False         False      4m41s
-storage                                    4.12.2   True        False         False      4m43s
-----
-
-[#hypershift-cluster-destroy-kubevirt]
-== Destroying a hosted cluster on {ocp-virt-short}
-
-To destroy a hosted cluster on {ocp-virt-short}, enter the following command on a command line:
-
-----
-hypershift destroy cluster kubevirt --name $CLUSTER_NAME
-----
-
-Replace names where necessary.

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -10,7 +10,7 @@ You can install a nested {ocp} cluster that runs on KubeVirt virtual machines wi
 * <<create-hosted-clusters-kubevirt-customized-ingress-dns,Customized Ingress and DNS behavior>>
 * <<create-hosted-clusters-kubevirt-scaling-node-pool,Scaling a node pool>>
 * <<create-hosted-clusters-kubevirt-adding-node-pool,Adding node pools>>
-//* <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on KubeVirt>>
+* <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on KubeVirt>>
 * <<hypershift-cluster-destroy-kubevirt,Destroying a hosted cluster on KubeVirt>>
 
 [#create-hosted-clusters-prereqs-kubevirt]
@@ -257,10 +257,48 @@ hypershift create nodepool kubevirt \
 oc get nodepools --namespace clusters
 ----
 
-//[#verifying-cluster-creation-kubevirt]
-//== Verifying hosted cluster creation on KubeVirt
+[#verifying-cluster-creation-kubevirt]
+== Verifying hosted cluster creation on KubeVirt
 
-//How do we verify cluster creation on KubeVirt?
+To verify that your hosted cluster was successfully created on KubeVirt, take the following steps.
+
+. Verify that the `HostedCluster` resource transitioned to the `completed` state, as shown in the following example:
++
+----
+oc get --namespace clusters hostedclusters ${CLUSTER_NAME}
+NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+----
+
+. Verify that all the cluster operators in the guest cluster are online:
++
+----
+# get the guest cluster's kubeconfig
+hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
+
+oc get co --kubeconfig=$CLUSTER_NAME-kubeconfig
+NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+console                                    4.10.26   True        False         False      2m38s
+csi-snapshot-controller                    4.10.26   True        False         False      4m3s
+dns                                        4.10.26   True        False         False      2m52s
+image-registry                             4.10.26   True        False         False      2m8s
+ingress                                    4.10.26   True        False         False      22m
+kube-apiserver                             4.10.26   True        False         False      23m
+kube-controller-manager                    4.10.26   True        False         False      23m
+kube-scheduler                             4.10.26   True        False         False      23m
+kube-storage-version-migrator              4.10.26   True        False         False      4m52s
+monitoring                                 4.10.26   True        False         False      69s
+network                                    4.10.26   True        False         False      4m3s
+node-tuning                                4.10.26   True        False         False      2m22s
+openshift-apiserver                        4.10.26   True        False         False      23m
+openshift-controller-manager               4.10.26   True        False         False      23m
+openshift-samples                          4.10.26   True        False         False      2m15s
+operator-lifecycle-manager                 4.10.26   True        False         False      22m
+operator-lifecycle-manager-catalog         4.10.26   True        False         False      23m
+operator-lifecycle-manager-packageserver   4.10.26   True        False         False      23m
+service-ca                                 4.10.26   True        False         False      4m41s
+storage                                    4.10.26   True        False         False      4m43s
+----
 
 [#hypershift-cluster-destroy-kubevirt]
 == Destroying a hosted cluster on KubeVirt

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -93,12 +93,14 @@ A guest cluster that has worker nodes that are backed by KubeVirt virtual machin
 
 
 . To check the status of the guest cluster, see the corresponding `HostedCluster` resource:
+
 +
 ----
 oc get --namespace clusters hostedclusters
 ----
 + 
 The following example output illustrates a fully provisioned `HostedCluster` object:
+
 +
 .Example output
 ----
@@ -112,12 +114,14 @@ clusters    example   4.12.7    example-admin-kubeconfig   Completed   True     
 To gain command line interface access to the guest cluster, retrieve the guest cluster kubeconfig environment variable. 
 
 . To retrieve the guest cluster kubeconfig environment variable by using the `hypershift` command line interface, enter the following command:
+
 +
 ----
 hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 ----
 
 . Access the cluster by entering the following command:
+
 +
 ----
 oc --kubeconfig $CLUSTER_NAME-kubeconfig get nodes
@@ -131,6 +135,7 @@ example-nc6g4         Ready    worker   32m   v1.25.4+18eadca
 ----
 
 . Check the cluster version by entering the following command:
+
 +
 ----
 oc --kubeconfig $CLUSTER_NAME-kubeconfig get clusterversion

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -72,7 +72,6 @@ A guest cluster that has worker nodes that are backed by KubeVirt virtual machin
 +
 .Example output
 ----
-shell linenums="1"
 oc get --namespace clusters hostedclusters
 NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
 clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
@@ -81,7 +80,6 @@ clusters    example   4.12.2    example-admin-kubeconfig   Completed   True     
 . To gain CLI access to the guest cluster, retrieve the guest cluster kubeconfig environment variable. The following example shows how to retrieve the guest cluster kubeconfig environment variable by using the `hypershift` CLI:
 +
 ----
-shell
 hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 ----
 
@@ -93,19 +91,18 @@ You must use a load balancer, such as MetalLB. The following example shows the s
 . Create a MetalLB instance:
 +
 ----
-oc create -f - <<EOF
+oc create -f - 
 apiVersion: metallb.io/v1beta1
 kind: MetalLB
 metadata:
   name: metallb
   namespace: metallb-system
-EOF
 ----
 
 . Create an address pool with an available range of IP addresses within the node network. Replace the following IP address ranges with an unused pool of available IP addresses in your network.
 +
 ----
-oc create -f - <<EOF
+oc create -f - 
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool
 metadata:
@@ -114,13 +111,12 @@ metadata:
 spec:
   addresses:
   - 192.168.216.32-192.168.216.122
-EOF
 ----
 
 . Advertise the address pool by using L2 protocol:
 +
 ----
-oc create -f - <<EOF
+oc create -f - 
 apiVersion: metallb.io/v1beta1
 kind: L2Advertisement
 metadata:
@@ -129,13 +125,12 @@ metadata:
 spec:
   ipAddressPools:
    - metallb
-EOF
 ----
 
 [#create-hosted-clusters-kubevirt-default-ingress-dns]
 === Default Ingress and DNS behavior
 
-Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the Hypershift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
+Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the HyperShift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
 
 For example, imagine that your {ocp-short} cluster has a default Ingress DNS entry of `*.apps.mgmt-cluster.example.com`. The default Ingress of a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster is `*.apps.guest.apps.mgmt-cluster.example.com`.
 
@@ -205,7 +200,7 @@ oc create -f apps-LB-service.yaml
 export EXTERNAL_IP=$(oc get service -n $KUBEVIRT_CLUSTER_NAMESPACE $KUBEVIRT_CLUSTER_NAME  | grep $KUBEVIRT_CLUSTER_NAME| awk '{ print $4 }' | tr -d '[:space:]')
 ----
 
-.. Configure a `*.apps.<cluster_name>.<base_domain>.` wildcard DNS entry that references the IP that is stored in the $EXTERNAL_IP environment variable that is routable both internally and externally in the cluster.
+.. Configure a `*.apps.<cluster_name>.<base_domain>.` wildcard DNS entry that references the IP that is stored in the `$EXTERNAL_IP` environment variable that is routable both internally and externally in the cluster.
 
 [#create-hosted-clusters-kubevirt-scaling-node-pool]
 === Scaling a node pool

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -39,7 +39,7 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 - You need the {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
 - You need to enable the hosted control planes feature. For information, see xref:../..//clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature[Enabling the hosted control planes feature].
-- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the CLI binary].
+- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the hosted control planes CLI binary].
 - Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -1,5 +1,5 @@
 [#hosted-control-planes-manage-kubevirt]
-= Creating hosted control plane clusters on {ocp-virt-short} (Technology Preview)
+= Managing hosted control plane clusters on {ocp-virt-short} (Technology Preview)
 
 With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters with worker nodes that are hosted by KubeVirt virtual machines. Hosted control planes on {ocp-virt-short} provides several benefits: 
 

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -38,7 +38,8 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 ----
 - You need the {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
-- You need to enable the hosted control planes feature. For information, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc##hosted-enable-feature-aws[Enabling the hosted control planes feature].
+- You need to enable the hosted control planes feature. For information, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#hosted-enable-feature-aws[Enabling the hosted control planes feature].
+- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the CLI binary].
 - Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -24,19 +24,18 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 You must meet the following prerequisites to create an {ocp-short} cluster on {ocp-virt-short}:
 
 - You need administrator access to an {ocp-short} cluster, version 4.12 or later, specified by the `KUBECONFIG` environment variable.
-- The management {ocp-short} cluster must have wildcard DNS routes enabled:
+- The management {ocp-short} cluster must have wildcard DNS routes enabled, as shown in the following DNS:
 +
 ----
 oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 ----
 - The management {ocp-short} cluster must have {ocp-virt-short} installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
 - The management {ocp-short} cluster must be configured with OVNKubernetes as the default pod network CNI.
-- The management {ocp-short} cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. This example shows how to set a default storage class:
+- The management {ocp-short} cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. The following example shows how to set a default storage class:
 +
 ----
 oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ----
-- You need the {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
 - You need to enable the hosted control planes feature. For information, see xref:../..//clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature[Enabling the hosted control planes feature].
 - After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the hosted control planes (`hypershift`) CLI binary].
@@ -69,7 +68,7 @@ A default node pool is created for the cluster with two virtual machine worker r
 +
 A guest cluster that has worker nodes that are backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned. 
 
-. To check the status of the guest cluster, see the corresponding HostedCluster resource. The following example output illustrates a fully provisioned HostedCluster object:
+. To check the status of the guest cluster, see the corresponding `HostedCluster` resource. The following example output illustrates a fully provisioned `HostedCluster` object:
 +
 .Example output
 ----
@@ -79,7 +78,7 @@ NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE
 clusters    example   4.12.2    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
 ----
 
-. To gain CLI access to the guest cluster, retrieve the guest cluster's kubeconfig environment variable. The following example shows how to retrieve the guest cluster's kubeconfig environment variable by using the `hypershift` CLI:
+. To gain CLI access to the guest cluster, retrieve the guest cluster kubeconfig environment variable. The following example shows how to retrieve the guest cluster kubeconfig environment variable by using the `hypershift` CLI:
 +
 ----
 shell
@@ -140,7 +139,7 @@ Every {ocp-short} cluster includes a default application Ingress controller, whi
 
 For example, imagine that your {ocp-short} cluster has a default Ingress DNS entry of `*.apps.mgmt-cluster.example.com`. The default Ingress of a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster is `*.apps.guest.apps.mgmt-cluster.example.com`.
 
-**Note:** For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following CLI command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
+*Note:* For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following CLI command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
 
 [#create-hosted-clusters-kubevirt-customized-ingress-dns]
 === Customized Ingress and DNS behavior
@@ -162,15 +161,15 @@ hypershift create cluster kubevirt \
 ----
 
 . Create a load balancer service to route Ingress traffic to the KubeVirt virtual machines that are acting as nodes for the guest cluster.
-+
+
 .. Inspect the guest cluster to learn what port to use as the target port when routing to the KubeVirt virtual machines. You can discover the target port by using the kubeconfig for the new KubeVirt cluster to retrieve the default router's NodePort service. The following CLI commands can automatically detect the target port of the guest cluster and store it in an environment variable:
 +
 ----
 hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
 export EXTERNAL_IP=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o wide --no-headers | sed -E 's|.*443:(.....).*$|\1|' |  tr -d '[:space:])
 ----
-+
-.. After you discover the target port, create a load balancer service to route traffic to the guest cluster's KubeVirt virtual machines:
+
+.. After you discover the target port, create a load balancer service to route traffic to the guest cluster KubeVirt virtual machines:
 +
 ----
 export CLUSTER_NAME=example

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -39,7 +39,7 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 - You need the {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
 - You need to enable the hosted control planes feature. For information, see xref:../..//clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature[Enabling the hosted control planes feature].
-- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the hosted control planes CLI binary].
+- After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the hosted control planes (`hypershift`) CLI binary].
 - Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -3,10 +3,12 @@
 
 With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters with worker nodes that are hosted by KubeVirt virtual machines. Hosted control planes on {ocp-virt-short} provides several benefits: 
 
-* Enhance resource usage by packing hosted control planes and hosted clusters in the same underlying bare metal infrastructure
-* Separate hosted control planes and guest clusters to provide strong isolation
-* Reduce cluster provision time by eliminating the bare metal node bootstrapping process
-* Manage many releases under the same base {ocp-short} cluster
+* Enhances resource usage by packing hosted control planes and hosted clusters in the same underlying bare metal infrastructure
+* Separates hosted control planes and guest clusters to provide strong isolation
+* Reduces cluster provision time by eliminating the bare metal node bootstrapping process
+* Manages many releases under the same base {ocp-short} cluster
+
+To learn how to create a hosted control plane cluster on {ocp-virt-short}, see the following sections:
 
 * <<create-hosted-clusters-prereqs-kubevirt,Prerequisites>>
 * <<creating-a-hosted-cluster-kubevirt,Creating a hosted cluster with the KubeVirt platform>>
@@ -17,6 +19,7 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 * <<verifying-cluster-creation-kubevirt,Verifying hosted cluster creation on {ocp-virt-short}>>
 * <<hypershift-cluster-destroy-kubevirt,Destroying a hosted cluster on {ocp-virt-short}>>
 * <<hosting-service-cluster-configure-metallb-config,Optional: Configuring MetalLB>>
+* <<managing-hosted-kubevirt-additional-resources,Additional resources>>
 
 [#create-hosted-clusters-prereqs-kubevirt]
 == Prerequisites
@@ -42,7 +45,7 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 - Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 
 [#creating-a-hosted-cluster-kubevirt]
-=== Creating a hosted cluster with the KubeVirt platform
+== Creating a hosted cluster with the KubeVirt platform
 
 . To create a guest cluster, use environment variables and the `hypershift` command line interface:
 +
@@ -89,17 +92,22 @@ redhat-operators-catalog-9d5fd4d44-z8qqk              1/1     Running   0       
 A guest cluster that has worker nodes that are backed by KubeVirt virtual machines typically takes 10-15 minutes to be fully provisioned.
 
 
-. To check the status of the guest cluster, see the corresponding `HostedCluster` resource. The following example output illustrates a fully provisioned `HostedCluster` object:
+. To check the status of the guest cluster, see the corresponding `HostedCluster` resource:
++
+----
+oc get --namespace clusters hostedclusters
+----
++ 
+The following example output illustrates a fully provisioned `HostedCluster` object:
 +
 .Example output
 ----
-oc get --namespace clusters hostedclusters
 NAMESPACE   NAME      VERSION   KUBECONFIG                 PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
 clusters    example   4.12.7    example-admin-kubeconfig   Completed   True        False         The hosted control plane is available
 ----
 
 [#access-hosted-cluster-kubevirt]
-=== Accessing the hosted cluster
+== Accessing the hosted cluster
 
 To gain command line interface access to the guest cluster, retrieve the guest cluster kubeconfig environment variable. 
 
@@ -135,7 +143,7 @@ version   4.12.7        True        False         5m39s   Cluster version is 4.1
 ----
 
 [#create-hosted-clusters-kubevirt-default-ingress-dns]
-=== Default Ingress and DNS behavior
+== Default Ingress and DNS behavior
 
 Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the HyperShift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
 
@@ -144,13 +152,14 @@ For example, imagine that your {ocp-short} cluster has a default Ingress DNS ent
 *Note:* For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
 
 [#create-hosted-clusters-kubevirt-customized-ingress-dns]
-=== Customizing Ingress and DNS behavior
+== Customizing Ingress and DNS behavior
 
 If you do not want to use the default Ingress and DNS behavior, you can configure a KubeVirt guest cluster with a unique base domain at creation time. This option requires manual configuration steps during creation. It involves three main steps: cluster creation, load balancer creation, and wildcard DNS configuration.
 
-. Deploy a hosted cluster that specifies the base domain:
+[#deploy-hosted-cluster-base-domain]
+=== Deploying a hosted cluster that specifies the base domain
 
-.. To create a hosted cluster that specifies the base domain, enter the following commands:
+. To create a hosted cluster that specifies the base domain, enter the following commands:
 +
 ----
 export CLUSTER_NAME=example <1>
@@ -172,8 +181,8 @@ hypershift create cluster kubevirt \
 <2> The base domain, which for example purposes, is `hypershift.lab`.
 +
 The result is a hosted cluster that has an Ingress wildcard that is configured for the cluster name and the base domain, or as shown in this example, `.apps.example.hypershift.lab`. The hosted cluster does not finish the deployment, but remains in `Partial` status. Because you configured a base domain, you must ensure that the required DNS records and load balancer are in place.
-+
-.. Enter the following command:
+
+. Enter the following command:
 +
 ----
 oc get --namespace clusters hostedclusters
@@ -184,8 +193,8 @@ oc get --namespace clusters hostedclusters
 NAME            VERSION   KUBECONFIG                       PROGRESS   AVAILABLE   PROGRESSING   MESSAGE
 example                   example-admin-kubeconfig         Partial    True        False         The hosted control plane is available
 ----
-+
-.. Access the cluster by entering the following commands:
+
+. Access the cluster by entering the following commands:
 +
 ----
 hypershift create kubeconfig --name $CLUSTER_NAME > $CLUSTER_NAME-kubeconfig
@@ -209,16 +218,19 @@ The next steps fixes the errors in the output.
 +
 *Note:* If your cluster is on bare metal, you might need MetalLB so that you can set up load balancer services. For more information, see _Optional: Configuring MetalLB_.
 
-. Set up the load balancer that routes to the KubeVirt VMs and assign a wildcard DNS entry to the load balancer IP address. To do so, you need to create a load balancer service that routes Ingress traffic to the KubeVirt VMs. A `NodePort` service that exposes the hosted cluster Ingress already exists, so you can export the node ports and create the load balancer service that targets those ports.
-+
-.. Export the node ports by entering the following commands:
+[#set-up-load-balancer]
+=== Setting up the load balancer 
+
+Set up the load balancer that routes to the KubeVirt VMs and assign a wildcard DNS entry to the load balancer IP address. To do so, you need to create a load balancer service that routes Ingress traffic to the KubeVirt VMs. A `NodePort` service that exposes the hosted cluster Ingress already exists, so you can export the node ports and create the load balancer service that targets those ports.
+
+. Export the node ports by entering the following commands:
 +
 ----
 export HTTP_NODEPORT=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="http")].nodePort}')
 export HTTPS_NODEPORT=$(oc --kubeconfig $CLUSTER_NAME-kubeconfig get services -n openshift-ingress router-nodeport-default -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
 ----
-+
-.. Create the load balancer service by entering the following commands:
+
+. Create the load balancer service by entering the following commands:
 +
 ----
 oc apply -f -
@@ -244,15 +256,18 @@ spec:
   type: LoadBalancer
 ----
 
-. Set up a wildcard DNS record or CNAME that references the external IP of the load balancer service.
-+
-.. Export the external IP by entering the following command:
+[#set-up-wildcard-dns]
+=== Setting up a wildcard DNS 
+
+Set up up a wildcard DNS record or CNAME that references the external IP of the load balancer service.
+
+. Export the external IP by entering the following command:
 +
 ----
 export EXTERNAL_IP=$(oc -n clusters-$CLUSTER_NAME get service $CLUSTER_NAME-apps -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ----
-+
-.. Configure a wildcard `*.apps.<hosted-cluster-name\>.<base-domain\>.` DNS entry that references the IP that is stored in the `$EXTERNAL_IP` path. The DNS entry must be able to route inside and outside of the cluster. If you use the example input from step 1, for the cluster that has an external IP value of `192.168.20.30`, the DNS resolutions look like this example:
+
+. Configure a wildcard `*.apps.<hosted-cluster-name\>.<base-domain\>.` DNS entry that references the IP that is stored in the `$EXTERNAL_IP` path. The DNS entry must be able to route inside and outside of the cluster. If you use the example input from step 1, for the cluster that has an external IP value of `192.168.20.30`, the DNS resolutions look like this example:
 +
 ----
 dig +short test.apps.example.hypershift.lab
@@ -273,10 +288,10 @@ example         4.12.7    example-admin-kubeconfig         Completed   True     
 ----
 
 [#create-hosted-clusters-kubevirt-scaling-node-pool]
-=== Scaling a node pool
+== Scaling a node pool
 
 . You can manually scale a NodePool by using the `oc scale` command:
-
++
 ----
 NODEPOOL_NAME=${CLUSTER_NAME}-work
 NODEPOOL_REPLICAS=5
@@ -301,7 +316,7 @@ example-twxns         Ready    worker   88s     v1.25.4+18eadca
 ----
 
 [#create-hosted-clusters-kubevirt-adding-node-pool]
-=== Adding node pools
+== Adding node pools
 
 You can create node pools for a guest cluster by specifying a name, number of replicas, and any additional information, such as memory and CPU requirements.
 
@@ -354,7 +369,7 @@ example-extra-cpu-zh9l5   Ready    worker   2m6s    v1.25.4+18eadca
 example-extra-cpu-zr8mj   Ready    worker   102s    v1.25.4+18eadca
 ----
 
-. Verify that the node pool is in the stat that you expect by entering this command:
+. Verify that the node pool is in the status that you expect by entering this command:
 +
 ----
 oc get nodepools --namespace clusters
@@ -423,7 +438,7 @@ storage                                    4.12.2   True        False         Fa
 [#hypershift-cluster-destroy-kubevirt]
 == Destroying a hosted cluster on {ocp-virt-short}
 
-To destroy a hosted cluster on {ocp-virt-short}, enter the following command on a command line:
+To delete a hosted cluster on {ocp-virt-short}, enter the following command on a command line:
 
 ----
 hypershift destroy cluster kubevirt --name $CLUSTER_NAME
@@ -434,7 +449,7 @@ Replace names where necessary.
 [#hosting-service-cluster-configure-metallb-config]
 === Optional: Configuring MetalLB
 
-You must use a load balancer, such as MetalLB. The following example shows the steps you can take to configure MetalLB after you install it. For more information about installing MetalLB, see link:https://docs.openshift.com/container-platform/4.12/networking/metallb/metallb-operator-install.html[Installing the MetalLB Operator].
+You must use a load balancer, such as MetalLB. The following example shows the steps you can take to configure MetalLB after you install it. For more information about installing MetalLB, see _Installing the MetalLB Operator_ in the {ocp-short} documentation.
 
 . Create a MetalLB instance:
 +
@@ -474,3 +489,8 @@ spec:
   ipAddressPools:
    - metallb
 ----
+
+[#managing-hosted-kubevirt-additional-resources]
+== Additional resources
+
+* For more information about MetalLB, see link:https://docs.openshift.com/container-platform/4.12/networking/metallb/metallb-operator-install.html[Installing the MetalLB Operator].

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -1,7 +1,12 @@
 [#hosted-control-planes-manage-kubevirt]
 = Creating hosted control plane clusters on {ocp-virt-short} (Technology Preview)
 
-With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters with worker nodes that are hosted by KubeVirt virtual machines.
+With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters with worker nodes that are hosted by KubeVirt virtual machines. Hosted control planes on {ocp-virt-short} provides several benefits: 
+
+* Enhance resource usage by packing hosted control planes and hosted clusters in the same underlying bare metal infrastructure
+* Separate hosted control planes and guest clusters to provide strong isolation
+* Reduce cluster provision time by eliminating the bare metal node bootstrapping process
+* Manage many releases under the same base {ocp-short} cluster
 
 * <<create-hosted-clusters-prereqs-kubevirt,Prerequisites>>
 * <<creating-a-hosted-cluster-kubevirt,Creating a hosted cluster with the KubeVirt platform>>

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -24,14 +24,14 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 You must meet the following prerequisites to create an {ocp-short} cluster on {ocp-virt-short}:
 
 - You need administrator access to an {ocp-short} cluster, version 4.12 or later, specified by the `KUBECONFIG` environment variable.
-- The management {ocp-short} cluster must have wildcard DNS routes enabled, as shown in the following DNS:
+- The {ocp-short} managed cluster must have wildcard DNS routes enabled, as shown in the following DNS:
 +
 ----
 oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 ----
-- The management {ocp-short} cluster must have {ocp-virt-short} installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
-- The management {ocp-short} cluster must be configured with OVNKubernetes as the default pod network CNI.
-- The management {ocp-short} cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. The following example shows how to set a default storage class:
+- The {ocp-short} managed cluster must have {ocp-virt-short} installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.12/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
+- The {ocp-short} managed cluster must be configured with OVNKubernetes as the default pod network CNI.
+- The {ocp-short} managed cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.12/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. The following example shows how to set a default storage class:
 +
 ----
 oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -38,7 +38,7 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 ----
 - You need the {ocp-short} CLI (`oc`) or the Kubernetes CLI (`kubectl`).
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
-- You need to enable the hosted control planes feature. For information, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#hosted-enable-feature-aws[Enabling the hosted control planes feature].
+- You need to enable the hosted control planes feature. For information, see xref:../..//clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature[Enabling the hosted control planes feature].
 - After you enable the hosted control planes feature, you need to xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#installing-the-hosted-control-planes-cli[install the CLI binary].
 - Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
 

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -8,6 +8,8 @@
 :mce-short: multicluster engine operator
 :ocp: Red Hat OpenShift Container Platform
 :ocp-short: OpenShift Container Platform
+:ocp-virt: Red Hat OpenShift Virtualization
+:ocp-virt-short: OpenShift Virtualization
 :olm: Operator Lifecycle Manager
 :ocm: OpenShift Cluster Manager
 :product-title: Red Hat Advanced Cluster Management for Kubernetes


### PR DESCRIPTION
This PR adds documentation to the hosted control planes section about using KubeVirt as a provider. This will be Technology Preview for MCE 2.3.

Related Jira task: https://issues.redhat.com/browse/ACM-3650