### PR TITLE
Changes to clarify the process (ready for editor)

### DIFF
--- a/clusters/support_troubleshooting/trouble_network_config_bm.adoc
+++ b/clusters/support_troubleshooting/trouble_network_config_bm.adoc
@@ -1,7 +1,7 @@
 [#troubleshooting-network-config-fail]
 = Troubleshooting: Adding day-two nodes to an existing cluster fails with pending user action
 
-Adding a node (scale out) to your existing cluster that is created by the {mce} with  Zero Touch Provisioning or Host inventory create methods fails during installation. The installation process works correctly during the Discovery phase, but fails on the installation phase. 
+Adding a node, or scaling out, to your existing cluster that is created by the {mce} with Zero Touch Provisioning or Host inventory create methods fails during installation. The installation process works correctly during the Discovery phase, but fails on the installation phase. 
 
 The configuration of the network is failing. Using the console, you see a `pending` user action. In the description, you can see it failing on the rebooting step.
 
@@ -12,10 +12,10 @@ The error message about failing is not very accurate, since the agent cannot rep
 
 At the Discover phase, the host cannot configure the network. Check for the following symptoms and messages:
 
-* In the console, check for `Pending` user action on the adding node:
+* In the console, check for `Pending` user action on the adding node, with the `Rebooting` indicator:
 +
 ----
-This host is pending user action. Host timed out when pulling ignition. Check the host console... *Rebooting*
+This host is pending user action. Host timed out when pulling ignition. Check the host console... Rebooting
 ----
 
 * Check all the `MachineConfings` of the existing cluster. Check if any of the `MachineConfigs` create any file on the following directories: 

--- a/clusters/support_troubleshooting/trouble_network_config_bm.adoc
+++ b/clusters/support_troubleshooting/trouble_network_config_bm.adoc
@@ -1,7 +1,9 @@
 [#troubleshooting-network-config-bm]
-= Troubleshooting network configuration for bare metal clusters
+= Adding day-2 nodes to an existing cluster fails pending user action
 
-When you have a cluster that is installed by the Infrastructure Operator for Red Hat OpenShift, you must manually update the network configuration for your hub cluster to install workers.
+Adding a new node (scale out) to your existing cluster created by the multicluster engine for Kubernetes (MCE), with  Zero Touch Provisioning (ZTP) or Host inventory create methods. The installation on this node fails. More on concrete, the installation goes oka during the first (discovery phase), but it fails on the installation phase. Using RHACM GUI you will see a pending user action. In the description, you can see it is failing on the rebooting step.
+
+The configuration of the network is failing. Therefore, the message on what could be failing would be not very accurate. Because the agent cannot longer report information back.
  
 [#symptom-worker-node-fail]
 == Symptom: Installation for day two workers fails

--- a/clusters/support_troubleshooting/trouble_network_config_bm.adoc
+++ b/clusters/support_troubleshooting/trouble_network_config_bm.adoc
@@ -1,7 +1,7 @@
 [#troubleshooting-network-config-bm]
-= Adding day-2 nodes to an existing cluster fails pending user action
+= Adding day-2 nodes to an existing cluster fails with pending user action
 
-Adding a new node (scale out) to your existing cluster created by the multicluster engine for Kubernetes (MCE), with  Zero Touch Provisioning (ZTP) or Host inventory create methods. The installation on this node fails. More on concrete, the installation goes oka during the first (discovery phase), but it fails on the installation phase. Using RHACM GUI you will see a pending user action. In the description, you can see it is failing on the rebooting step.
+Adding a new node (scale out) to your existing cluster created by the multicluster engine for Kubernetes (MCE), with  Zero Touch Provisioning (ZTP) or Host inventory create methods. The installation on this node fails. More on concrete, the installation works correctly during the discovery phase, but it fails on the installation phase. Using RHACM GUI you will see a pending user action. In the description, you can see it is failing on the rebooting step.
 
 The configuration of the network is failing. Therefore, the message on what could be failing would be not very accurate. Because the agent cannot longer report information back.
  
@@ -9,33 +9,34 @@ The configuration of the network is failing. Therefore, the message on what coul
 == Symptom: Installation for day two workers fails
 
 At the Discover phase, the host cannot configure the network. Check for the following symptoms and messages:
-----
-This host is pending user action. Host timed out when pulling ignition. Check the host console...
-----
 
-Also check all the MCs (we need this actual term) from the `/sysroot/etc/NetworkManager/system-connections/` or `/sysroot/etc/sysconfig/network-scripts/` file paths. 
+ * Check, that RHACM GUI shows an Pending user action on the adding node.
+====
+This host is pending user action. Host timed out when pulling ignition. Check the host console... *Rebooting*
+====
+ * Check all the MachineConfings of the currently existing cluster. Check if any of the MachineConfigs create any file on the following directories: 
+    ** `/sysroot/etc/NetworkManager/system-connections/` 
+    ** `/sysroot/etc/sysconfig/network-scripts/` 
 
-Check the failing host for the following messages:
+ * Check the failing host (console or journalctl) for the following messages:
+====
+info: networking config is defined in the real root
 
-----
-system: Stopped Create Volatile Files and Directories...
-----
-----
-system: Stopped target Swap...
-----
+info: will not attempt to propagate initramfs networking
+====
+Actually, this last message is the real problem. The networking configuration is not been propagated. Because it already found an existing network configuration on the folders listed above.
 
 [#resolving-cluster-rotating-agents]
-== Resolving the problem: Manually configure the network
+== Resolving the problem: Recreate the node merging network configuration
 
 Perform the following task to manually configure your network:
 
-. Delete the node from your hub cluster.
-. Create your cluster from the console again.
-. Add or append the following annotation to the BMH of the new node:
-
-----
+. Delete the node from your hub cluster
+. Repeat your previous process to install the node in the same way
+. This time, add the following annotation to the BareMetalHost (BMH) object of the new node: 
+====
 "bmac.agent-install.openshift.io/installer-args": "[\"--append-karg\", \"coreos.force_persist_ip\"]"
-----
+====
 
-The node starts the installation, and after the Discovery phase, merges the network configuration between your changes and the initial phase.
+The node starts the installation. After the Discovery phase, it will reboot. This time, it merges the network configuration between the changes on the existint cluster and the initial configuration.
 

--- a/clusters/support_troubleshooting/trouble_network_config_bm.adoc
+++ b/clusters/support_troubleshooting/trouble_network_config_bm.adoc
@@ -1,42 +1,50 @@
-[#troubleshooting-network-config-bm]
-= Adding day-2 nodes to an existing cluster fails with pending user action
+[#troubleshooting-network-config-fail]
+= Troubleshooting: Adding day-two nodes to an existing cluster fails with pending user action
 
-Adding a new node (scale out) to your existing cluster created by the multicluster engine for Kubernetes (MCE), with  Zero Touch Provisioning (ZTP) or Host inventory create methods. The installation on this node fails. More on concrete, the installation works correctly during the discovery phase, but it fails on the installation phase. Using RHACM GUI you will see a pending user action. In the description, you can see it is failing on the rebooting step.
+Adding a node (scale out) to your existing cluster that is created by the {mce} with  Zero Touch Provisioning or Host inventory create methods fails during installation. The installation process works correctly during the Discovery phase, but fails on the installation phase. 
 
-The configuration of the network is failing. Therefore, the message on what could be failing would be not very accurate. Because the agent cannot longer report information back.
+The configuration of the network is failing. Using the console, you see a `pending` user action. In the description, you can see it failing on the rebooting step.
+
+The error message about failing is not very accurate, since the agent cannot report information.
  
-[#symptom-worker-node-fail]
+[#symptom-network-config-fail]
 == Symptom: Installation for day two workers fails
 
 At the Discover phase, the host cannot configure the network. Check for the following symptoms and messages:
 
- * Check, that RHACM GUI shows an Pending user action on the adding node.
-====
+- In the console, check for `Pending` user action on the adding node:
++
+----
 This host is pending user action. Host timed out when pulling ignition. Check the host console... *Rebooting*
-====
- * Check all the MachineConfings of the currently existing cluster. Check if any of the MachineConfigs create any file on the following directories: 
-    ** `/sysroot/etc/NetworkManager/system-connections/` 
-    ** `/sysroot/etc/sysconfig/network-scripts/` 
+----
 
- * Check the failing host (console or journalctl) for the following messages:
-====
+- Check all the `MachineConfings` of the existing cluster. Check if any of the `MachineConfigs` create any file on the following directories: 
+
+- `/sysroot/etc/NetworkManager/system-connections/` 
+- `/sysroot/etc/sysconfig/network-scripts/` 
+
+In the console, check the failing host for the following messages. You can also use `journalctl` to see the log messages:
+
+----
 info: networking config is defined in the real root
 
 info: will not attempt to propagate initramfs networking
-====
-Actually, this last message is the real problem. The networking configuration is not been propagated. Because it already found an existing network configuration on the folders listed above.
+----
 
-[#resolving-cluster-rotating-agents]
+If you get the last message in the log, the networking configuration is not propagated because it already found an existing network configuration on the folders previously listed in the _Symptom_.
+
+[#resolving-network-config-fail]
 == Resolving the problem: Recreate the node merging network configuration
 
 Perform the following task to manually configure your network:
 
 . Delete the node from your hub cluster
-. Repeat your previous process to install the node in the same way
-. This time, add the following annotation to the BareMetalHost (BMH) object of the new node: 
-====
-"bmac.agent-install.openshift.io/installer-args": "[\"--append-karg\", \"coreos.force_persist_ip\"]"
-====
+. Repeat your previous process to install the node as you did before.
+. Then, add the following annotation to the `BareMetalHost` object of the new node: 
 
-The node starts the installation. After the Discovery phase, it will reboot. This time, it merges the network configuration between the changes on the existint cluster and the initial configuration.
+----
+"bmac.agent-install.openshift.io/installer-args": "[\"--append-karg\", \"coreos.force_persist_ip\"]"
+----
+
+The node starts the installation and after the Discovery phase, it reboots. With succes, it merges the network configuration between the changes on the existing cluster and the initial configuration.
 

--- a/clusters/support_troubleshooting/trouble_network_config_bm.adoc
+++ b/clusters/support_troubleshooting/trouble_network_config_bm.adoc
@@ -12,16 +12,16 @@ The error message about failing is not very accurate, since the agent cannot rep
 
 At the Discover phase, the host cannot configure the network. Check for the following symptoms and messages:
 
-- In the console, check for `Pending` user action on the adding node:
+* In the console, check for `Pending` user action on the adding node:
 +
 ----
 This host is pending user action. Host timed out when pulling ignition. Check the host console... *Rebooting*
 ----
 
-- Check all the `MachineConfings` of the existing cluster. Check if any of the `MachineConfigs` create any file on the following directories: 
+* Check all the `MachineConfings` of the existing cluster. Check if any of the `MachineConfigs` create any file on the following directories: 
 
-- `/sysroot/etc/NetworkManager/system-connections/` 
-- `/sysroot/etc/sysconfig/network-scripts/` 
+ ** `/sysroot/etc/NetworkManager/system-connections/` 
+ ** `/sysroot/etc/sysconfig/network-scripts/` 
 
 In the console, check the failing host for the following messages. You can also use `journalctl` to see the log messages:
 
@@ -41,7 +41,7 @@ Perform the following task to manually configure your network:
 . Delete the node from your hub cluster
 . Repeat your previous process to install the node as you did before.
 . Then, add the following annotation to the `BareMetalHost` object of the new node: 
-
++
 ----
 "bmac.agent-install.openshift.io/installer-args": "[\"--append-karg\", \"coreos.force_persist_ip\"]"
 ----


### PR DESCRIPTION
Hi have added some changes to explain the problem, the process and how to fix it.

I have asked people on Assisted Installer to use the proper terminology, specially for the first section. They recommended me to use the entry as:

"Adding a new node (scale out) to your existing cluster created by the multicluster engine for Kubernetes (MCE), with  Zero Touch Provisioning (ZTP) or Host inventory create methods."

specially about using multicluster engine for kubernetes. That means, that the cluster was installed by the AI, using ZTP or just Host Inventory. 