### PR TITLE
[ACM-4613]: Adding instructions to enable ARM control planes for HyperShift on AWS

### DIFF
--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -208,7 +208,7 @@ The access secrets for hosted control plane clusters are stored in the `hypershi
 [#hosted-cluster-arm-aws]
 == Enabling a hosted cluster on {ocp-short} ARM
 
-You can enable an x86 control plane to operate with an {ocp} ARM data plane in a hosted control planes environment. This feature is available for hosted control planes on AWS only.
+You can enable an ARM-hosted control plane to operate with an {ocp} ARM data plane in a management cluster environment. This feature is available for hosted control planes on AWS only.
 
 .Prerequisites
 
@@ -216,22 +216,51 @@ Before you begin, you must meet the following prerequisites:
 
 * You must have an {ocp-short} ARM management cluster. 
 // Will most users know where to get an OCP ARM management cluster? If not, we should point them in the right direction.
-* You must have a HyperShift Operator that is built on ARM. You can obtain a HyperShift Operator in one of two ways:
-//I didn't include the option to download the Operator from https://quay.io/repository/acm-d/hypershift-rhel8-operator because it looks like that option requires onboarding, which doesn't seem appropriate for users.
-** Go to the link:https://quay.io/repository/hypershift/hypershift-operator[hypershift/hypershift-operator repository] and select the build that has the `4.13-arm64` tag. 
-** Build your own HyperShift Operator by modifying the HyperShift Dockerfile to build from ARM images.
-//Do we want to mention this option in the product docs? If so, we should likely explain how to build the Operator by modifying the Dockerfile.
+* You must have a HyperShift Operator that is built on ARM. You can obtain a HyperShift Operator by going to the link:https://quay.io/repository/hypershift/hypershift-operator[hypershift/hypershift-operator repository] and selecting the build that has the `4.13-arm64` tag. 
 
 .Procedure
 
 To run a hosted cluster on {ocp-short} ARM, take the following steps:
 
-. Install the ARM HyperShift Operator on the management cluster.
-// Is this step straightforward for most people, or do we need to tell users how to install the Operator on the management cluster?
+. Install the ARM HyperShift Operator on the management cluster to override the default HyperShift Operator image.
++
+For example, through the hosted control planes (`hypershift`) CLI, enter the following commands, being careful to replace the bucket name, AWS credentials, and region with your information:
++
+----
+hypershift install \
+--oidc-storage-provider-s3-bucket-name $BUCKET_NAME \
+--oidc-storage-provider-s3-credentials $AWS_CREDS \
+--oidc-storage-provider-s3-region $REGION \
+--hypershift-image quay.io/hypershift/hypershift-operator:4.13-arm64
+----
+
 . Create a hosted cluster that overrides the default release image with a multi-architecture release image.
-// Can we add more details here?
++
+For example, through the hosted control planes (`hypershift`) CLI, enter the following commands, being careful to replace the cluster name, node pool replicas, base domain, pull secret, AWS credentials, and region with your information:
++
+----
+hypershift create cluster aws \ 
+--name $CLUSTER_NAME \
+--node-pool-replicas=$NODEPOOL_REPLICAS \
+--base-domain $BASE_DOMAIN \
+--pull-secret $PULL_SECRET \
+--aws-creds $AWS_CREDS \
+--region $REGION \
+--release-image quay.io/openshift-release-dev/ocp-release:4.13.0-rc.0-multi
+----
++
+This example adds a default `NodePool` object through the `--node-pool-replicas` flag.
+
 . Add an x86 `NodePool` object to the hosted cluster.
-// Can we add more details here?
++
+For example, through the hosted control planes (`hypershift`) CLI, enter the following commands, being careful to replace the cluster name, node pool name, and node pool replicas with your information:
++
+----
+hypershift create nodepool aws \
+--cluster-name $CLUSTER_NAME \
+--name $NODEPOOL_NAME \
+--node-count=$NODEPOOL_REPLICAS
+----
 
 [#hypershift-cluster-destroy-aws]
 == Destroying a hosted cluster on AWS

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -206,23 +206,22 @@ The access secrets for hosted control plane clusters are stored in the `hypershi
 - `kubeadmin` password secret: `<hostingNamespace>-<name>-kubeadmin-password` (clusters-hypershift-demo-kubeadmin-password)
 
 [#hosted-cluster-arm-aws]
-== Enabling a hosted cluster on {ocp-short} ARM
+== Enabling hosted control planes on an ARM64 {ocp-short} cluster
 
-You can enable an ARM-hosted control plane to operate with an {ocp} ARM data plane in a management cluster environment. This feature is available for hosted control planes on AWS only.
+You can enable an ARM64-hosted control plane to operate with an {ocp} ARM64 data plane in a management cluster environment. This feature is available for hosted control planes on AWS only.
 
 .Prerequisites
 
 Before you begin, you must meet the following prerequisites:
 
-* You must have an {ocp-short} ARM management cluster. 
-// Will most users know where to get an OCP ARM management cluster? If not, we should point them in the right direction.
-* You must have a HyperShift Operator that is built on ARM. You can obtain a HyperShift Operator by going to the link:https://quay.io/repository/hypershift/hypershift-operator[hypershift/hypershift-operator repository] and selecting the build that has the `4.13-arm64` tag. 
+* You must have an {ocp-short} cluster that was installed on a 64-bit ARM infrastructure. For more information, see link:https://console.redhat.com/openshift/install/aws/arm[Create an OpenShift Cluster: AWS (ARM)].
+* You must have a HyperShift Operator that is built on a 64-bit ARM infrastructure. You can obtain a HyperShift Operator by going to the link:https://quay.io/repository/hypershift/hypershift-operator[hypershift/hypershift-operator repository] and selecting the build that has the `4.13-arm64` tag. 
 
 .Procedure
 
-To run a hosted cluster on {ocp-short} ARM, take the following steps:
+To run a hosted cluster on an ARM64 {ocp-short} cluster, take the following steps:
 
-. Install the ARM HyperShift Operator on the management cluster to override the default HyperShift Operator image.
+. Install the HyperShift Operator for ARM64 on the management cluster to override the default HyperShift Operator image.
 +
 For example, through the hosted control planes (`hypershift`) CLI, enter the following commands, being careful to replace the bucket name, AWS credentials, and region with your information:
 +
@@ -251,7 +250,7 @@ hypershift create cluster aws \
 +
 This example adds a default `NodePool` object through the `--node-pool-replicas` flag.
 
-. Add an x86 `NodePool` object to the hosted cluster.
+. Add a 64-bit x86 `NodePool` object to the hosted cluster.
 +
 For example, through the hosted control planes (`hypershift`) CLI, enter the following commands, being careful to replace the cluster name, node pool name, and node pool replicas with your information:
 +

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -205,6 +205,34 @@ The access secrets for hosted control plane clusters are stored in the `hypershi
 - `kubeconfig` secret: `<hostingNamespace>-<name>-admin-kubeconfig` (clusters-hypershift-demo-admin-kubeconfig)
 - `kubeadmin` password secret: `<hostingNamespace>-<name>-kubeadmin-password` (clusters-hypershift-demo-kubeadmin-password)
 
+[#hosted-cluster-arm-aws]
+== Enabling a hosted cluster on {ocp-short} ARM
+
+You can enable an x86 control plane to operate with an {ocp} ARM data plane in a hosted control planes environment. This feature is available for hosted control planes on AWS only.
+
+.Prerequisites
+
+Before you begin, you must meet the following prerequisites:
+
+* You must have an {ocp-short} ARM management cluster. 
+// Will most users know where to get an OCP ARM management cluster? If not, we should point them in the right direction.
+* You must have a HyperShift Operator that is built on ARM. You can obtain a HyperShift Operator in one of two ways:
+//I didn't include the option to download the Operator from https://quay.io/repository/acm-d/hypershift-rhel8-operator because it looks like that option requires onboarding, which doesn't seem appropriate for users.
+** Go to the link:https://quay.io/repository/hypershift/hypershift-operator[hypershift/hypershift-operator repository] and select the build that has the `4.13-arm64` tag. 
+** Build your own HyperShift Operator by modifying the HyperShift Dockerfile to build from ARM images.
+//Do we want to mention this option in the product docs? If so, we should likely explain how to build the Operator by modifying the Dockerfile.
+
+.Procedure
+
+To run a hosted cluster on {ocp-short} ARM, take the following steps:
+
+. Install the ARM HyperShift Operator on the management cluster.
+// Is this step straightforward for most people, or do we need to tell users how to install the Operator on the management cluster?
+. Create a hosted cluster that overrides the default release image with a multi-architecture release image.
+// Can we add more details here?
+. Add an x86 `NodePool` object to the hosted cluster.
+// Can we add more details here?
+
 [#hypershift-cluster-destroy-aws]
 == Destroying a hosted cluster on AWS
 

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -208,16 +208,15 @@ The access secrets for hosted control plane clusters are stored in the `hypershi
 [#hosted-cluster-arm-aws]
 == Enabling hosted control planes on an ARM64 {ocp-short} cluster
 
-You can enable an ARM64-hosted control plane to operate with an {ocp} ARM64 data plane in a management cluster environment. This feature is available for hosted control planes on AWS only.
+You can enable an ARM64-hosted control plane to operate with an {ocp-short} ARM64 data plane in a management cluster environment. This feature is available for hosted control planes on AWS only.
 
-.Prerequisites
+[#prerequisites-hosted-arm]
+=== Prerequisites
 
 Before you begin, you must meet the following prerequisites:
 
 * You must have an {ocp-short} cluster that was installed on a 64-bit ARM infrastructure. For more information, see link:https://console.redhat.com/openshift/install/aws/arm[Create an OpenShift Cluster: AWS (ARM)].
 * You must have a HyperShift Operator that is built on a 64-bit ARM infrastructure. You can obtain a HyperShift Operator by going to the link:https://quay.io/repository/hypershift/hypershift-operator[hypershift/hypershift-operator repository] and selecting the build that has the `4.13-arm64` tag. 
-
-.Procedure
 
 To run a hosted cluster on an ARM64 {ocp-short} cluster, take the following steps:
 


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4613

This PR adds instructions to enable OCP ARM for hosted control planes.

Engineering contact: Bryan Cox
QE: Liangquan Li