### PR TITLE
https://issues.redhat.com/browse/ACM-8363 updates

### DIFF
--- a/clusters/install_upgrade/install_connected.adoc
+++ b/clusters/install_upgrade/install_connected.adoc
@@ -3,11 +3,9 @@
 
 The {mce-short} is installed with Operator Lifecycle Manager, which manages the installation, upgrade, and removal of the components that encompass the {mce-short}.
 
-**Required access:** Cluster administrator
+*Required access:* Cluster administrator
 
 *Important:* 
-
-- The {mce-short} is automatically installed during the {product-title-short} installation.
 
 - For {ocp-short} Dedicated environment, you must have `cluster-admin` permissions. By default `dedicated-admin` role does not have the required permissions to create namespaces in the {ocp-short} Dedicated environment. 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8363
Removing the line about RHACM. MCE can be installed w/o RHACM. It is not important for the MCE user to know that MCE is automatically installed with RHACM