### PR TITLE
[ACM-4260]: Creating ARM NodePools on AWS hosted clusters

### DIFF
--- a/clusters/hosted_control_planes/hosted_cluster_arm_aws.adoc
+++ b/clusters/hosted_control_planes/hosted_cluster_arm_aws.adoc
@@ -95,7 +95,7 @@ metadata:
   name: hypershift-arm-us-east-1a
   namespace: clusters
 spec:
-  arch: arm64
+  arch: amd64
   clusterName: hypershift-arm
   management:
     autoRepair: false
@@ -104,7 +104,7 @@ spec:
   platform:
     aws:
       instanceProfile: hypershift-arm-2m289-worker
-      instanceType: m6g.large
+      instanceType: m5.large
       rootVolume:
         size: 120
         type: gp3

--- a/clusters/hosted_control_planes/hosted_cluster_arm_aws.adoc
+++ b/clusters/hosted_control_planes/hosted_cluster_arm_aws.adoc
@@ -1,5 +1,5 @@
 [#hosted-cluster-arm-aws]
-= Enabling hosted control planes on an ARM64 {ocp-short} cluster
+= Enabling hosted control planes on an ARM64 {ocp-short} cluster (Technology Preview)
 
 You can enable an ARM64-hosted control plane to operate with an {ocp-short} ARM64 data plane in a management cluster environment. This feature is available for hosted control planes on AWS only.
 
@@ -45,3 +45,94 @@ hcp create nodepool aws \
 --name $NODEPOOL_NAME \
 --node-count=$NODEPOOL_REPLICAS
 ----
+
+[#hosted-cluster-arm-node-pools]
+== Creating ARM NodePool objects on AWS hosted clusters
+
+You can schedule application workloads (`NodePool` objects) on 64-bit ARM and AMD64 from the same hosted control plane. To do so, you define the `arch` field in the `NodePool` specification to set the required processor architecture for the `NodePool` object. The valid values for the `arch` field are as follows:
+
+* `arm64`
+* `amd64`
+
+If you do not specify a value for the `arch` field, the `amd64` value is used by default.
+
+To create an ARM `NodePool` object on a hosted cluster on AWS, complete the following steps:
+
+. Ensure that you have a multi-architecture image for the `HostedCluster` custom resource to use. You can access multi-architecture nightly images at link:https://multi.ocp.releases.ci.openshift.org/[https://multi.ocp.releases.ci.openshift.org/].
+
++
+A multi-architecture nightly image resembles the following example:
+
++
+----
+% oc image info quay.io/openshift-release-dev/ocp-release-nightly@sha256:9b992c71f77501678c091e3dc77c7be066816562efe3d352be18128b8e8fce94 -a ~/pull-secrets.json
+
+error: the image is a manifest list and contains multiple images - use --filter-by-os to select from:
+
+  OS            DIGEST
+  linux/amd64   sha256:c9dc4d07788ebc384a3d399a0e17f80b62a282b2513062a13ea702a811794a60
+  linux/ppc64le sha256:c59c99d6ff1fe7b85790e24166cfc448a3c2ac3ef3422fce3c7259e48d2c9aab
+  linux/s390x   sha256:07fcd16d5bee95196479b1e6b5b3b8064dd5359dac75e3d81f0bd4be6b8fe208
+  linux/arm64   sha256:1d93a6beccc83e2a4c56ecfc37e921fe73d8964247c1a3ec34c4d66f175d9b3d
+----
+
+. Render the `NodePool` object by entering the following command on the hosted control plane command line interface (`hcp`):
+
++
+----
+hcp create nodepool aws --cluster-name $CLUSTER_NAME --name $ARM64_NODEPOOL_NAME --node-count=$NODEPOOL_REPLICAS --render > arm_nodepool_spec.yml
+----
+
++
+The command creates a YAML file that specifies the CPU architecture for the `NodePool` object, as shown in the following example:
+
++
+----
+apiVersion: hypershift.openshift.io/v1beta1
+kind: NodePool
+metadata:
+  creationTimestamp: null
+  name: hypershift-arm-us-east-1a
+  namespace: clusters
+spec:
+  arch: arm64
+  clusterName: hypershift-arm
+  management:
+    autoRepair: false
+    upgradeType: Replace
+  nodeDrainTimeout: 0s
+  platform:
+    aws:
+      instanceProfile: hypershift-arm-2m289-worker
+      instanceType: m6g.large
+      rootVolume:
+        size: 120
+        type: gp3
+      securityGroups:
+      - id: sg-064ea63968d258493
+      subnet:
+        id: subnet-02c74cf1cf1e7413f
+    type: AWS
+  release:
+    image: quay.io/openshift-release-dev/ocp-release-nightly@sha256:390a33cebc940912a201a35ca03927ae5b058fbdae9626f7f4679786cab4fb1c
+  replicas: 3
+status:
+  replicas: 0
+----
+
+. Modify the `arch` and `instanceType` values in the YAML file by entering the following command. In the command, the ARM instance type is `m6g.large`, but any ARM instance type works:
+
++
+----
+sed 's/arch: amd64/arch: arm64/g; s/instanceType: m5.large/instanceType: m6g.large/g' arm_nodepool_spec.yml > temp.yml && mv temp.yml arm_nodepool_spec.yml
+----
+
+. Apply the rendered YAML file to the hosted cluster by entering the following command:
+
++
+----
+oc apply -f arm_nodepool_spec.yml
+----
+
++
+//lahinson - sept. 2023 - adding comment to ensure proper formatting

--- a/clusters/hosted_control_planes/hosted_cluster_arm_aws.adoc
+++ b/clusters/hosted_control_planes/hosted_cluster_arm_aws.adoc
@@ -87,6 +87,7 @@ hcp create nodepool aws --cluster-name $CLUSTER_NAME --name $ARM64_NODEPOOL_NAME
 The command creates a YAML file that specifies the CPU architecture for the `NodePool` object, as shown in the following example:
 
 +
+[source,yaml]
 ----
 apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-4260

This PR adds documentation about creating ARM NodePools in hosted clusters on AWS.