### PR TITLE
[ACM-4770]: removing link to upstream HyperShift docs

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -356,7 +356,7 @@ If you plan to provision hosted control plane clusters on the AWS platform with 
 | Required
 |===
 +
-See _Deploying AWS private clusters_ in the HyperShift documentation for more information. The following example shows the sample `hypershift-operator-private-link-credentials` secret template:
+The following example shows the sample `hypershift-operator-private-link-credentials` secret template:
 +
 ----
 oc create secret generic hypershift-operator-private-link-credentials --from-literal=aws-access-key-id=<aws-access-key-id> --from-literal=aws-secret-access-key=<aws-secret-access-key> --from-literal=region=<region> -n local-cluster
@@ -490,9 +490,6 @@ See link:https://access.redhat.com/documentation/en-us/openshift_container_platf
 [#additional-resources-configure-hosted-cluster-aws]
 == Additional resources
 
-For more information about hosted control planes on AWS, see the following resources:
-
-* For details about the AWS credential secret, see link:https://hypershift-docs.netlify.app/how-to/aws/deploy-aws-private-clusters/[Deploying AWS private clusters] in the HyperShift documentation.
-//This link will be removed when we port the AWS private cluster doc to the RHACM docs
+For more information about hosted control planes on AWS, see the following resource:
 
 * You can now deploy the SR-IOV Operator. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes].


### PR DESCRIPTION
The [Configuring the hosting cluster on AWS](https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-enable-private-link) topic links to the upstream HyperShift docs for more information about AWS PrivateLink. I ported those upstream docs to `clusters/hosted_control_planes/deploying_aws_private_clusters.adoc` as part of an effort to replace any links to upstream docs since upstream docs are not officially supported.

The original reference to the upstream docs said "For details about the AWS secret, see Deploying AWS private clusters". However, neither the upstream docs nor the docs that I ported over from upstream to the new file really mention more details about the AWS secret, so I don't think that link is helpful or necessary.