### PR TITLE
Update GRC policy flapping known issue

### DIFF
--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -618,7 +618,20 @@ To resolve the issue, disable the policy and compare the differences between `ob
 
 - The `objectDefinition` in the `ConfigurationPolicy` does not match because Kubernetes processing the object when the policy is applied.
 +
-To resolve the issue, disable the policy and compare the differences between `objectDefinition` in the policy and the object on the managed cluster. If the keys are different or missing, Kubernetes might have processed the keys before applying them to the object. For `PodSecurityPolicy`, for example, Kubernetes removes keys with values set to `false`, which you can see in the resulting object on the managed cluster. In this case, remove the keys from the `objectDefinition` in the policy.
+To resolve the issue, disable the policy and compare the differences between `objectDefinition` in the policy and the object on the managed cluster. If the keys are different or missing, Kubernetes might have processed the keys before applying them to the object, such as removing keys containing default or empty values.
++
+Known examples:
++
+|===
+| Kind | Issue description
+
+|`PodSecurityPolicy`
+| Kubernetes removes keys with values set to `false`, which you can see in the resulting object on the managed cluster. In this case, remove the keys from the `objectDefinition` in the policy.
+
+|`Secret`
+| The `stringData` map is processed by Kubernetes to `data` with `base64` encoded values. Instead of using `stringData`, use `data` directly with `base64` encoded values instead of strings.
+
+|===
 
 [#policy-templates-not-removed]
 === Policy template issues


### PR DESCRIPTION
`stringData` for secrets is another known case of policy flapping that makes the known issue clearer.

ref: https://issues.redhat.com/browse/ACM-5543