### PR TITLE
Making 'Configuring on AWS' book parallel with 'Configuring on bare metal' book

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -12,7 +12,7 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 *Best practice:* Be sure to run the hub cluster and workers on the same platform for hosted control planes.
 
 [#hosting-service-cluster-configure-prereq-aws]
-=== Prerequisites
+== Prerequisites
 
 You must have the following prerequisites to configure a hosting cluster: 
 
@@ -28,7 +28,7 @@ oc get managedclusters local-cluster
 * A hosting cluster with at least 3 worker nodes to run the HyperShift Operator.
 
 [#hosted-create-aws-secret]
-=== Creating the Amazon Web Services S3 OIDC secret
+== Creating the Amazon Web Services S3 OIDC secret
 
 If you plan to create and manage hosted clusters on AWS, complete the following steps:
 
@@ -64,7 +64,7 @@ oc label secret hypershift-operator-oidc-provider-s3-credentials -n local-cluste
 ----
 
 [#hosted-create-public-zone-aws]
-=== Creating a routable public zone
+== Creating a routable public zone
 
 To access applications in your guest clusters, the public zone must be routable. If the public zone exists, skip this step. Otherwise, the public zone will affect the existing functions.
 
@@ -76,7 +76,7 @@ aws route53 create-hosted-zone --name $BASE_DOMAIN --caller-reference $(whoami)-
 ----
 
 [#hosted-enable-ext-dns-aws]
-=== Enabling external DNS
+== Enabling external DNS
 
 If you plan to provision hosted control plane clusters with service-level DNS (external DNS), complete the following steps:
 
@@ -121,7 +121,7 @@ oc label secret hypershift-operator-external-dns-credentials -n local-cluster cl
 ----
 
 [#hosted-enable-private-link]
-=== Enabling AWS PrivateLink
+== Enabling AWS PrivateLink
 
 If you plan to provision hosted control plane clusters on the AWS platform with PrivateLink, complete the following steps:
 
@@ -158,7 +158,7 @@ oc label secret hypershift-operator-private-link-credentials -n local-cluster cl
 ----
 
 [#hosted-enable-feature-aws]
-=== Enabling the hosted control planes feature
+== Enabling the hosted control planes feature
 
 The hosted control planes feature is disabled by default. Enabling the feature automatically also enables the `hypershift-addon` managed cluster add-on. You can run the following command to enable the feature:
 
@@ -188,7 +188,7 @@ spec:
 ----
 
 [#hosted-enable-hypershift-add-on-aws]
-==== Manually enabling the hypershift-addon managed cluster add-on for local-cluster
+=== Manually enabling the hypershift-addon managed cluster add-on for local-cluster
 
 Enabling the hosted control planes feature automatically enables the `hypershift-addon` managed cluster add-on. If you need to enable the `hypershift-addon` managed cluster add-on manually, complete the following steps to use the `hypershift-addon` to install the HyperShift Operator on `local-cluster`:
 
@@ -229,7 +229,7 @@ hypershift-addon   True
 Your HyperShift add-on is installed and the hosting cluster is available to create and manage HyperShift clusters.
 
 [#hosted-install-cli]
-=== Installing the hosted control planes CLI
+== Installing the hosted control planes CLI
 
 The hosted control planes (HyperShift) CLI is used to create and manage {ocp-short} hosted control plane clusters. After enabling the hosted control planes feature, you can install the hosted control planes CLI by completing the following steps:
 

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -19,6 +19,7 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 * <<hosted-enable-feature-aws,Enabling the hosted control planes feature>>
 * <<hosted-enable-hypershift-add-on-aws,Manually enabling the hypershift-addon managed cluster add-on for local-cluster>>
 * <<hosted-install-cli,Installing the hosted control planes CLI>>
+* <<additional-resources-configure-hosted-cluster-aws,Additional resources>>
 
 [#hosting-service-cluster-configure-prereq-aws]
 == Prerequisites

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -61,7 +61,7 @@ If you plan to create and manage hosted clusters on AWS, complete the following 
 | Specifies the region of the S3 bucket.
 |===
 +
-See https://hypershift-docs.netlify.app/getting-started/[Getting started] in the HyperShift documentation for more information about the secret. The following example shows a sample AWS secret template:
+See _Getting started_ in the HyperShift documentation for more information about the secret. The following example shows a sample AWS secret template:
 +
 ----
 oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=$HOME/.aws/credentials --from-literal=bucket=<s3-bucket-for-hypershift> --from-literal=region=<region> -n local-cluster
@@ -118,7 +118,7 @@ If you plan to provision hosted control plane clusters with service-level DNS (e
 | Optional when using the AWS DNS service
 |===
 +
-See link:https://hypershift-docs.netlify.app/how-to/aws/external-dns/[External DNS] in the HyperShift documentation for more information. The following example shows the sample `hypershift-operator-external-dns-credentials` secret template:
+See _External DNS_ in the HyperShift documentation for more information. The following example shows the sample `hypershift-operator-external-dns-credentials` secret template:
 +
 ----
 oc create secret generic hypershift-operator-external-dns-credentials --from-literal=provider=aws --from-literal=domain-filter=service.my.domain.com --from-file=credentials=<credentials-file> -n local-cluster
@@ -155,7 +155,7 @@ If you plan to provision hosted control plane clusters on the AWS platform with 
 | Required
 |===
 +
-See https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/[Deploying AWS private clusters] in the HyperShift documentation for more information. The following example shows the sample `hypershift-operator-private-link-credentials` secret template:
+See _Deploying AWS private clusters_ in the HyperShift documentation for more information. The following example shows the sample `hypershift-operator-private-link-credentials` secret template:
 +
 ----
 oc create secret generic hypershift-operator-private-link-credentials --from-literal=aws-access-key-id=<aws-access-key-id> --from-literal=aws-secret-access-key=<aws-secret-access-key> --from-literal=region=<region> -n local-cluster
@@ -275,5 +275,11 @@ hypershift create cluster aws --help
 
 [#additional-resources-configure-hosted-cluster-aws]
 == Additional resources
+
+* For more information about the S3 OIDC secret, see link:https://hypershift-docs.netlify.app/getting-started/[Getting started] in the HyperShift documentation.
+
+* For more information about the AWS credential secret, see link:https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/[Deploying AWS private clusters] in the HyperShift documentation.
+
+* For more information about external DNS, see link:https://hypershift-docs.netlify.app/how-to/aws/external-dns/[External DNS] in the HyperShift documentation.
 
 * You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -11,6 +11,15 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 
 *Best practice:* Be sure to run the hub cluster and workers on the same platform for hosted control planes.
 
+* <<hosting-service-cluster-configuring-prereq-aws,Prerequisites>>
+* <<hosted-create-aws-secret,Creating the Amazon Web Services S3 OIDC secret>>
+* <<hosted-create-public-zone-aws,Creating a routable public zone>>
+* <<hosted-enable-ext-dns-aws,Enabling external DNS>>
+* <<hosted-enable-private-link,Enabling AWS PrivateLink>>
+* <<hosted-enable-feature-aws,Enabling the hosted control planes feature>>
+* <<hosted-enable-hypershift-add-on-aws,Manually enabling the hypershift-addon managed cluster add-on for local-cluster>>
+* <<hosted-install-cli,Installing the hosted control planes CLI>>
+
 [#hosting-service-cluster-configure-prereq-aws]
 == Prerequisites
 
@@ -262,3 +271,8 @@ You can now use the `hypershift create cluster` command to create and manage hos
 ----
 hypershift create cluster aws --help
 ----
+
+[#additional-resources-configure-hosted-cluster-aws]
+== Additional resources
+
+* You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -1,17 +1,11 @@
-[#hosted-control-planes-configure]
-= Configuring hosted control planes (Technology Preview)
+[#hosting-service-cluster-configure-aws]
+= Configuring the hosting cluster on AWS (Technology Preview)
 
 To configure hosted control planes, you need a hosting cluster and a hosted cluster. By deploying the HyperShift operator on an existing managed cluster by using the `hypershift-addon` managed cluster add-on, you can enable that cluster as a hosting cluster and start to create the hosted cluster. 
 
 The {mce-short} 2.2 supports only the default `local-cluster` and the hub cluster as the hosting cluster.
 
-Hosted control planes is a Technology Preview feature, so the related components are disabled by default. See the following topics to learn more about how to enable hosted control planes on Amazon Web Services (AWS) or bare metal:
-
-* <<hosting-service-cluster-configure-aws,Configuring the hosting cluster on AWS>>
-* <<hosting-service-cluster-configure-bm,Configuring the hosting cluster on bare metal>>
-
-[#hosting-service-cluster-configure-aws]
-== Configuring the hosting cluster on AWS
+Hosted control planes is a Technology Preview feature, so the related components are disabled by default.
 
 You can deploy hosted control planes by configuring an existing cluster to function as a hosting cluster. The hosting cluster is the {ocp} cluster where the control planes are hosted. {product-title-short} 2.7 can use the hub cluster, also known as the `local-cluster`, as the hosting cluster. See the following topics to learn how to configure the `local-cluster` as the hosting cluster.
 
@@ -268,49 +262,3 @@ You can now use the `hypershift create cluster` command to create and manage hos
 ----
 hypershift create cluster aws --help
 ----
-
-[#hosting-service-cluster-configure-bm]
-== Configuring the hosting cluster on bare metal
-
-To provision hosted control planes on bare metal, you can use the Agent platform. The Agent platform uses the Central Infrastructure Management (CIM) service to add worker nodes to a hosted cluster. For an introduction to the CIM service, see link:https://github.com/openshift/assisted-service/blob/master/docs/hive-integration/kube-api-getting-started.md[Kube API - Getting Started Guide]. Each bare metal host must be started with a Discovery Image that the CIM provides. You can start the hosts manually or through automation by using the Cluster-Baremetal-Operator. After each host starts, it runs an Agent process to discover the host details and complete the installation. An `Agent` custom resource represents each host.
-
-When you create a hosted cluster with the Agent platform, HyperShift installs the Agent CAPI provider in the Hosted Control Plane (HCP) namespace.
-
-When you scale up a node pool, a machine is created. The CAPI provider finds an Agent that is approved, is passing validations, is not currently in use, and meets the requirements that are specified in the node pool specification. You can monitor the installation of an Agent by checking its status and conditions.
-
-When you scale down a node pool, Agents are unbound from the corresponding cluster. Before you can reuse the clusters, you must restart them using the Discovery image to update the number of nodes.
-
-[#hosting-service-cluster-configure-prereq-bm]
-=== Prerequisites
-
-You must have the following prerequisites to configure a hosting cluster: 
-
-* {mce} 2.2 and later installed on an {ocp-short} cluster. When you install {product-title-short}, {mce-short} is automatically installed. You can also install {mce-short} without {product-title-short} as an Operator from the {ocp-short} OperatorHub.
-
-* The hosted control planes command line interface (CLI) as a plugin for `oc` to create and manage the hosted cluster in {mce}. To install the CLI, follow the instructions in xref:../hosted_control_planes/configure_hosted.adoc#hosted-install-cli[Installing the hosted control plane CLI.
-
-* {mce} must have at least one managed {ocp-short} cluster. The `local-cluster` is automatically imported in {mce} 2.2 and later. See xref:../install_upgrade/adv_config_install.adoc#advanced-config-engine[Advanced configuration] for more information about the `local-cluster`. You can check the status of your hub cluster by running the following command:
-+
-----
-oc get managedclusters local-cluster
-----
-
-[#configure-dns-aws]
-=== Configuring DNS
-
-The API Server for the hosted cluster is exposed a `NodePort` service. A DNS entry must exist for `api.${HOSTED_CLUSTER_NAME}.${BASEDOMAIN}` that points to destination where the API Server can be reached.
-
-The DNS entry can be as simple as a record that points to one of the nodes in the management cluster that is running the hosted control plane. The entry can also point to a load balancer that is deployed to redirect incoming traffic to the ingress pods. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-on-any-platform#installation-load-balancing-user-infra_installing-platform-agnostic[Load balancing requirements for user-provisioned infrastructure] for more information about load balancers.
-
-.Example DNS configuration
-----
-api.example.krnl.es.    IN A 192.168.122.20
-api.example.krnl.es.    IN A 192.168.122.21
-api.example.krnl.es.    IN A 192.168.122.22
-api-int.example.krnl.es.    IN A 192.168.122.20
-api-int.example.krnl.es.    IN A 192.168.122.21
-api-int.example.krnl.es.    IN A 192.168.122.22
-*.apps.example.krnl.es. IN A 192.168.122.23
-----
-
-You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.


### PR DESCRIPTION
I don't have a Jira for this one. I noticed on 2.8 staging that in the hosted control planes book, the "Configuring on bare metal" info was in two places (1.7.1.2 and 1.7.3), and the "Configuring on AWS" book needed to be moved up one level.