### PR TITLE
fixing spelling of hosted control planes in heading

### DIFF
--- a/clusters/release_notes/known_issues.adoc
+++ b/clusters/release_notes/known_issues.adoc
@@ -24,7 +24,7 @@ Or consider a troubleshooting topic.
 Review the known issues for cluster lifecycle with {mce-short}. The following list contains known issues for this release, or known issues that continued from the previous release. For your {ocp-short} cluster, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12[{ocp-short} release notes].
 
 * <<cluster-lifecycle-issues-mce,Cluster lifecycle>>
-* <<hosted-control-plane-mce,Hosted control plane>>
+* <<hosted-control-plane-mce,Hosted control planes>>
 
 [#cluster-lifecycle-issues-mce]
 == Cluster management


### PR DESCRIPTION
No Jira - this PR fixes the spelling of "Hosted control planes" in a heading in the known issues file.