### PR TITLE
https://issues.redhat.com/browse/ACM-7660 Update fips_readiness.adoc

### DIFF
--- a/release_notes/fips_readiness.adoc
+++ b/release_notes/fips_readiness.adoc
@@ -10,9 +10,7 @@ If you plan to manage clusters with FIPS enabled, you must have a FIPS-ready hub
 [#fips-limitations]
 == Limitations 
 
-Read the following limitations with {product-title-short} and FIPS.
-
-* {ocp} only supports FIPS on the `x86_64` architecture. 
+Read the following limitations with {product-title-short} and FIPS. 
 
 * Persistent Volume Claim (PVC) and S3 storage that is used by the search and observability components must be encrypted when you configure the provided storage. {product-title-short} does not provide storage encryption, see the {ocp-short} documentation, link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/installing/installing-fips[Support for FIPS cryptography].
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7660

Removing the bullet point that mentioned ocp only supported x86_64 architecture bc we list the architectures