### PR TITLE
[ACM-4111]: Updates to the configuring hosted control planes on bare metal docs

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_bm.adoc
@@ -1,15 +1,15 @@
 [#configuring-hosting-service-cluster-configure-bm]
 = Configuring the hosting cluster on bare metal (Technology Preview)
 
-To configure hosted control planes, you need a _hosting_ cluster and a _hosted_ cluster. By deploying the HyperShift operator on an existing managed cluster by using the `hypershift-addon` managed cluster add-on, you can enable that cluster as a hosting cluster and start to create the hosted cluster. 
+To configure hosted control planes, you need a _hosting_ cluster and a _hosted_ cluster. You can enable a managed cluster to be a hosting cluster by using the `hypershift` add-on to deploy the HyperShift Operator on that cluster. Then, you can start to create the hosted cluster. 
 
 The {mce-short} 2.2 supports only the default `local-cluster` and the hub cluster as the hosting cluster.
 
-Hosted control planes is a Technology Preview feature, so the related components are disabled by default. See the following topics to learn more about how to enable hosted control planes on Amazon Web Services (AWS):
+Hosted control planes is a Technology Preview feature, so the related components are disabled by default.
 
-You can deploy hosted control planes by configuring an existing cluster to function as a hosting cluster. The hosting cluster is the {ocp-cluster} cluster where the control planes are hosted. 
+You can deploy hosted control planes by configuring a cluster to function as a hosting cluster. The hosting cluster is the {ocp-short} cluster where the control planes are hosted. 
 
-{product-title-short} 2.7 users can use the managed hub cluster, also known as the `local-cluster`, as the hosting cluster. See the following topics to learn how to configure the `local-cluster` as the hosting cluster.
+On {product-title-short} 2.7, you can use the managed hub cluster, also known as the `local-cluster`, as the hosting cluster.
 
 *Important:* 
 
@@ -17,13 +17,17 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 
 - To provision hosted control planes on bare metal, you can use the Agent platform. The Agent platform uses the Central Infrastructure Management (CIM) service to add worker nodes to a hosted cluster. 
 
-- Each bare metal host must be started with a Discovery Image that the CIM provides. You can start the hosts manually or through automation by using the `Cluster-Baremetal-Operator`. After each host starts, it runs an Agent process to discover the host details and complete the installation. An `Agent` custom resource represents each host.
+- Each bare metal host must be started with a Discovery Image that the CIM provides. You can start the hosts manually or through automation by using `Cluster-Baremetal-Operator`. After each host starts, it runs an Agent process to discover the host details and complete the installation. An `Agent` custom resource represents each host.
 
 - When you create a hosted cluster with the Agent platform, HyperShift installs the Agent Cluster API provider in the hosted control plane namespace.
 
 - When you scale up a node pool, a machine is created. The Cluster API provider finds an Agent that is approved, is passing validations, is not currently in use, and meets the requirements that are specified in the node pool specification. You can monitor the installation of an Agent by checking its status and conditions.
 
 - When you scale down a node pool, Agents are unbound from the corresponding cluster. Before you can reuse the clusters, you must restart them by using the Discovery image to update the number of nodes.
+
+* <<hosting-service-cluster-configure-prereq,Prerequisites>>
+* <<configuring-dns-bm,Configuring DNS>>
+* <<additional-resources-config-bm,Additional resources>>
 
 [#hosting-service-cluster-configure-prereq]
 == Prerequisites
@@ -48,7 +52,7 @@ oc get managedclusters local-cluster
 
 The API Server for the hosted cluster is exposed as a `NodePort` service. A DNS entry must exist for `api.${HOSTED_CLUSTER_NAME}.${BASEDOMAIN}` that points to destination where the API Server can be reached.
 
-The DNS entry can be as simple as a record that points to one of the nodes in the managed cluster that is running the hosted control plane. The entry can also point to a load balancer that is deployed to redirect incoming traffic to the ingress pods. 
+The DNS entry can be as simple as a record that points to one of the nodes in the managed cluster that is running the hosted control plane. The entry can also point to a load balancer that is deployed to redirect incoming traffic to the Ingress pods. 
 
 See the following example DNS configuration:
 ----


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4111

This PR contains a few updates to the "Configuring the hosting cluster on bare metal" topic, including the removal of unnecessary text, revision to the opening paragraph, and typo fixes.