### PR TITLE
fixing incorrect ID reference in node autoscaling docs

### DIFF
--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -43,7 +43,7 @@ To create a hosted control plane cluster on {ocp-virt-short}, see the following 
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_default_ingress_dns.adoc#create-hosted-clusters-kubevirt-default-ingress-dns[Default Ingress and DNS behavior]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_default_ingress_dns.adoc#create-hosted-clusters-kubevirt-customized-ingress-dns[Customizing Ingress and DNS behavior]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc#create-hosted-clusters-kubevirt-scaling-node-pool[Scaling a node pool]
-* xref:../hosted_control_planes/node_autoscaling_hosted_cluster.adoc#enable-node-autoscaling-hosted-cluster[Enabling node auto-scaling for the hosted cluster]
+* xref:../hosted_control_planes/node_autoscaling_hosted_cluster.adoc#enable-node-auto-scaling-hosted-cluster[Enabling node auto-scaling for the hosted cluster]
 * xref:../hosted_control_planes/create_hosted_clusters_kubevirt_scaling_node_pool.adoc#create-hosted-clusters-kubevirt-adding-node-pool[Adding node pools]
 * xref:../hosted_control_planes/verifying_cluster_creation_kubevirt.adoc#verifying-cluster-creation-kubevirt[Verifying hosted cluster creation on OpenShift Virtualization]
 * xref:../hosted_control_planes/configuring_storage_kubevirt.adoc#configuring-storage-kubevirt[Configuring storage for hosted control planes on OpenShift Virtualization]


### PR DESCRIPTION
This PR fixes a broken reference in the clusters book.