### PR TITLE
[ACM-6026]: Minor update to hosted control planes intro

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -3,7 +3,7 @@
 
 With {mce-short} cluster management, you can deploy {ocp-short} clusters by using two different control plane configurations: standalone or hosted control planes. The standalone configuration uses dedicated virtual machines or physical machines to host the {ocp-short} control plane. With hosted control planes for {ocp-short}, you create control planes as pods on a hosting cluster without the need for dedicated physical machines for each control plane.
 
-Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS), bare metal or virtual environments, and {ocp-virt}. You can host the control planes on {ocp-short} version 4.10.7 and later.
+Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS), bare metal, and {ocp-virt}. You can host the control planes on {ocp-short} version 4.10.7 and later.
 
 **Note:** Run the hub cluster and workers on the same platform for hosted control planes.
 


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-6026

This PR removes the mention of "virtual environments" from the hosted control planes overview per Adel. 