### PR TITLE
No Jira: Commenting out xref to cim_adv_config.adoc

### DIFF
--- a/clusters/cluster_lifecycle/cim_create_cli.adoc
+++ b/clusters/cluster_lifecycle/cim_create_cli.adoc
@@ -152,5 +152,6 @@ You can continue by configuring static networking, if required, and begin adding
 == Additional resources
 
 - See xref:../cluster_lifecycle/cim_enable.adoc#enable-cim[Enabling the central infrastructure management service].
-- See xref:../cluster_lifecycle/cim_adv_config.adoc#cim-configure-networking[Configuring advanced networking for a host inventory].
+//lahinson - oct. 31 2023 - commenting out the following xref temporarily, as it references a file not found
+//- See xref:../cluster_lifecycle/cim_adv_config.adoc#cim-configure-networking[Configuring advanced networking for a host inventory].
 - Return to <<create-host-inventory-console,Creating a host inventory by using the console>>.


### PR DESCRIPTION
I temporarily commented out an xref in `cim_create_cli.adoc` because the xref seems to be pointing to a nonexistent file.