### PR TITLE
[ACM-4437]: Clarifying steps to import a managed cluster

### DIFF
--- a/multicluster_engine/cluster_lifecycle/import_cli.adoc
+++ b/multicluster_engine/cluster_lifecycle/import_cli.adoc
@@ -5,7 +5,7 @@ After you install {mce}, you are ready to import a cluster to manage by using th
 
 * <<cli-prerequisites,Prerequisites>>
 * <<supported-architecture,Supported architecture>>
-* <<prepare-for-import,Prepare for import>>
+* <<prepare-for-import,Preparing for import>>
 * <<importing-the-cluster-auto-import-secret,Importing the cluster with the auto import secret>>
 * <<importing-the-cluster-manual,Importing the cluster with the manual commands>>
 * <<importing-the-klusterlet,Importing the klusterlet add-on>>
@@ -28,7 +28,7 @@ After you install {mce}, you are ready to import a cluster to manage by using th
 * macOS
 
 [#prepare-for-import]
-== Prepare for import
+== Preparing for import
 
 . Log in to your _hub cluster_ by running the following command:
 +
@@ -73,7 +73,10 @@ vendor: OpenShift
 oc apply -f managed-cluster.yaml
 ----
 
-Continue with <<importing-the-cluster-auto-import-secret,Importing the cluster with the auto import secret>> or <<importing-the-cluster-manual,Importing the cluster with the manual commands>>.
+Next, import the cluster by completing the steps in one of the following procedures:
+
+* <<importing-the-cluster-auto-import-secret,Importing the cluster with the auto import secret>> 
+* <<importing-the-cluster-manual,Importing the cluster with the manual commands>>
 
 [#importing-the-cluster-auto-import-secret]
 == Importing the cluster with the auto import secret
@@ -136,7 +139,7 @@ oc login
 oc get pod -n open-cluster-management-agent
 ----
 
-Continue with <<importing-the-klusterlet,Importing the klusterlet add-on>>.
+Next, complete the steps in <<importing-the-klusterlet,Importing the klusterlet add-on>>. Importing the add-on is a necessary step to finish the entire process of importing a cluster.
 
 [#importing-the-cluster-manual]
 == Importing the cluster with the manual commands
@@ -181,7 +184,7 @@ oc apply -f import.yaml
 oc get managedcluster ${CLUSTER_NAME}
 ----
 
-Continue with <<importing-the-klusterlet,Importing the klusterlet add-on>>.
+Next, complete the steps in <<importing-the-klusterlet,Importing the klusterlet add-on>>. Importing the add-on is a necessary step to finish the entire process of importing a cluster.
 
 [#importing-the-klusterlet]
 == Importing the klusterlet add-on


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4437

This PR clarifies the docs about importing a managed cluster to better indicate that the user needs to import the add-on in order to complete the full process to import a cluster.