### PR TITLE
https://issues.redhat.com/browse/ACM-7007 Removal (ingress)

### DIFF
--- a/release_notes/deprecate_remove.adoc
+++ b/release_notes/deprecate_remove.adoc
@@ -175,12 +175,6 @@ A _deprecated_ component, feature, or service is supported, but no longer recomm
 | While `PlacementRule` is still available, it is not supported and the console displays `Placement` by default.
 
 | Installer
-| `ingress.sslCiphers` field in `operator.open-cluster-management.io_multiclusterhubs_crd.yaml`
-| 2.7
-| None
-| See link:../install/adv_config_install.adoc[Advanced Configuration] for configuring install.
-
-| Installer
 | `customCAConfigmap` field in `operator.open-cluster-management.io_multiclusterhubs_crd.yaml`
 | 2.7
 | None
@@ -213,6 +207,12 @@ A _removed_ item is typically function that was deprecated in previous releases 
 
 |===
 |Product or category | Affected item | Version | Recommended action | More details and links
+
+| Installer
+| `ingress.sslCiphers` field in `operator.open-cluster-management.io_multiclusterhubs_crd.yaml`
+| 2.9
+| None
+| See link:../install/adv_config_install.adoc[Advanced Configuration] for configuring install.
 
 | Governance
 | The management ingress used in previous releases is removed.


### PR DESCRIPTION
Is this enough? We still have some topics like https://github.com/stolostron/rhacm-docs/blob/2.9_stage/install/adv_config_install.adoc#sslciphers-deprecated floating around. As well as a FIPS notice about sslCiphers and various mentions here and there in the doc.