### PR TITLE
[Contributed, no issue, need dev/qe] Remove the escaping of nodeSelector and tolerations in ManagedCluster

### DIFF
--- a/clusters/cluster_lifecycle/adv_config_cluster.adoc
+++ b/clusters/cluster_lifecycle/adv_config_cluster.adoc
@@ -127,10 +127,8 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   annotations:
-    open-cluster-management/nodeSelector: '{\"dedicated\":\"acm\"}'
-    open-cluster-management/tolerations: '[
-{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"acm\",\"effect\":\"NoSchedule\"}
-]' 
+    open-cluster-management/nodeSelector: '{"dedicated":"acm"}'
+    open-cluster-management/tolerations: '[{"key":"dedicated","operator":"Equal","value":"acm","effect":"NoSchedule"}]' 
 ----
 
 [#add-resources-adv-cluster]

--- a/clusters/cluster_lifecycle/import_gui.adoc
+++ b/clusters/cluster_lifecycle/import_gui.adoc
@@ -163,10 +163,8 @@ apiVersion: cluster.open-cluster-management.io/v1
 kind: ManagedCluster
 metadata:
   annotations:
-    open-cluster-management/nodeSelector: '{\"dedicated\":\"acm\"}'
-    open-cluster-management/tolerations: '[
-{\"key\":\"dedicated\",\"operator\":\"Equal\",\"value\":\"acm\",\"effect\":\"NoSchedule\"}
-]' 
+    open-cluster-management/nodeSelector: '{"dedicated":"acm"}'
+    open-cluster-management/tolerations: '[{"key":"dedicated","operator":"Equal","value":"acm","effect":"NoSchedule"}]' 
 ----
 
 You can also use a `KlusterletConfig` to configure the `nodeSelector` and `tolerations` for the managed cluster. Complete the following steps to configure these settings:


### PR DESCRIPTION
We recently installed ACM on our cluster and noticed a documentation error when installing 'ManagedCluster' resources on the infra nodes with a custom nodeSelector and tolerations.

Both annotations must not include escaped double quotes, as otherwise, the cluster cannot be imported into the hub.