### PR TITLE
https://issues.redhat.com/browse/ACM-4940 Errata update

### DIFF
--- a/release_notes/errata.adoc
+++ b/release_notes/errata.adoc
@@ -17,7 +17,7 @@ FIPS notice: If you do not specify your own ciphers in `spec.ingress.sslCiphers`
 
 * The `must-gather` command now collects the {ocp} version number. (https://issues.redhat.com/browse/ACM-2857[ACM-2857])
 
-* Fixes an issue that caused the `max_item_size` setting in the `MEMCACHED` index to not propogate changes to all `MEMCACHED` clients. (https://issues.redhat.com/browse/ACM-4683[ACM-4683])
+* Fixes an issue that caused the `max_item_size` setting in the `MEMCACHED` index to not propogate changes to all `MEMCACHED` clients. (https://issues.redhat.com/browse/ACM-4684[ACM-4684])
 
 == Errata 2.6.4
 

--- a/release_notes/errata.adoc
+++ b/release_notes/errata.adoc
@@ -17,6 +17,8 @@ FIPS notice: If you do not specify your own ciphers in `spec.ingress.sslCiphers`
 
 * The `must-gather` command now collects the {ocp} version number. (https://issues.redhat.com/browse/ACM-2857[ACM-2857])
 
+* Fixes an issue that caused the `max_item_size` setting in the `MEMCACHED` index to not propogate changes to all `MEMCACHED` clients. (https://issues.redhat.com/browse/ACM-4683[ACM-4683])
+
 == Errata 2.6.4
 
 * Fixes an issue that causes `ClusterCurator` upgrades to time out by adding the `spec.upgrade.monitorTimeout` setting to the `ClusterCurator` API. (https://issues.redhat.com/browse/ACM-2024[ACM-2024])


### PR DESCRIPTION
This one was missed by the release manager so I offered a one time exception to add it late. For the future I have let the issue reporter know to contact the release manager directly if they notice a missing errata label on an engineering issue.