### PR TITLE
[ACM-6026]: Backport to 2.7

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -3,7 +3,7 @@
 
 With {mce-short} cluster management, you can deploy {ocp-short} clusters by using two different control plane configurations: standalone or hosted control planes. The standalone configuration uses dedicated virtual machines or physical machines to host the {ocp-short} control plane. With hosted control planes for {ocp-short}, you create control planes as pods on a hosting cluster without the need for dedicated physical machines for each control plane.
 
-Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS) and on bare metal or virtual environments. You can host the control planes on {ocp-short} version 4.10.7 and later.
+Hosted control planes for {ocp-short} are available as a Technology Preview feature on Amazon Web Services (AWS) and on bare metal. You can host the control planes on {ocp-short} version 4.10.7 and later.
 
 **Note:** Run the hub cluster and workers on the same platform for hosted control planes.
 
@@ -22,7 +22,7 @@ Hosted control plane clusters offer several advantages:
 For more information about hosted control planes, continue reading the following topics:
 
 * xref:../hosted_control_planes/configure_hosted_aws.adoc#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)]
-* xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS]
+* xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-control-planes-manage-aws[Managing hosted control planes on AWS (Technology Preview)]
 * xref:../hosted_control_planes/configure_hosted_bm.adoc#configuring-hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal (Technology Preview)]
-* xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]
-* xref:../hosted_control_planes/disable_hosted.adoc#disable-hosted-control-planes[Disabling the hosted control feature]
+* xref:../hosted_control_planes/managing_hosted_bm.adoc#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal (Technology Preview)]
+* xref:../hosted_control_planes/disable_hosted.adoc#disable-hosted-control-planes[Disabling the hosted control feature (Technology Preview)]


### PR DESCRIPTION
Backporting changes from https://github.com/stolostron/rhacm-docs/pull/5206 to 2.7