### PR TITLE
[ACM-8528] Improve title: CRD -> Custom Resource (after GA)

### DIFF
--- a/gitops/gitops_push_pull.adoc
+++ b/gitops/gitops_push_pull.adoc
@@ -1,7 +1,7 @@
 [#gitops-push-pull]
-= Deploying Argo CD with Push and Pull model 
+= Deploying Argo CD with Push and Pull model
 
-Using a _Push model_, The Argo CD server on the hub cluster deploys the application resources on the managed clusters. For the _Pull model_(Technology Preview), the application resources are propagated by the _Propagation controller_ to the managed clusters by using `manifestWork`. 
+Using a _Push model_, The Argo CD server on the hub cluster deploys the application resources on the managed clusters. For the _Pull model_(Technology Preview), the application resources are propagated by the _Propagation controller_ to the managed clusters by using `manifestWork`.
 
 *Technology Preview:* Pull model has limited support this release.
 
@@ -15,7 +15,7 @@ For both models, the same `ApplicationSet` CRD is used to deploy the application
 * <<status-report,_MulticlusterApplicationSetReport_>>
 
 [#prereqs-pull-model]
-== Prerequisites 
+== Prerequisites
 
 * *Important:* If your `openshift-gitops-ArgoCD-application-controller` service account is _not_ assigned as a cluster administrator, the GitOps application controller might not deploy resources. The application status might send an error similar to the following error:
 
@@ -50,15 +50,15 @@ metadata:
 
 See the following requirements to use the Argo CD _Pull_ model:
 
-- The GitOps operator must be installed on the hub cluster and the target managed clusters in the `openshift-gitops` namespace. 
+- The GitOps operator must be installed on the hub cluster and the target managed clusters in the `openshift-gitops` namespace.
 
-- The required hub cluster {ocp-short} GitOps operator must be version 1.9.0 or later. 
+- The required hub cluster {ocp-short} GitOps operator must be version 1.9.0 or later.
 
 - The required managed clusters {ocp-short} GitOps operator must be the same version as the hub cluster.
 
 - You need the _ApplicationSet controller_ to propagate the Argo CD application template for a managed cluster.
 
-- Every managed cluster must have a cluster secret in the Argo CD server namespace on the hub cluster, which is required by the ArgoCD application set controller to propagate the Argo CD application template for a managed cluster. 
+- Every managed cluster must have a cluster secret in the Argo CD server namespace on the hub cluster, which is required by the ArgoCD application set controller to propagate the Argo CD application template for a managed cluster.
 
 +
 To create the cluster secret, create a `gitOpsCluster` resource that contains a reference to a `placement` resource. The `placement` resource selects all the managed clusters that need to support the Pull model. When the GitOps cluster controller reconciles, it creates the cluster secrets for the managed clusters in the Argo CD server namespace.
@@ -71,9 +71,9 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 [#arch-push]
 === Architecture Push model
 
-- With Push model, {ocp-short} GitOps applies resources _directly_ from a centralized hub cluster to the managed clusters. 
+- With Push model, {ocp-short} GitOps applies resources _directly_ from a centralized hub cluster to the managed clusters.
 
-- An Argo CD application that is running on the hub cluster communicates with the GitHub repository and deploys the manifests directly to the managed clusters. 
+- An Argo CD application that is running on the hub cluster communicates with the GitHub repository and deploys the manifests directly to the managed clusters.
 
 - Push model implementation only contains the Argo CD application on the hub cluster, which has credentials for managed clusters. The Argo CD application on the hub cluster can deploy the applications to the managed clusters.
 
@@ -88,7 +88,7 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 
 - With Pull model, {ocp-short} GitOps _does not_ apply resources directly from a centralized hub cluster to the managed clusters. The Argo CD Application is propagated from the hub cluster to the managed clusters.
 
-- Pull model implementation applies {ocm} registration, placement, and `manifestWork` APIs so that the hub cluster can use the secure communication channel between the hub cluster and the managed cluster to deploy resources. 
+- Pull model implementation applies {ocm} registration, placement, and `manifestWork` APIs so that the hub cluster can use the secure communication channel between the hub cluster and the managed cluster to deploy resources.
 
 - Each managed cluster individually communicates with the GitHub repository to deploy the resource manifests locally, so you must install and configure GitOps operators on each managed cluster.
 
@@ -107,11 +107,11 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 - The status of the deployments is gathered back to the hub cluster, but not all the detailed information is transmitted. Additional status updates are periodically scraped to provide an overview. The status feedback is not real-time, and each managed cluster GitOps operator needs to communicate with the Git repository, which results in multiple requests.
 
 [#crd-pull-model]
-== Creating the _ApplicationSet_ CRD
+== Creating the _ApplicationSet_ Custom Resource
 
-The Argo CD `ApplicationSet` CRD is used to deploy applications on the managed clusters by using the Push or Pull model with a `placement` resource in the generator field that is used to get a list of managed clusters. 
+The Argo CD `ApplicationSet` CRD is used to deploy applications on the managed clusters by using the Push or Pull model with a `placement` resource in the generator field that is used to get a list of managed clusters.
 
-. For the Pull model, set the destination for the application to the default local Kubernetes server, as displayed in the following example. The application is deployed locally by the application controller on the managed cluster. 
+. For the Pull model, set the destination for the application to the default local Kubernetes server, as displayed in the following example. The application is deployed locally by the application controller on the managed cluster.
 
 . Add the annotations that are required to override the default Push model, as displayed in the following example `ApplicationSet` YAML, which uses the Pull model with template annotations:
 
@@ -135,7 +135,7 @@ spec:
     metadata:
       annotations:
         apps.open-cluster-management.io/ocm-managed-cluster: '{{name}}'<1>
-        apps.open-cluster-management.io/ocm-managed-cluster-app-namespace: openshift-gitops 
+        apps.open-cluster-management.io/ocm-managed-cluster-app-namespace: openshift-gitops
         argocd.argoproj.io/skip-reconcile: "true" <2>
       labels:
         apps.open-cluster-management.io/pull-to-ocm-managed-cluster: "true" <3>
@@ -146,12 +146,12 @@ spec:
         server: https://kubernetes.default.svc
       project: default
       sources: [
-      { 
+      {
         repoURL: https://github.com/argoproj/argocd-example-apps.git
         targetRevision: main
         path: guestbook
          }
-      ]   
+      ]
       syncPolicy:
         automated: {}
         syncOptions:
@@ -167,9 +167,9 @@ spec:
 
 - For the Pull model, the `MulticlusterApplicationSetReport` aggregates application status from across your managed clusters.
 
-- The report includes the list of resources and the overall status of the application from each managed cluster. 
+- The report includes the list of resources and the overall status of the application from each managed cluster.
 
-- A separate report resource is created for each Argo CD ApplicationSet resource. The report is created in the same namespace as the `ApplicationSet`. 
+- A separate report resource is created for each Argo CD ApplicationSet resource. The report is created in the same namespace as the `ApplicationSet`.
 
 - The report includes the following items:
 
@@ -185,8 +185,8 @@ spec:
 
 +
 ----
-NAMESPACE               NAME                                       READY   STATUS  
-open-cluster-management multicluster-integrations-7c46498d9-fqbq4  3/3     Running  
+NAMESPACE               NAME                                       READY   STATUS
+open-cluster-management multicluster-integrations-7c46498d9-fqbq4  3/3     Running
 ----
 
 The following is an example `MulticlusterApplicationSetReport` YAML file for the `guestbook` application:
@@ -232,4 +232,3 @@ statuses:
 
 
 - See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/cicd/gitops#setting-up-argocd-instance[Setting up an Argo CD instance] in the {ocp-short} documentation.
-


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8528

The CRD is already created during the installation of the OpenShift GitOps operator, and the section guides the reader through creation of a CR. This change is an attempt to improve the title to reflect that.