### PR TITLE
Minor link and title fixes

### DIFF
--- a/clusters/hosted_control_planes/disable_hosted.adoc
+++ b/clusters/hosted_control_planes/disable_hosted.adoc
@@ -58,5 +58,5 @@ spec:
 [#additional-resources-disable]
 == Additional resources
 
-* link:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-aws[Managing hosted control planes on AWS]
-* link:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-create[Managing hosted control plane clusters]
+* xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS (Technology Preview)]
+* xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal (Technology Preview)]

--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -29,8 +29,8 @@ See the following highly available hosted control plane requirements, which were
 For more information about hosted control planes, continue reading the following topics:
 
 * xref:../hosted_control_planes/configure_hosted_aws.adoc#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)]
-* xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS]
+* xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS (Technology Preview)]
 * xref:../hosted_control_planes/configure_hosted_bm.adoc#configuring-hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal (Technology Preview)]
-* xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]
-* xref:../hosted_control_planes/managing_hosted_kubevirt.adoc#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization]
-* xref:../hosted_control_planes/disable_hosted.adoc#disable-hosted-control-planes[Disabling the hosted control feature]
+* xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal (Technology Preview)]
+* xref:../hosted_control_planes/managing_hosted_kubevirt.adoc#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization (Technology Preview)]
+* xref:../hosted_control_planes/disable_hosted.adoc#disable-hosted-control-planes[Disabling the hosted control feature (Technology Preview)]

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -11,7 +11,6 @@ You can use the {mce} console to create a {ocp} hosted cluster. Hosted control p
 * <<importing-hosted-cluster-aws,Importing a hosted control plane cluster on AWS>>
 * <<hosted-cluster-arm-aws,Enabling hosted control planes on an ARM64 {ocp-short} cluster>>
 * <<hypershift-cluster-destroy-aws,Destroying a hosted cluster on AWS>>
-* <<additional-resources-manage-hosted-aws,Additional resources>>
 
 [#hosted-prerequisites-aws]
 == Prerequisites
@@ -313,11 +312,3 @@ oc delete managedcluster <cluster_name>
 ----
 +
 Replace `cluster_name` with the name of your cluster.
-
-[#additional-resources-manage-hosted-aws]
-== Additional resources
-
-For more information about managing hosted control plane clusters on AWS, see the following topics:
-
-* xref:../hosted_control_planes/deploying_aws_private_clusters.adoc#deploying-aws-private-clusters[Deploying a private hosted cluster on AWS]
-* xref:../hosted_control_planes/managing_aws_infra_iam.adoc#hosted-control-planes-manage-aws-infra-iam[Managing AWS infrastructure and IAM permissions for hosted control planes]


### PR DESCRIPTION
Fixing a few minor issues and inconsistencies that I spotted in the hosted control plane docs for ACM 2.8. Also, I removed the 'Additional resources' section from the "Managing on AWS" topic because the two resources that are mentioned immediately follow in the body of the text and the TOC.