### PR TITLE
ACM-7909: add a note about uniqueness of hosted cluster names

### DIFF
--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -1,7 +1,7 @@
 [#hosted-control-planes-manage-aws]
 = Managing hosted control plane clusters on AWS (Technology Preview)
 
-You can use the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
+You can use the hosted control plane command line interface (`hcp`) to create an {ocp-short} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you want to disable this automatic import feature, see xref:../hosted_control_planes/hosted_disable_auto_import.adoc#hosted-disable-auto-import[Disabling the automatic import of hosted clusters into {mce-short}].
 
 Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
 

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -3,7 +3,7 @@
 
 You can use the hosted control plane command line interface (`hcp`) to create an {ocp-short} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you want to disable this automatic import feature, see xref:../hosted_control_planes/hosted_disable_auto_import.adoc#hosted-disable-auto-import[Disabling the automatic import of hosted clusters into {mce-short}].
 
-Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
+*Note:* Each hosted cluster must have a unique name in order for {mce-short} to manage it.
 
 //lahinson - july 2023 - should we specify which CLI we're referring to in the latter sentence?
 

--- a/clusters/hosted_control_planes/managing_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_aws.adoc
@@ -1,7 +1,10 @@
 [#hosted-control-planes-manage-aws]
 = Managing hosted control plane clusters on AWS (Technology Preview)
 
-You can use the {mce} console to create a {ocp} hosted cluster. If you use hosted control planes on AWS, you can create a hosted cluster by using the console, or you can import a hosted cluster by using either the console or the command line interface.
+You can use the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
+
+Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
+
 //lahinson - july 2023 - should we specify which CLI we're referring to in the latter sentence?
 
 [#hosted-prerequisites-aws]

--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -1,7 +1,9 @@
 [#hosted-control-planes-manage-bm]
 = Managing hosted control plane clusters on bare metal
 
-You can use the {mce} console to create and manage a {ocp} hosted cluster. Hosted control planes are available as a Technology Preview on bare metal.
+You can use the {mce} console or the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
+
+Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
 
 [#hosted-prerequisites-bm]
 == Prerequisites

--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -1,7 +1,7 @@
 [#hosted-control-planes-manage-bm]
 = Managing hosted control plane clusters on bare metal
 
-You can use the {mce} console or the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
+You can use the {mce-short} console or the hosted control plane command line interface (`hcp`) to create an {ocp-short} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you want to disable this automatic import feature, see xref:../hosted_control_planes/hosted_disable_auto_import.adoc#hosted-disable-auto-import[Disabling the automatic import of hosted clusters into {mce-short}].
 
 Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
 

--- a/clusters/hosted_control_planes/managing_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_bm.adoc
@@ -3,7 +3,7 @@
 
 You can use the {mce-short} console or the hosted control plane command line interface (`hcp`) to create an {ocp-short} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you want to disable this automatic import feature, see xref:../hosted_control_planes/hosted_disable_auto_import.adoc#hosted-disable-auto-import[Disabling the automatic import of hosted clusters into {mce-short}].
 
-Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
+*Note:* Each hosted cluster must have a unique name in order for {mce-short} to manage it.
 
 [#hosted-prerequisites-bm]
 == Prerequisites

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -8,7 +8,7 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 * Reduces cluster provision time by eliminating the bare metal node bootstrapping process
 * Manages many releases under the same base {ocp-short} cluster
 
-You can use the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
+You can use the hosted control plane command line interface (`hcp`) to create an {ocp-short} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you want to disable this automatic import feature, see xref:../hosted_control_planes/hosted_disable_auto_import.adoc#hosted-disable-auto-import[Disabling the automatic import of hosted clusters into {mce-short}].
 
 *Note:* Each hosted cluster must have a unique name in order for {mce-short} to manage it.
 

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -10,7 +10,7 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 
 You can use the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
 
-Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
+*Note:* Each hosted cluster must have a unique name in order for {mce-short} to manage it.
 
 [#create-hosted-clusters-prereqs-kubevirt]
 == Prerequisites

--- a/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
+++ b/clusters/hosted_control_planes/managing_hosted_kubevirt.adoc
@@ -8,6 +8,10 @@ With hosted control planes and {ocp-virt}, you can create {ocp-short} clusters w
 * Reduces cluster provision time by eliminating the bare metal node bootstrapping process
 * Manages many releases under the same base {ocp-short} cluster
 
+You can use the hcp command line interface to create a {ocp} hosted cluster. The hosted cluster is automatically imported as a managed cluster. If you wish to disable this automatic import feature, refer to https://github.com/stolostron/rhacm-docs/blob/2.9_stage/clusters/hosted_control_planes/hosted_disable_auto_import.adoc.
+
+Note: Each hosted cluster must have a unique name in order of {mce-short} to manage it.
+
 [#create-hosted-clusters-prereqs-kubevirt]
 == Prerequisites
 


### PR DESCRIPTION
This is for https://issues.redhat.com/browse/ACM-7563, https://issues.redhat.com/browse/ACM-7909.

We need to add a note about MCE's requirement that each hosted cluster must have a unique name to be managed by MCE or ACM. 

Also a correction for BareMetal that it is not tech-preview any more.