### PR TITLE
[ACM-4770]: Porting upstream docs into official docs - AWS S3 bucket

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -38,9 +38,28 @@ oc get managedclusters local-cluster
 * A hosting cluster with at least 3 worker nodes to run the HyperShift Operator.
 
 [#hosted-create-aws-secret]
-== Creating the Amazon Web Services S3 OIDC secret
+== Creating the Amazon Web Services S3 bucket and S3 OIDC secret
 
 If you plan to create and manage hosted clusters on AWS, complete the following steps:
+
+. Create an S3 bucket that has public access to host OIDC discovery documents for your clusters.
++
+** To create the bucket in the us-east-1 region, enter the following code:
++ 
+----
+BUCKET_NAME=<your_bucket_name>
+aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME
+----
++
+** To create the bucket in a region other than the us-east-1 region, enter the following code:
++
+----
+BUCKET_NAME=your-bucket-name
+REGION=us-east-2
+aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME \
+  --create-bucket-configuration LocationConstraint=$REGION \
+  --region $REGION
+----
 
 . Create an OIDC S3 secret named `hypershift-operator-oidc-provider-s3-credentials` for the HyperShift operator.
 
@@ -61,7 +80,7 @@ If you plan to create and manage hosted clusters on AWS, complete the following 
 | Specifies the region of the S3 bucket.
 |===
 +
-See _Getting started_ in the HyperShift documentation for more information about the secret. The following example shows a sample AWS secret template:
+The following example shows a sample AWS secret template:
 +
 ----
 oc create secret generic hypershift-operator-oidc-provider-s3-credentials --from-file=credentials=$HOME/.aws/credentials --from-literal=bucket=<s3-bucket-for-hypershift> --from-literal=region=<region> -n local-cluster
@@ -275,8 +294,6 @@ hypershift create cluster aws --help
 
 [#additional-resources-configure-hosted-cluster-aws]
 == Additional resources
-
-* For more information about the S3 OIDC secret, see link:https://hypershift-docs.netlify.app/getting-started/[Getting started] in the HyperShift documentation.
 
 * For more information about the AWS credential secret, see link:https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/[Deploying AWS private clusters] in the HyperShift documentation.
 

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -37,6 +37,8 @@ oc get managedclusters local-cluster
 
 * A hosting cluster with at least 3 worker nodes to run the HyperShift Operator.
 
+* The AWS command line interface. 
+
 [#hosted-create-aws-secret]
 == Creating the Amazon Web Services S3 bucket and S3 OIDC secret
 


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4770?filter=12412126

This PR removes links to the HyperShift upstream docs and ports over any necessary details from the upstream docs to the official docs.

This particular PR focuses on porting over information about creating an S3 bucket.