### PR TITLE
[ACM-4111]: Adding 'Additional resources' anchor link

### DIFF
--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -13,6 +13,7 @@ You can use the {mce} console to create and manage a {ocp} hosted cluster. Hoste
 * <<enable-node-auto-scaling-hosted-cluster,Enabling node auto-scaling for the hosted cluster>>
 * <<verifying-cluster-creation-bm,Verifying hosted cluster creation>>
 * <<hypershift-cluster-destroy-bm,Destroying a hosted cluster on bare metal>>
+* <<additional-resources-manage-bm,Additional resources>>
 
 [#hosted-prerequisites-bm]
 == Prerequisites
@@ -214,7 +215,7 @@ type: Opaque
 +
 *Note:* The `infraenvs.agent-install.openshift.io` label is used to specify which `InfraEnv` is used to start the BMH. The `bmac.agent-install.openshift.io/hostname` label is used to manually set a hostname.
 +
-If you want to manually specify the installation disk, you can use the `rootDeviceHints` in the BMH specification. If `rootDeviceHints` are not provided, the agent picks the installation disk that better suits the installation requirements.
+If you want to manually specify the installation disk, you can use the `rootDeviceHints` in the BMH specification. If `rootDeviceHints` are not provided, the agent picks the installation disk that better suits the installation requirements. For more information about `rootDeviceHints`, see the _rootDeviceHints_ section of the BareMetalHost documentation.
 +
 ----
 oc apply -f -
@@ -795,4 +796,4 @@ You can use the console to destroy bare metal hosted clusters. Complete the foll
 == Additional resources
 
 * For more information about MetalLB, see link:https://docs.openshift.com/container-platform/4.13/networking/metallb/about-metallb.html[About MetalLB and the MetalLB Operator] in the {ocp-short} documentation.
-* For more information about `rootDeviceHints`, see link:https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md#rootdevicehints[_rootDeviceHints_ section] of the BareMetalHost documentation.
+* For more information about `rootDeviceHints`, see the link:https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md#rootdevicehints[rootDeviceHints section] of the BareMetalHost documentation.


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4111

Small update to BM docs to add an anchor link to the Additional resources section.