### PR TITLE
Fixing link syntax

### DIFF
--- a/release_notes/known_issues.adoc
+++ b/release_notes/known_issues.adoc
@@ -25,7 +25,7 @@ Review the known issues for {product-title}. The following list contains known i
 
 For your {ocp} cluster, see https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/release_notes/ocp-4-12-release-notes#ocp-4-12-known-issues[{ocp-short} known issues]. 
 
-For more about deprecations and removals, see http:..release_notes/deprecate_remove.adoc#deprecations-removals[Deprecations and removals] in the release notes.
+For more about deprecations and removals, see http:../release_notes/deprecate_remove.adoc#deprecations-removals[Deprecations and removals] in the release notes.
 
 
 * <<documentation-known-issues,Documentation known issues>>


### PR DESCRIPTION
no issue just noticed while making a change in 2.7

<img width="1063" alt="Screenshot 2023-08-23 at 8 02 44 PM" src="https://github.com/stolostron/rhacm-docs/assets/60616885/33827a4c-551b-4dcb-a7ec-f61452970e85">
