### PR TITLE
[ACM-4111]: Updates to 'Configuring the hosting cluster on bare metal'

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_bm.adoc
@@ -19,9 +19,9 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 
 - Each bare metal host must be started with a Discovery Image that the CIM provides. You can start the hosts manually or through automation by using the `Cluster-Baremetal-Operator`. After each host starts, it runs an Agent process to discover the host details and complete the installation. An `Agent` custom resource represents each host.
 
-- When you create a hosted cluster with the Agent platform, HyperShift installs the Agent CAPI provider in the hosted control plane namespace.
+- When you create a hosted cluster with the Agent platform, HyperShift installs the Agent Cluster API provider in the hosted control plane namespace.
 
-- When you scale up a node pool, a machine is created. The CAPI provider finds an Agent that is approved, is passing validations, is not currently in use, and meets the requirements that are specified in the node pool specification. You can monitor the installation of an Agent by checking its status and conditions.
+- When you scale up a node pool, a machine is created. The Cluster API provider finds an Agent that is approved, is passing validations, is not currently in use, and meets the requirements that are specified in the node pool specification. You can monitor the installation of an Agent by checking its status and conditions.
 
 - When you scale down a node pool, Agents are unbound from the corresponding cluster. Before you can reuse the clusters, you must restart them by using the Discovery image to update the number of nodes.
 

--- a/clusters/hosted_control_planes/configure_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_bm.adoc
@@ -41,7 +41,7 @@ oc get managedclusters local-cluster
 
 * You need a hosting cluster with at least 3 worker nodes to run the HyperShift Operator.
 
-* You must enable the hosted control planes feature. For more information, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#hosted-enable-feature-aws[Enabling the hosted control planes feature].
+* You must enable the hosted control planes feature. For more information, see xref:../..//clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature[Enabling the hosted control planes feature].
 
 [#configure-dns-bm]
 == Configuring DNS

--- a/clusters/hosted_control_planes/configure_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_bm.adoc
@@ -19,18 +19,18 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 
 - Each bare metal host must be started with a Discovery Image that the CIM provides. You can start the hosts manually or through automation by using the `Cluster-Baremetal-Operator`. After each host starts, it runs an Agent process to discover the host details and complete the installation. An `Agent` custom resource represents each host.
 
-- When you create a hosted cluster with the Agent platform, HyperShift installs the Agent CAPI provider in the Hosted Control Plane (HCP) namespace.
+- When you create a hosted cluster with the Agent platform, HyperShift installs the Agent CAPI provider in the hosted control plane namespace.
 
 - When you scale up a node pool, a machine is created. The CAPI provider finds an Agent that is approved, is passing validations, is not currently in use, and meets the requirements that are specified in the node pool specification. You can monitor the installation of an Agent by checking its status and conditions.
 
-- When you scale down a node pool, Agents are unbound from the corresponding cluster. Before you can reuse the clusters, you must restart them using the Discovery image to update the number of nodes.
+- When you scale down a node pool, Agents are unbound from the corresponding cluster. Before you can reuse the clusters, you must restart them by using the Discovery image to update the number of nodes.
 
 [#hosting-service-cluster-configure-prereq]
 == Prerequisites
 
 You must have the following prerequisites to configure a hosting cluster: 
 
-* You need the {mce} 2.2 and later installed on an {ocp-short} cluster. The {mce-short} is automatically installed when you install {product-title-short}. The {mce-short} can also be installed without {product-title-short} as an Operator from the {ocp-short} OperatorHub.
+* You need the {mce} 2.2 and later installed on an {ocp-short} cluster. The {mce-short} is automatically installed when you install {product-title-short}. You can also install {mce-short} without {product-title-short} as an Operator from the {ocp-short} OperatorHub.
 
 * You need the {mce-short} must have at least one managed {ocp-short} cluster. The `local-cluster` is automatically imported in {mce-short} 2.2 and later. See xref:../install_upgrade/adv_config_install.adoc#advanced-config-engine[Advanced configuration] for more information about the `local-cluster`. You can check the status of your hub cluster by running the following command:
 
@@ -40,6 +40,8 @@ oc get managedclusters local-cluster
 ----
 
 * You need a hosting cluster with at least 3 worker nodes to run the HyperShift Operator.
+
+* You must enable the hosted control planes feature. For more information, see xref:../../clusters/hosted_control_planes/configure_hosted_aws.adoc#hosted-enable-feature-aws[Enabling the hosted control planes feature].
 
 [#configure-dns-bm]
 == Configuring DNS


### PR DESCRIPTION
Related Jira task: https://issues.redhat.com/browse/ACM-4111

Per reviewer feedback on the "Configuring the hosting cluster on bare metal" topic, add prerequisite step to enable the hosted control planes feature.