### PR TITLE
[ACM-5665]: Minor formatting fixes to hosted control plane docs

### DIFF
--- a/clusters/hosted_control_planes/hosted_bare_metal_agents.adoc
+++ b/clusters/hosted_control_planes/hosted_bare_metal_agents.adoc
@@ -3,7 +3,8 @@
 
 You can add agents by manually configuring the machine to start with the live ISO or by using Metal3.
 
-* To manually add agents, follow these steps:
+[#hosted-bare-metal-adding-agents-manual]
+== Manually adding agents
 
 . Download the live ISO and use it to start a host (bare metal or VM). The URL for the live ISO can be found in the `InfraEnv` resource, in the `status.isoDownloadURL` field. At startup, the host communicates with the Assisted Service and registers as an agent in the same namespace as the `InfraEnv` resource.
 
@@ -50,8 +51,9 @@ NAME                                   CLUSTER   APPROVED   ROLE          STAGE
 e57a637f-745b-496e-971d-1abbf03341ba             true       auto-assign
 ----
 
-* To add agents by using Metal3, follow these instructions:
-+
+[#hosted-bare-metal-adding-agents-metal3]
+== Adding agents by using Metal3
+
 **Important:** Because the `BaremetalHost` objects are created outside the baremetal-operator namespace, you must configure the Operator to watch all namespaces.
 
 . Enter the following command:
@@ -85,6 +87,7 @@ export REDFISH_SCHEME="redfish-virtualmedia" <7>
 export REDFISH="${REDFISH_SCHEME}://${BMC_IP}/redfish/v1/Systems/${UUID}" <8>
 ----
 
++
 <1> The user name to connect to the BMC.
 <2> The password to connect to the BMC.
 <3> The IP address that Metal3 uses to connect to the BMC.
@@ -113,8 +116,10 @@ type: Opaque
 ----
 
 .. Create the BareMetalHost object:
+
 +
 *Note:* The `infraenvs.agent-install.openshift.io` label is used to specify which `InfraEnv` is used to start the BareMetalHost. The `bmac.agent-install.openshift.io/hostname` label is used to manually set a hostname.
+
 +
 If you want to manually specify the installation disk, you can use the `rootDeviceHints` in the BareMetalHost specification. If `rootDeviceHints` are not provided, the agent picks the installation disk that better suits the installation requirements. For more information about `rootDeviceHints`, see the _rootDeviceHints_ section of the BareMetalHost documentation.
 
@@ -143,8 +148,8 @@ spec:
 
 +
 The agent is automatically approved. If it is not approved, confirm that the `bootMACAddress` is correct.
-+
 
++
 The BareMetalHost is provisioned:
 
 +

--- a/clusters/hosted_control_planes/hosted_create_bare_metal.adoc
+++ b/clusters/hosted_control_planes/hosted_create_bare_metal.adoc
@@ -23,6 +23,7 @@ hypershift create cluster agent \
     --api-server-address=api.${HOSTED_CLUSTER_NAME}.${BASEDOMAIN} \
 ----
 
++
 <1> Typically, the namespace is created by the HyperShift Operator, but agent cluster creation generates a cluster API provider role that needs the namespace to already exist.
 
 . After a few moments, verify that your hosted control plane pods are up and running by entering the following command:

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -164,11 +164,11 @@ hypershift create kubeconfig --namespace ${CLUSTERS_NAMESPACE} --name ${HOSTED_C
 
 +
 . After you save the `kubeconfig` file, you can access the hosted cluster by entering the following example command:
-
 +
 ----
 oc --kubeconfig ${HOSTED_CLUSTER_NAME}.kubeconfig get nodes
 ----
+
 
 [#importing-hosted-cluster-aws]
 == Importing a hosted control plane cluster on AWS

--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -22,6 +22,7 @@ oc -n ${CLUSTERS_NAMESPACE} scale nodepool ${NODEPOOL_NAME} --replicas 2
 
 +
 The Cluster API agent provider randomly picks two agents that are then assigned to the hosted cluster. Those agents go through different states and finally join the hosted cluster as {ocp-short} nodes. The agents pass through states in the following order:
+
 + 
 * `binding`
 * `discovering`
@@ -31,10 +32,10 @@ The Cluster API agent provider randomly picks two agents that are then assigned 
 * `added-to-existing-cluster`
 
 +
-//lahinson - June 2023 - Need to add a step here to explain what the following command does
 ----
 oc -n ${HOSTED_CONTROL_PLANE_NAMESPACE} get agent
 ----
+//lahinson - June 2023 - Need to add a step above to explain what this command does
 
 +
 See the following example output:
@@ -93,9 +94,9 @@ hypercluster1-c96b6f675-tl42p   hypercluster1-b2qhl   ocp-worker-2   agent://4da
 
 +
 The `clusterversion` reconcile process eventually reaches a point where only Ingress and Console cluster operators are missing:
+//lahinson - June 2023 - Is the following code output, or a command followed by output?
 
 +
-//lahinson - June 2023 - Is the following code output, or a command followed by output?
 ----
 oc --kubeconfig ${HOSTED_CLUSTER_NAME}.kubeconfig get clusterversion,co
 
@@ -238,8 +239,10 @@ spec:
     - ingress-public-ip
 ----
 
++
 .. Save the file as `ipaddresspool-bgpadvertisement-config.yaml`.
 
++
 .. Create the resources by entering the following command:
 
 +
@@ -452,9 +455,9 @@ NAME           STATUS   ROLES    AGE   VERSION
 ocp-worker-1   Ready    worker   51m   v1.24.0+3882f8f
 ocp-worker-2   Ready    worker   52m   v1.24.0+3882f8f
 ----
+//lahinson - June 2023 - Should the following command be preceded by a step? Or is it part of the example output?
 
 +
-//lahinson - June 2023 - Should the following command be preceded by a step? Or is it part of the example output?
 ----
 oc -n ${HOSTED_CONTROL_PLANE_NAMESPACE} get agent -o jsonpath='{range .items[*]}BMH: {@.metadata.labels.agent-install\.openshift\.io/bmh} Agent: {@.metadata.name} State: {@.status.debugInfo.state}{"\n"}{end}'
 


### PR DESCRIPTION
Related PR: https://github.com/stolostron/rhacm-docs/pull/5211

This PR incorporates a few formatting fixes to the recently updated hosted control planes docs. No content was changed.