### PR TITLE
create-via annotation should be set to hypershift for hosted cluster …

### DIFF
--- a/clusters/hosted_control_planes/importing_hosted_cluster_aws.adoc
+++ b/clusters/hosted_control_planes/importing_hosted_cluster_aws.adoc
@@ -23,7 +23,7 @@ metadata:
   annotations:    
     import.open-cluster-management.io/hosting-cluster-name: local-cluster    
     import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
-    open-cluster-management/created-via: other  
+    open-cluster-management/created-via: hypershift  
   labels:    
     cloud: auto-detect    
     cluster.open-cluster-management.io/clusterset: default    


### PR DESCRIPTION
This is for story https://issues.redhat.com/browse/ACM-6547 about setting the `open-cluster-management/created-via: hypershift` annotation in the ManagedCluster CR to import a hosted cluster.