### PR TITLE
Updating misspelled word in obs API 2.7

### DIFF
--- a/observability/customize_observability.adoc
+++ b/observability/customize_observability.adoc
@@ -297,7 +297,7 @@ _optional_|Advanced configuration for the HTTP client.|<<jsonmulticlusterobserva
 |**basic_auth** +
 _optional_|HTTP client configuration for basic authentication.|<<jsonmulticlusterobservability_basicauth,BasicAuth>>
 |**tls_config** +
-_optioal_|HTTP client configuration for TLS.|<<jsonmulticlusterobservability_tls,TLSConfig>>
+_optional_|HTTP client configuration for TLS.|<<jsonmulticlusterobservability_tls,TLSConfig>>
 |===
 
 [[jsonmulticlusterobservability_basicauth]]
@@ -316,7 +316,7 @@ _optional_|Password for basic authorization.|string
 |===
 |Name|Description|Schema
 |**secret_name** +
-_optioal_|Name of the secret that contains certificates.|string
+_optional_|Name of the secret that contains certificates.|string
 |**ca_file_key** +
 _optional_|Key of the CA certificate in the secret.|string
 |**cert_file_key** +


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-4482

Misnamed the branch 