### PR TITLE
No Jira: Updating OCP links to 4.14

### DIFF
--- a/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
+++ b/clusters/hosted_control_planes/configuring_storage_kubevirt.adoc
@@ -111,7 +111,7 @@ hcp create cluster kubevirt \
 [#kubevirt-storage-config-additional-resources]
 === Additional resources
 
-* link:https://docs.openshift.com/container-platform/4.14/virt/virtual_machines/virtual_disks/virt-cloning-a-datavolume-using-smart-cloning.html[Cloning a data volume using smart-cloning]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/virtualization/virtual-machines#virt-cloning-a-datavolume-using-smart-cloning[Cloning a data volume using smart-cloning]
 
 
 

--- a/clusters/hosted_control_planes/dr_hosted_cluster.adoc
+++ b/clusters/hosted_control_planes/dr_hosted_cluster.adoc
@@ -3,6 +3,6 @@
 
 The hosted control plane runs on the {mce-short} hub cluster. The data plane runs on a separate platform that you choose. When recovering the {mce-short} hub cluster from a disaster, you might also want to recover the hosted control planes.
 
-See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/hosted_control_planes/hcp-backup-restore-dr#hcp-dr-aws[Disaster recovery for a hosted cluster within an AWS region] to learn how to back up a hosted control plane cluster and restore it on a different cluster.
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-backup-restore-dr#hcp-dr-aws[Disaster recovery for a hosted cluster within an AWS region] to learn how to back up a hosted control plane cluster and restore it on a different cluster.
 
 *Important:* Disaster recovery for hosted clusters is available on AWS only.

--- a/clusters/hosted_control_planes/handling_ingress_hosted.adoc
+++ b/clusters/hosted_control_planes/handling_ingress_hosted.adoc
@@ -210,4 +210,4 @@ clusteroperator.config.openshift.io/storage                                    4
 [#handling-ingress-additional-resources]
 == Additional resources
 
-* For more information about MetalLB, see link:https://docs.openshift.com/container-platform/4.14/networking/metallb/about-metallb.html[About MetalLB and the MetalLB Operator] in the {ocp-short} documentation.
+* For more information about MetalLB, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/networking/load-balancing-with-metallb#about-metallb[About MetalLB and the MetalLB Operator] in the {ocp-short} documentation.

--- a/clusters/hosted_control_planes/hosting_service_cluster_configure_metallb.adoc
+++ b/clusters/hosted_control_planes/hosting_service_cluster_configure_metallb.adoc
@@ -48,4 +48,4 @@ spec:
 [#managing-hosted-kubevirt-additional-resources]
 == Additional resources
 
-* For more information about MetalLB, see link:https://docs.openshift.com/container-platform/4.14/networking/metallb/metallb-operator-install.html[Installing the MetalLB Operator].
+* For more information about MetalLB, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/networking/load-balancing-with-metallb#metallb-operator-install[Installing the MetalLB Operator].

--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -21,5 +21,5 @@ xref:../hosted_control_planes/node_autoscaling_hosted_cluster.adoc#enable-node-a
 [#additional-resources-manage-bm]
 === Additional resources
 
-* You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_4.14/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.
+* You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.
 

--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -21,5 +21,5 @@ xref:../hosted_control_planes/node_autoscaling_hosted_cluster.adoc#enable-node-a
 [#additional-resources-manage-bm]
 === Additional resources
 
-* You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.
+* You can now deploy the SR-IOV Operator. See link:https://access.redhat.com/documentation/en-us/openshift_4.14/html/networking/hardware-networks#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes] to learn more about deploying the SR-IOV Operator.
 

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -20,9 +20,9 @@ You must meet the following prerequisites to create an {ocp-short} cluster on {o
 ----
 oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p '[{ "op": "add", "path": "/spec/routeAdmission", "value": {wildcardPolicy: "WildcardsAllowed"}}]'
 ----
-- The {ocp-short} managed cluster must have {ocp-virt-short}, version 4.14 or later, installed on it. For more information, see link:https://docs.openshift.com/container-platform/4.14/virt/install/installing-virt-web.html[Installing OpenShift Virtualization using the web console].
+- The {ocp-short} managed cluster must have {ocp-virt-short}, version 4.14 or later, installed on it. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/virtualization/installing#installing-virt-web[Installing OpenShift Virtualization using the web console].
 - The {ocp-short} managed cluster must be configured with OVNKubernetes as the default pod network CNI.
-- The {ocp-short} managed cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.14/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. The following example shows how to set a default storage class:
+- The {ocp-short} managed cluster must have a default storage class. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/post-installation_configuration/post-install-storage-configuration[Post-installation storage configuration]. The following example shows how to set a default storage class:
 
 +
 ----


### PR DESCRIPTION
This PR ensures that any links to the OCP docs within the hosted control planes docs point to the OCP 4.14 docs on the portal.