### PR TITLE
[ACM-3981]: Adding disconnected docs for AWS

### DIFF
--- a/clusters/hosted_control_planes/configure_hosted_disconnected.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_disconnected.adoc
@@ -1,0 +1,39 @@
+[#configure-hosted-disconnected]
+= Configuring hosted control planes in a disconnected environment
+
+The `hypershift-addon` managed cluster add-on enables the `--enable-uwm-telemetry-remote-write` option in the HyperShift Operator. By enabling that option, you ensure that user workload monitoring is enabled and that it can remotely write telemetry metrics from control planes. 
+
+If you installed {mce-short} on {ocp-short} clusters that are not connected to the internet, when you try to run the user workload monitoring feature of the HyperShift Operator by entering the following command, the feature fails with an error:
+
+----
+oc get events -n hypershift
+----
+
+The error might look like this example:
+
+----
+LAST SEEN   TYPE      REASON           OBJECT                MESSAGE
+4m46s       Warning   ReconcileError   deployment/operator   Failed to ensure UWM telemetry remote write: cannot get telemeter client secret: Secret "telemeter-client" not found
+----
+
+To avoid that error, you must disable the user workload monitoring option by creating a config map in the `local-cluster` namespace. You can create the config map either before or after you enable the add-on. The add-on agent reconfigures the HyperShift Operator.
+
+. Create the following config map:
+
++
+[source,yaml]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hypershift-operator-install-flags
+  namespace: local-cluster
+data:
+  installFlagsToAdd: ""
+  installFlagsToRemove: "--enable-uwm-telemetry-remote-write"
+----
+
+//For more information about the config map, see the HyperShift Operator configuration options. ADD LINK
+
+[#verify-hosted-control-plane-feature]
+== 

--- a/clusters/hosted_control_planes/configure_hosted_disconnected.adoc
+++ b/clusters/hosted_control_planes/configure_hosted_disconnected.adoc
@@ -18,9 +18,8 @@ LAST SEEN   TYPE      REASON           OBJECT                MESSAGE
 
 To avoid that error, you must disable the user workload monitoring option by creating a config map in the `local-cluster` namespace. You can create the config map either before or after you enable the add-on. The add-on agent reconfigures the HyperShift Operator.
 
-. Create the following config map:
+Create the following config map:
 
-+
 [source,yaml]
 ----
 kind: ConfigMap
@@ -33,7 +32,83 @@ data:
   installFlagsToRemove: "--enable-uwm-telemetry-remote-write"
 ----
 
-//For more information about the config map, see the HyperShift Operator configuration options. ADD LINK
-
 [#verify-hosted-control-plane-feature]
-== 
+== Verifying the status of the hosted control plane feature 
+
+Starting with {mce-short} 2.4, the hosted control plane feature is enabled by default. 
+
+. If the feature is disabled and you want to enable it, enter the following command. Replace `multiclusterengine` with the name of your {mce-short} instance:
+
++
+----
+oc patch mce <multiclusterengine> --type=merge -p '{"spec":{"overrides":{"components":[{"name":"hypershift","enabled": true}]}}}'
+----
+
++
+When you enable the feature, the `hypershift-addon` managed cluster add-on is installed in the `local-cluster` managed cluster, and the add-on agent installs the HyperShift Operator on the {mce-short} hub cluster.
+
+. Confirm that the `hypershift-addon` managed cluster add-on is installed by entering the following command:
+
++
+----
+oc get managedclusteraddons -n local-cluster hypershift-addon
+----
+
+. See the resulting output:
+
++
+----
+NAME               AVAILABLE   DEGRADED   PROGRESSING
+hypershift-addon   True        False
+----
+
+. To avoid a timeout during this process, enter the following commands:
+
++
+----
+oc wait --for=condition=Degraded=True managedclusteraddons/hypershift-addon -n local-cluster --timeout=5m
+----
+
++
+----
+oc wait --for=condition=Available=True managedclusteraddons/hypershift-addon -n local-cluster --timeout=5m
+----
+
++
+When the process is complete, the `hypershift-addon` managed cluster add-on and the HyperShift Operator are installed, and the `local-cluster` managed cluster is available to host and manage hosted clusters.
+
+[#configure-addon-infra-node]
+== Configuring the hypershift-addon managed cluster add-on to run on an infrastructure node
+
+By default, no node placement preference is specified for the `hypershift-addon` managed cluster add-on. Consider running the add-ons on the infrastructure nodes, because by doing so, you can prevent incurring billing costs against subscription counts and separate maintenance and management tasks.
+
+. Log in to the hub cluster.
+
+. Open the `hypershift-addon-deploy-config` add-on deployment config specification for editing by entering the following command:
+
++
+----
+oc edit addondeploymentconfig hypershift-addon-deploy-config -n multicluster-engine
+----
+
+. Add the `nodePlacement` field to the specification, as shown in the following example:
+
++
+[source,yaml]
+----
+apiVersion: addon.open-cluster-management.io/v1alpha1
+kind: AddOnDeploymentConfig
+metadata:
+  name: hypershift-addon-deploy-config
+  namespace: multicluster-engine
+spec:
+  nodePlacement:
+    nodeSelector:
+      node-role.kubernetes.io/infra: ""
+    tolerations:
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      operator: Exists 
+----
+
+. Save the changes. The `hypershift-addon` managed cluster add-on is deployed on an infrastructure node for new and existing managed clusters.


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-3981

From Roke:
>In https://github.com/stolostron/rhacm-docs/blob/2.8_stage/clusters/hosted_control_planes/configure_hosted_aws.adoc, add https://github.com/stolostron/hypershift-addon-operator/blob/main/docs/provision_hosted_cluster_on_mce_local_cluster.md#disconnected-environment-configuration]before the https://github.com/stolostron/rhacm-docs/blob/2.8_stage/clusters/hosted_control_planes/configure_hosted_aws.adoc#enabling-the-hosted-control-planes-feature section.