### PR TITLE
[ACM-4937]: Update AWS OIDC S3 docs for hosted control planes

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -50,7 +50,8 @@ If you plan to create and manage hosted clusters on AWS, complete the following 
 + 
 ----
 BUCKET_NAME=<your_bucket_name>
-aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME
+aws s3api create-bucket --bucket $BUCKET_NAME
+aws s3api delete-public-access-block --bucket $BUCKET_NAME
 ----
 +
 ** To create the bucket in a region other than the us-east-1 region, enter the following code:
@@ -58,9 +59,10 @@ aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME
 ----
 BUCKET_NAME=your-bucket-name
 REGION=us-east-2
-aws s3api create-bucket --acl public-read --bucket $BUCKET_NAME \
+aws s3api create-bucket --bucket $BUCKET_NAME \
   --create-bucket-configuration LocationConstraint=$REGION \
   --region $REGION
+aws s3api delete-public-access-block --bucket $BUCKET_NAME
 ----
 
 . Create an OIDC S3 secret named `hypershift-operator-oidc-provider-s3-credentials` for the HyperShift operator.


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4937

This PR makes an update to the OIDC S3 docs to align with recent changes from AWS. This update will be backported to 2.7 and 2.6.