### PR TITLE
https://issues.redhat.com/browse/ACM-7071 Remove API 2.9

### DIFF
--- a/release_notes/deprecate_remove.adoc
+++ b/release_notes/deprecate_remove.adoc
@@ -71,7 +71,7 @@ Learn when parts of the product are deprecated or removed from {product-title}. 
 | The `v1beta1` API is removed.
 | 2.9
 | Use `v1beta2` instead.
-| ManagedClusterSetBindings.cluster.open-cluster-management.io
+| `ManagedClusterSetBindings.cluster.open-cluster-management.io`
 
 | HypershiftDeployment
 | The `HypershiftDeployment` API is removed.

--- a/release_notes/deprecate_remove.adoc
+++ b/release_notes/deprecate_remove.adoc
@@ -65,7 +65,7 @@ Learn when parts of the product are deprecated or removed from {product-title}. 
 | The `v1beta1` API is removed.
 | 2.9
 | Use `v1beta2` instead.
-| ManagedClusterSets.cluster.open-cluster-management.io
+| `ManagedClusterSets.cluster.open-cluster-management.io`
 
 | ManagedClusterSetBindings
 | The `v1beta1` API is removed.

--- a/release_notes/deprecate_remove.adoc
+++ b/release_notes/deprecate_remove.adoc
@@ -53,18 +53,6 @@ Learn when parts of the product are deprecated or removed from {product-title}. 
 | None 
 | The deployable API remains just for upgrade path. Any deployable CR create, update, or delete will not get reconciled.
 
-| ManagedClusterSets
-| The `v1beta1` API is upgraded to `v1beta2` because `v1beta1` is deprecated. 
-| 2.7 
-| Use `v1beta2`. 
-| None
-
-| ManagedClusterSetBindings
-| The `v1beta1` API is upgraded to `v1beta2` because `v1beta1` is deprecated. 
-| 2.7 
-| Use `v1beta2`. 
-| None
-
 |===	
 
 [#api-removals]

--- a/release_notes/deprecate_remove.adoc
+++ b/release_notes/deprecate_remove.adoc
@@ -73,6 +73,18 @@ Learn when parts of the product are deprecated or removed from {product-title}. 
 |===
 | Product or category | Affected item | Version | Recommended action | More details and links
 
+| ManagedClusterSets
+| The `v1beta1` API is removed.
+| 2.9
+| Use `v1beta2` instead.
+| ManagedClusterSets.cluster.open-cluster-management.io
+
+| ManagedClusterSetBindings
+| The `v1beta1` API is removed.
+| 2.9
+| Use `v1beta2` instead.
+| ManagedClusterSetBindings.cluster.open-cluster-management.io
+
 | HypershiftDeployment
 | The `HypershiftDeployment` API is removed.
 | 2.7
@@ -96,18 +108,6 @@ Learn when parts of the product are deprecated or removed from {product-title}. 
 | 2.7
 | Use `v1beta1` instead.
 | PlacementDecisions.cluster.open-cluster-management.io
-
-| ManagedClusterSets
-| The `v1alpha1` API is removed.
-| 2.7
-| Use `v1beta1` instead.
-| ManagedClusterSets.cluster.open-cluster-management.io
-
-| ManagedClusterSetBindings
-| The `v1alpha1` API is removed.
-| 2.7
-| Use `v1beta1` instead.
-| ManagedClusterSetBindings.cluster.open-cluster-management.io
 
 | ClusterManagementAddOn
 | The field `addOnConfiguration` is deprecated in the `ClusterManagementAddOn` spec.  


### PR DESCRIPTION
Should we remove the deprecated entries for the 2 APIs as well?