### PR TITLE
Update special_considerations.md simplify asterisks

### DIFF
--- a/_pages/special_considerations.md
+++ b/_pages/special_considerations.md
@@ -13,7 +13,7 @@ In AsciiDoc, `*` (asterisk symbol, Unicode `U+002A`) denotes the beginning of bo
 
 Asterisks can cause formatting issues when used for other purposes, such as for placeholders or as part of a command or code. See the following DNS example:
 
-Ingress for workloads within the hosted cluster, such as the following domain: `*.apps.service-consumer-domain.com`
+Ingress for workloads within the hosted cluster, such as the following domain: `*.apps.service-consumer-domain.com`.
 
 To avoid formatting issues, place them within the backtics `*`, just as we do for any of the code or command element. If you are creating a DNS command, it is best to format that within the same line as the text inside backtics, as seen in the previous example.
 

--- a/_pages/special_considerations.md
+++ b/_pages/special_considerations.md
@@ -9,14 +9,16 @@ You might encounter some rare and specific writing cirumstances that require a w
 
 ## Asterisks
 
-In AsciiDoc, `*` (asterisk symbol, Unicode `U+002A`) denotes the beginning of bold text or a bullet point. This can cause formatting issues when `*` is used for other purposes, such as for placeholders or as part of a command or code.
+In AsciiDoc, `*` (asterisk symbol, Unicode `U+002A`) denotes the beginning of bold text or a bullet point. Sometimes using a dash (-) for bulleted lists can fix formatting issues that you may have in your PR.
 
-To avoid formatting issues, do not use a single `*` if possible. You can often ask developers to provide alternatives if a codeblock or similar has stray asterisks.
+Asterisks can cause formatting issues when used for other purposes, such as for placeholders or as part of a command or code. See the following DNS example:
 
-If you must use `*`, make sure to only use a single `*` per line. If necessary, separate paragraphs with multiple single asterisks into several lines to avoid formatting or build issues.
+Ingress for workloads within the hosted cluster, such as the following domain: `*.apps.service-consumer-domain.com`
 
-Additionally to only appearing once per line, a single  `*` should also be enclosed in backticks, not in a codeblock.
+To avoid formatting issues, place them within the backtics `*`, just as we do for any of the code or command element. If you are creating a DNS command, it is best to format that within the same line as the text inside backtics, as seen in the previous example.
+
+Ensure you only use a single `*` for each line, in backtics and not codeblock. If necessary, separate paragraphs with multiple single asterisks into several lines to avoid formatting or build issues.
 
 ## IP addresses
 
-To avoid security issues, do not include public IP addresses from test clusters in the documentation. You can use private IP addresses where necessary.
+To avoid security issues, do not include public IP addresses from test clusters in the documentation. You can use private IP addresses where necessary. This is just good security practice for the tech industry in general.


### PR DESCRIPTION
With internal doc/process being shared across the team, we want to ensure that we don't document what writers should just know (like what is code and what is not) because most things are in style manuals or taught in collegiate programs (like grammar). We all have a chance to update this topic based on where people are running into issues, but in the simplest way possible. I didn't understand a few lines here, though I knew what we were trying to say. 

Asterisks are either part of the code if not bulleted lists or bold tags, and should always be treated as such (I feel this is just standard), but I added a recent example that wasn't really clear before how to fix lists, and how to avoid formatting issues in DNS examples.

