### PR TITLE
ACM-6974: Update bare metal version for hosted control planes

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -9,7 +9,7 @@ The following table indicates which {ocp-short} versions are supported for each 
 
 |===
 | Platform | Hosting {ocp-short} version | Minimum hosted {ocp-short} version
-| Bare metal | 4.11 - 4.14 | 4.14
+| Bare metal | 4.14 | 4.14
 | {ocp-virt} | 4.14 | 4.14
 | AWS (Technology Preview) | 4.11 - 4.14 | 4.14
 |===


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-6974

This PR updates the versions for bare metal from 4.11-4.14 to 4.14, per a discussion with Adel and Roke on Slack.