### PR TITLE
[ACM-5757]: Adding info about multiclusterengine commands

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -20,7 +20,6 @@ You can deploy hosted control planes by configuring an existing cluster to funct
 * <<hosted-enable-hypershift-add-on-aws,Manually enabling the hypershift-addon managed cluster add-on for local-cluster>>
 * <<hosted-install-cli,Installing the hosted control planes command line interface>>
 * <<dr-hosted-cluster,Disaster recovery for a hosted cluster>>
-* <<additional-resources-configure-hosted-cluster-aws,Additional resources>>
 
 [#hosting-service-cluster-configure-prereq-aws]
 == Prerequisites

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -379,14 +379,14 @@ The hosted control planes feature is disabled by default. Enabling the feature a
 ----
 oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": true}]}}}' <1>
 ----
-<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
 
 . Run the following command to verify that the `hypershift-preview` and `hypershift-local-hosting` features are enabled in the `MultiClusterEngine` custom resource:
 +
 ----
 oc get mce multiclusterengine -o yaml <1>
 ----
-<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
 +
 The output resembles the following example:
 +

--- a/clusters/hosted_control_planes/configure_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_aws.adoc
@@ -377,14 +377,16 @@ The hosted control planes feature is disabled by default. Enabling the feature a
 . You can run the following command to enable the feature:
 +
 ----
-oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": true}]}}}'
+oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": true}]}}}' <1>
 ----
+<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
 
 . Run the following command to verify that the `hypershift-preview` and `hypershift-local-hosting` features are enabled in the `MultiClusterEngine` custom resource:
 +
 ----
-oc get mce multiclusterengine -o yaml
+oc get mce multiclusterengine -o yaml <1>
 ----
+<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
 +
 The output resembles the following example:
 +

--- a/clusters/hosted_control_planes/disable_hosted.adoc
+++ b/clusters/hosted_control_planes/disable_hosted.adoc
@@ -4,7 +4,7 @@
 You can uninstall the the HyperShift Operator and disable the hosted control plane. When disabling the hosted control plane cluster feature, you must destroy the hosted cluster and the managed cluster resource on {mce-short}, as described in the _Managing hosted control plane clusters_ topics.
 
 [#hypershift-uninstall-operator]
-== Uninstalling the HyperShift operator
+== Uninstalling the HyperShift Operator
 
 To uninstall the HyperShift Operator and disable the `hypershift-addon` from the `local-cluster`, complete the following steps:
 
@@ -19,8 +19,10 @@ oc get hostedcluster -A
 . Disable the `hypershift-addon` by running the following command:
 +
 ----
-oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}'
+oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}' <1>
 ----
++
+<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
 +
 *Tip:* You can also disable the `hypershift-addon` for the `local-cluster` from the {mce-short} console after disabling the `hypershift-addon`.
 
@@ -30,14 +32,18 @@ oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"componen
 You must first uninstall the HyperShift Operator before disabling the hosted control planes feature. Run the following command to disable the hosted control planes feature:
 
 ----
-oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": false}]}}}'
+oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": false}]}}}' <1>
 ----
+
+<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
 
 You can verify that the `hypershift-preview` and `hypershift-local-hosting` features are disabled in the `MultiClusterEngine` custom resource by running the following command:
 
 ----
-oc get mce multiclusterengine -o yaml
+oc get mce multiclusterengine -o yaml <1>
 ----
+
+<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
 
 See the following example where `hypershift-preview` and `hypershift-local-hosting` have their `enabled:` flags set to `false`:
 [source,yaml]

--- a/clusters/hosted_control_planes/disable_hosted.adoc
+++ b/clusters/hosted_control_planes/disable_hosted.adoc
@@ -22,7 +22,7 @@ oc get hostedcluster -A
 oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-local-hosting","enabled": false}]}}}' <1>
 ----
 +
-<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
 +
 *Tip:* You can also disable the `hypershift-addon` for the `local-cluster` from the {mce-short} console after disabling the `hypershift-addon`.
 
@@ -35,7 +35,7 @@ You must first uninstall the HyperShift Operator before disabling the hosted con
 oc patch mce multiclusterengine --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift-preview","enabled": false}]}}}' <1>
 ----
 
-<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
 
 You can verify that the `hypershift-preview` and `hypershift-local-hosting` features are disabled in the `MultiClusterEngine` custom resource by running the following command:
 
@@ -43,7 +43,7 @@ You can verify that the `hypershift-preview` and `hypershift-local-hosting` feat
 oc get mce multiclusterengine -o yaml <1>
 ----
 
-<1> The default MultiClusterEngine instance name is `multiclusterengine`, but you can get the MultiClusterEngine name from your cluster by running the following command: `$ oc get mce`.
+<1> The default `MultiClusterEngine` resource instance name is `multiclusterengine`, but you can get the `MultiClusterEngine` name from your cluster by running the following command: `$ oc get mce`.
 
 See the following example where `hypershift-preview` and `hypershift-local-hosting` have their `enabled:` flags set to `false`:
 [source,yaml]


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-5757

This PR adds information to instances of the following commands in the hosted control plane docs:
- oc patch mce multiclusterengine
- oc get mce multiclusterengine

The purpose of the additional information is to let users know what the default MultiClusterEngine resource instance name is and how they can find out what the instance name is from their hosted cluster.