### PR TITLE
Adding asterisks back per SME review

### DIFF
--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -156,17 +156,9 @@ version   4.12.7        True        False         5m39s   Cluster version is 4.1
 
 Every {ocp-short} cluster includes a default application Ingress controller, which must have an wildcard DNS record associated with it. By default, guest clusters that are created by using the HyperShift KubeVirt provider automatically become a subdomain of the underlying {ocp-short} cluster that the KubeVirt virtual machines run on.
 
-For example, your {ocp-short} cluster might have the following default Ingress DNS entry:
+For example, your {ocp-short} cluster might have the default Ingress DNS entry of `*.apps.mgmt-cluster.example.com`.
 
-----
-<dns-prefix>.apps.mgmt-cluster.example.com
-----
-
-As a result, a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster has the following default Ingress:
-
-----
-<dns-prefix>.apps.guest.apps.mgmt-cluster.example.com
-----
+As a result, a KubeVirt guest cluster that is named `guest` and that runs on that underlying {ocp-short} cluster has the default Ingress of `*.apps.guest.apps.mgmt-cluster.example.com`.
 
 *Note:* For the default Ingress DNS to work properly, the underlying cluster that hosts the KubeVirt virtual machines must allow wildcard DNS routes. You can configure this behavior by entering the following command: `oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'`
 


### PR DESCRIPTION
The lead engineer for the KubeVirt docs is concerned that the target audience will be confused by removing the asterisks from the code. Trying to add them back but work with the formatting so that the build won't break.