### PR TITLE
[ACM-6773]: Updating kubevirt docs

### DIFF
--- a/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
+++ b/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
@@ -58,7 +58,7 @@ hcp create cluster kubevirt \
 [#kubevirt-vm-image-caching]
 == Enabling KubeVirt VM image caching
 
-KubeVirt image caching is an advanced feature that you can use to optimize both cluster startup time and storage utilization. This feature requires the use of a storage class that is capable of smart cloning and the `ReadWriteMany` access mode.
+KubeVirt image caching is an advanced feature that you can use to optimize both cluster startup time and storage utilization. This feature requires the use of a storage class that is capable of smart cloning and the `ReadWriteMany` access mode. For more information about smart cloning, see _Cloning a data volume using smart-cloning_.
 
 Image caching works as follows:
 
@@ -67,7 +67,7 @@ Image caching works as follows:
 
 Image caching reduces VM startup time by requiring only a single image import. It can further reduce overall cluster storage usage when the storage class supports copy-on-write cloning.
 
-To enable image caching, during cluster creation, use the `hcp` command line interface and the `--root-volume-cache-stragegy=PVC` argument, as shown in the following example:
+To enable image caching, during cluster creation, use the `hcp` command line interface and the `--root-volume-cache-strategy=PVC` argument, as shown in the following example:
 
 ----
 export CLUSTER_NAME=example
@@ -107,6 +107,11 @@ hcp create cluster kubevirt \
 --cores $CPU \
 --etcd-storage-class="local"
 ----
+
+[#kubevirt-storage-config-additional-resources]
+=== Additional resources
+
+* link:https://docs.openshift.com/container-platform/4.13/virt/virtual_machines/virtual_disks/virt-cloning-a-datavolume-using-smart-cloning.html[Cloning a data volume using smart-cloning]
 
 
 

--- a/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
+++ b/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
@@ -8,7 +8,7 @@ If no advanced configuration is provided, the default storage class is used for 
 
 KubeVirt CSI permits any infrastructure storage class with the `ReadWriteMany` access mode to be exposed to the hosted cluster. This mapping of infrastructure cluster storage class to hosted cluster storage class can be configured during cluster creation by using the `hcp` command line interface and the `--infra-storage-class-mapping` argument.
 
-To map infrastructure storage classes to hosted storage classes, see the following example. The example shows how to map two infrastructure storage classes called `infra-sc1` and `infra-sc2` to hosted storage classes called `guest-sc1` and `guest-sc2`. The `--infra-storage-class-mapping` argument can be used multiple times within the `create` command.
+To map infrastructure storage classes to hosted storage classes, see the following example. The example shows how to map two infrastructure storage classes called `infra-sc1` and `infra-sc2` to hosted storage classes called `guest-sc1` and `guest-sc2`. The `--infra-storage-class-mapping` argument can be used multiple times within the `create` command:
 
 ----
 export CLUSTER_NAME=example
@@ -36,7 +36,7 @@ After you create the hosted cluster, the `guest-sc1` and `guest-sc2` storage cla
 
 At cluster creation time, you can configure the storage class that is used to host the KubeVirt VM root volumes by using the `hcp` command line interface and the `--root-volume-storage-class` argument. You can configure the size of the volume by using the `--root-volume-size` argument.
 
-To set a custom storage class and volume size for KubeVirt VMs, see the following example. In the example, the result is a hosted cluster with VMs that are hosted on 64Gi PVCs that are hosted by the `ocs-storagecluster-ceph-rdb` storage class.
+To set a custom storage class and volume size for KubeVirt VMs, see the following example. In the example, the result is a hosted cluster with VMs that are hosted on 64Gi PVCs that are hosted by the `ocs-storagecluster-ceph-rdb` storage class:
 
 ----
 export CLUSTER_NAME=example

--- a/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
+++ b/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
@@ -1,0 +1,112 @@
+[#configuring-storage-kubevirt]
+= Configuring storage for hosted control planes on OpenShift Virtualization
+
+If no advanced configuration is provided, the default storage class is used for the KubeVirt virtual machine (VM) images, the KubeVirt CSI mapping, and the etcd volumes.
+
+[#storageclass-mapping]
+== Mapping KubeVirt CSI storage classes
+
+KubeVirt CSI permits any infrastructure storage class with the `ReadWriteMany` access mode to be exposed to the hosted cluster. This mapping of infrastructure cluster storage class to hosted cluster storage class can be configured during cluster creation by using the `hcp` command line interface and the `--infra-storage-class-mapping` argument.
+
+To map infrastructure storage classes to hosted storage classes, see the following example. The example shows how to map two infrastructure storage classes called `infra-sc1` and `infra-sc2` to hosted storage classes called `guest-sc1` and `guest-sc2`. The `--infra-storage-class-mapping` argument can be used multiple times within the `create` command.
+
+----
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--infra-storage-class-mapping=infra-sc1/guest-sc1 \
+--infra-storage-class-mapping=infra-sc2/guest-sc2
+----
+
+After you create the hosted cluster, the `guest-sc1` and `guest-sc2` storage classes are visible within the hosted cluster. When you create a PVC within the hosted cluster that uses one of those storage classes, KubeVirt CSI provisions that volume by using the infrastructure storage class mapping that you configured during cluster creation.
+
+*Note:* KubeVirt CSI supports mapping only a infrastructure storage class that is capable of `ReadWriteMany` (RWX) access.
+
+[#kubevirt-vm-root-volume-config]
+== Configuring KubeVirt VM root volume
+
+At cluster creation time, you can configure the storage class that is used to host the KubeVirt VM root volumes by using the `hcp` command line interface and the `--root-volume-storage-class` argument. You can configure the size of the volume by using the `--root-volume-size` argument.
+
+To set a custom storage class and volume size for KubeVirt VMs, see the following example. In the example, the result is a hosted cluster with VMs that are hosted on 64Gi PVCs that are hosted by the `ocs-storagecluster-ceph-rdb` storage class.
+
+----
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--root-volume-storage-class ocs-storagecluster-ceph-rbd \
+--root-volume-size 64
+----
+
+[#kubevirt-vm-image-caching]
+== Enabling KubeVirt VM image caching
+
+KubeVirt image caching is an advanced feature that you can use to optimize both cluster startup time and storage utilization. This feature requires the use of a storage class that is capable of smart cloning and the `ReadWriteMany` access mode.
+
+Image caching works as follows:
+
+. The VM image is imported to a PVC that is associated with the hosted cluster.
+. A unique clone of that PVC is created for every KubeVirt VM that is added as a worker node to the cluster. 
+
+Image caching reduces VM startup time by requiring only a single image import. It can further reduce overall cluster storage usage when the storage class supports copy-on-write cloning.
+
+To enable image caching, during cluster creation, use the `hcp` command line interface and the `--root-volume-cache-stragegy=PVC` argument, as shown in the following example:
+
+----
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--root-volume-cache-strategy=PVC
+----
+
+[#etcd-storage-configuration-kubevirt]
+== Configuring etcd storage
+
+At cluster creation time, you can configure the storage class that is used to host etcd data by using the `hcp` command line interface and the `--etcd-storage-class` argument. If you do not provide an `--etcd-storage-class` argument, the default storage class is used.
+
+To configure a storage class for etcd, see the following example:
+
+----
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--etcd-storage-class="local"
+----
+
+
+

--- a/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
+++ b/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
@@ -77,9 +77,9 @@ By default, the HyperShift Operator hosts both the control plane pods of the hos
 [#hosting-cluster-types]
 === Hosting cluster types
 
-The _management cluster_ is the OpenShift cluster that runs the HyperShift Operator and hosts the control plane pods for a hosted cluster. The management cluster is sometimes referred to as the _hosting_ cluster.
+The _management cluster_ is the {ocp-short} cluster that runs the HyperShift Operator and hosts the control plane pods for a hosted cluster. The management cluster is sometimes referred to as the _hosting_ cluster.
 
-The _infrastructure cluster_ is the OpenShift cluster that runs the KubeVirt worker VMs for a hosted cluster.
+The _infrastructure cluster_ is the {ocp-short} cluster that runs the KubeVirt worker VMs for a hosted cluster.
 
 By default, the management cluster also acts as the infrastructure cluster that hosts VMs. However, for external infrastructure, the management and infrastructure clusters are different.
 

--- a/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
+++ b/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
@@ -68,3 +68,48 @@ clusters    example   4.12.7    example-admin-kubeconfig   Completed   True     
 ----
 
 Next, you can access the hosted cluster by following the instructions in xref:../hosted_control_planes/hosting_service_cluster_access.adoc#access-hosted-cluster[Accessing the hosted cluster].
+
+[#kubevirt-create-hosted-cluster-external-infra]
+== Creating a hosted cluster by using external infrastructure
+
+By default, the HyperShift Operator hosts both the control plane pods of the hosted cluster and the KubeVirt worker VMs within the same cluster. With the external infrastructure feature, you can place the worker node VMs on a separate cluster from the control plane pods.
+
+[#hosting-cluster-types]
+=== Hosting cluster types
+
+The _management cluster_ is the OpenShift cluster that runs the HyperShift Operator and hosts the control plane pods for a hosted cluster. The management cluster is sometimes referred to as the _hosting_ cluster.
+
+The _infrastructure cluster_ is the OpenShift cluster that runs the KubeVirt worker VMs for a hosted cluster.
+
+By default, the management cluster also acts as the infrastructure cluster that hosts VMs. However, for external infrastructure, the management and infrastructure clusters are different.
+
+[#external-infrastructure-prereqs]
+=== Prerequisites
+
+* You must have a namespace on the external infrastructure cluster for the KubeVirt nodes to be hosted in.
+
+* You must have a `kubeconfig` file for the external infrastructure cluster.
+
+[#create-hosted-cluster-external-infrastructure]
+=== Creating a hosted cluster by using external infrastructure
+
+You can create a hosted cluster by using the `hcp` command line interface. To place the KubeVirt worker VMs on the infrastructure cluster, use the `--infra-kubeconfig-file` and `--infra-namespace` arguments, as shown in the following example:
+
+----
+export CLUSTER_NAME=example
+export PULL_SECRET="$HOME/pull-secret"
+export MEM="6Gi"
+export CPU="2"
+export WORKER_COUNT="2"
+
+hcp create cluster kubevirt \
+--name $CLUSTER_NAME \
+--node-pool-replicas $WORKER_COUNT \
+--pull-secret $PULL_SECRET \
+--memory $MEM \
+--cores $CPU \
+--infra-namespace=clusters-example \
+--infra-kubeconfig-file=$HOME/external-infra-kubeconfig
+----
+
+After you enter that command, the control plane pods are hosted on the management cluster that the HyperShift Operator runs on, and the KubeVirt VMs are hosted on a separate infrastructure cluster.

--- a/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
+++ b/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
@@ -77,7 +77,7 @@ By default, the HyperShift Operator hosts both the control plane pods of the hos
 [#hosting-cluster-types]
 === Hosting cluster types
 
-The _management cluster_ is the {ocp-short} cluster that runs the HyperShift Operator and hosts the control plane pods for a hosted cluster. The management cluster is sometimes referred to as the _hosting_ cluster.
+The _management cluster_ is the {ocp-short} cluster that runs the HyperShift Operator and hosts the control plane pods for a hosted cluster.
 
 The _infrastructure cluster_ is the {ocp-short} cluster that runs the KubeVirt worker VMs for a hosted cluster.
 

--- a/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
+++ b/clusters/hosted_control_planes/creating_a_hosted_cluster_kubevirt.adoc
@@ -113,3 +113,5 @@ hcp create cluster kubevirt \
 ----
 
 After you enter that command, the control plane pods are hosted on the management cluster that the HyperShift Operator runs on, and the KubeVirt VMs are hosted on a separate infrastructure cluster.
+
+Next, you can access the hosted cluster by following the instructions in xref:../hosted_control_planes/hosting_service_cluster_access.adoc#access-hosted-cluster[Accessing the hosted cluster].

--- a/clusters/hosted_control_planes/hypershift_cluster_destroy_kubevirt.adoc
+++ b/clusters/hosted_control_planes/hypershift_cluster_destroy_kubevirt.adoc
@@ -1,7 +1,7 @@
 [#hypershift-cluster-destroy-kubevirt]
 = Destroying a hosted cluster on OpenShift Virtualization
 
-To delete a hosted cluster on {ocp-virt-short}, enter the following command on a command line:
+To delete a hosted cluster on {ocp-virt-short}, enter the following command:
 
 ----
 hcp destroy cluster kubevirt --name $CLUSTER_NAME

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -31,7 +31,7 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 - You need a valid pull secret file for the `quay.io/openshift-release-dev` repository. For more information, see link:https://console.redhat.com/openshift/install/platform-agnostic/user-provisioned[Install OpenShift on any x86_64 platform with user-provisioned infrastructure].
 - You need to enable the hosted control planes feature. For information, see xref:../hosted_control_planes/configure_hosted_aws.adoc#hosted-enable-feature-aws[Enabling the hosted control planes feature].
 - After you enable the hosted control planes feature, you need to xref:../hosted_control_planes/configure_hosted_aws.adoc#hosted-install-cli[install the hcp command line interface binary].
-- Before you can provision your cluster, you need to configure a load balancer. For more information, see <<hosting-service-cluster-configure-metallb-config,Configuring a load balancer>>.
+- Before you can provision your cluster, you need to configure a load balancer. For more information, see xref:../hosted_control_planes/hosting_service_cluster_configure_metallb.adoc#hosting-service-cluster-configure-metallb-config[Optional: Configuring MetalLB].
 
 [#manage-hosted-cluster-ovn]
 == Managing hosted control plane clusters on OpenShift Virtualization

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -46,4 +46,5 @@ To create a hosted control plane cluster on {ocp-virt-short}, see the following 
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc#create-hosted-clusters-kubevirt-scaling-node-pool[Scaling a node pool]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc#create-hosted-clusters-kubevirt-adding-node-pool[Adding node pools]
 * xref:../hosted_control_planes/verifying_cluster_creation_kubevirt.adoc#verifying-cluster-creation-kubevirt[Verifying hosted cluster creation on OpenShift Virtualization]
+* xref:../hosted_control_planes/configuring_storage_kubevirt.adoc#configuring-storage-kubevirt[Configuring storage for hosted control planes on OpenShift Virtualization]
 * xref:../hosted_control_planes/hypershift_cluster_destroy_kubevirt.adoc#hypershift-cluster-destroy-kubevirt[Destroying a hosted cluster on OpenShift Virtualization]

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -42,7 +42,6 @@ To create a hosted control plane cluster on {ocp-virt-short}, see the following 
 * xref:../hosted_control_planes/hosting_service_cluster_access.adoc#access-hosted-cluster[Accessing the hosted cluster]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_default_ingress_dns.adoc#create-hosted-clusters-kubevirt-default-ingress-dns[Default Ingress and DNS behavior]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_default_ingress_dns.adoc#create-hosted-clusters-kubevirt-customized-ingress-dns[Customizing Ingress and DNS behavior]
-* xref:../hosted_control_planes/hosting_service_cluster_configure_metallb.adoc##hosting-service-cluster-configure-metallb-config[Optional: Configuring MetalLB]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc#create-hosted-clusters-kubevirt-scaling-node-pool[Scaling a node pool]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc#create-hosted-clusters-kubevirt-adding-node-pool[Adding node pools]
 * xref:../hosted_control_planes/verifying_cluster_creation_kubevirt.adoc#verifying-cluster-creation-kubevirt[Verifying hosted cluster creation on OpenShift Virtualization]

--- a/clusters/main.adoc
+++ b/clusters/main.adoc
@@ -108,6 +108,7 @@ include::hosted_control_planes/create_hosted_clusters_kubevirt_default_ingress_d
 include::hosted_control_planes/hosting_service_cluster_configure_metallb.adoc[leveloffset=+4]
 include::hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc[leveloffset=+4]
 include::hosted_control_planes/verifying_cluster_creation_kubevirt.adoc[leveloffset=+4]
+include::hosted_control_planes/configuring_storage_kubevirt.adoc[leveloffset=+4]
 include::hosted_control_planes/hypershift_cluster_destroy_kubevirt.adoc[leveloffset=+4]
 include::hosted_control_planes/hosted-cluster-workload-distributing.adoc[leveloffset=+3]
 include::hosted_control_planes/disable_hosted.adoc[leveloffset=+3]


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-6773

This PR adds new documentation to the KubeVirt platform docs related to storage configuration and using the external infrastructure feature to create a hosted cluster.