### PR TITLE
https://issues.redhat.com/browse/ACM-6623 2.2.7 Errata

### DIFF
--- a/clusters/release_notes/errata.adoc
+++ b/clusters/release_notes/errata.adoc
@@ -11,7 +11,7 @@ FIPS notice: If you do not specify your own ciphers in `spec.ingress.sslCiphers`
 
 * Delivers updates to one or more of the product container images and security fixes.
 
-* Fixes an issue that caused the console to display an incorrect scaling alert when addiung nodes to a managed cluster that is not part of Hive `MachinePools`. (link:https://issues.redhat.com/browse/ACM-5169[ACM-5169])
+* Fixes an issue that caused the console to display an incorrect scaling alert when adding nodes to a managed cluster that is not part of Hive `MachinePools`. (link:https://issues.redhat.com/browse/ACM-5169[ACM-5169])
 
 == Errata 2.2.6
 

--- a/clusters/release_notes/errata.adoc
+++ b/clusters/release_notes/errata.adoc
@@ -7,6 +7,12 @@ For {mce-short}, the Errata updates are automatically applied when released.
 
 FIPS notice: If you do not specify your own ciphers in `spec.ingress.sslCiphers`, then the `multiclusterhub-operator` provides a default list of ciphers. For 2.4, this list includes two ciphers that are _not_ FIPS approved. If you upgrade from a version 2.4.x or earlier and want FIPS compliance, remove the following two ciphers from the `multiclusterhub` resource: `ECDHE-ECDSA-CHACHA20-POLY1305` and `ECDHE-RSA-CHACHA20-POLY1305`.
 
+== Errata 2.2.7
+
+* Delivers updates to one or more of the product container images and security fixes.
+
+* Fixes an issue that caused the console to display an incorrect scaling alert when addiung nodes to a managed cluster that is not part of Hive `MachinePools`. (link:https://issues.redhat.com/browse/ACM-5169[ACM-5169])
+
 == Errata 2.2.6
 
 * Fixes an issue that caused the klusterlet agent to fail when the total file size of secrets is too large. (link:https://issues.redhat.com/browse/ACM-5873[ACM-5873])


### PR DESCRIPTION
Is the standard container images/security fixes enough to cover FIPS remediation?