### PR TITLE
[ACM-6622]: Add links to node tuning docs

### DIFF
--- a/clusters/hosted_control_planes/hosting_service_cluster_access.adoc
+++ b/clusters/hosted_control_planes/hosting_service_cluster_access.adoc
@@ -37,4 +37,12 @@ oc --kubeconfig ${HOSTED_CLUSTER_NAME}.kubeconfig get nodes
 ----
 
 +
-//lahinson - aug 2023 - comment to ensure proper formatting
+//lahinson -august 2023 - adding comment to ensure proper formatting
+
+[#access-hosted-cluster-additional-resources]
+== Additional resources
+
+To configure node tuning for a hosted cluster, see the following topics:
+
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/scalability_and_performance/using-node-tuning-operator#node-tuning-hosted-cluster_node-tuning-operator[Configuring node tuning in a hosted cluster]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/scalability_and_performance/using-node-tuning-operator#advanced-node-tuning-hosted-cluster_node-tuning-operator[Advanced node tuning for hosted clusters by setting kernel boot parameters].


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-6622

This PR adds links to the node tuning docs for hosted control planes in OCP.