### PR TITLE
[GRC] Remove policy generator version

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -3,7 +3,7 @@
 
 The Policy Generator is a part of the {product-title} application lifecycle subscription GitOps workflow that generates {product-title-short} policies using Kustomize. The Policy Generator builds {product-title-short} policies from Kubernetes manifest YAML files, which are provided through a `PolicyGenerator` manifest YAML file that is used to configure it. The Policy Generator is implemented as a Kustomize generator plug-in. For more information on Kustomize, read the _Kustomize documentation_. 
 
-The Policy Generator version bundled in this version of {product-title-short} is v1.10.0. View the following topics to for more information:
+View the following topics to for more information:
 
 * <<policy-generator-capabilities,Policy Generator capabilities>>
 * <<policy-generator-configuration,Policy Generator configuration structure>>
@@ -377,7 +377,6 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 == Additional resources
 
 * Read link:../gitops/gitops_policy_operator.adoc#gitops-policy-operator[Generating a policy to install GitOps Operator].
-* Read the link:https://github.com/open-cluster-management-io/policy-generator-plugin[`policy-generator-plugin`] repository for more details.
 * Read to xref:../governance/policy_set_ctrl.adoc#policy-set-controller[Policy set controller] for more details.
 * Read link:../applications/subscription_sample.adoc#applying-kustomize[Applying Kustomize] for more information.
 * Read the xref:../governance/grc_intro.adoc#governance[Governance] documentation for more topics.
@@ -386,4 +385,3 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 * Refer link:https://open-policy-agent.github.io/gatekeeper/website/docs/[Gatekeeper] for more details.
 * Refer to the link:https://kustomize.io/[Kustomize documentation]. 
 * Return to the xref:../governance/third_party_policy.adoc#integrate-third-party-policy-controllers[Integrate third-party policy controllers] documentation.
-

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -3,7 +3,7 @@
 
 The Policy Generator is a part of the {product-title} application lifecycle subscription GitOps workflow that generates {product-title-short} policies using Kustomize. The Policy Generator builds {product-title-short} policies from Kubernetes manifest YAML files, which are provided through a `PolicyGenerator` manifest YAML file that is used to configure it. The Policy Generator is implemented as a Kustomize generator plug-in. For more information on Kustomize, read the _Kustomize documentation_. 
 
-View the following topics to for more information:
+View the following sections for more information:
 
 * <<policy-generator-capabilities,Policy Generator capabilities>>
 * <<policy-generator-configuration,Policy Generator configuration structure>>
@@ -12,11 +12,13 @@ View the following topics to for more information:
 [#policy-generator-capabilities]
 == Policy Generator capabilities
 
-The Policy Generator and its integration with the {product-title-short} application lifecycle subscription GitOps workflow simplifies the distribution of Kubernetes resource objects to managed {ocp-short} clusters, and Kubernetes clusters through {product-title-short} policies. In particular, use the Policy Generator to complete the following actions:
+The Policy Generator and its integration with the {product-title-short} application lifecycle subscription GitOps workflow simplifies the distribution of Kubernetes resource objects to managed {ocp-short} clusters, and Kubernetes clusters through {product-title-short} policies. 
 
-- Convert any Kubernetes manifest files to {product-title-short} configuration policies, including manifests created from a Kustomize directory.
+Use the Policy Generator to complete the following actions:
+
+- Convert any Kubernetes manifest files to {product-title-short} configuration policies, including manifests that are created from a Kustomize directory.
 - Patch the input Kubernetes manifests before they are inserted into a generated {product-title-short} policy.
-- Generate additional configuration policies to be able to report on Gatekeeper policy violations through {product-title}.
+- Generate additional configuration policies so you can report on Gatekeeper policy violations through {product-title}.
 - Generate policy sets on the hub cluster.
 
 [#policy-generator-configuration]
@@ -32,7 +34,7 @@ generators:
   - policy-generator-config.yaml
 ----
 
-The `policy-generator-config.yaml` file referenced in the previous example is a YAML file with the instructions of the policies to generate. A simple `PolicyGenerator` configuration file might resemble the following example:
+The `policy-generator-config.yaml` file that is referenced in the previous example is a YAML file with the instructions of the policies to generate. A simple `PolicyGenerator` configuration file might resemble the following example:
 
 [source,yaml]
 ----
@@ -130,7 +132,7 @@ spec:
 [#policy-gen-yaml-table]
 == Policy Generator configuration reference table
 
-Note that all the fields in the `policyDefaults` section except for `namespace` can be overridden per policy, and all the fields in the `policySetDefaults` section can be overridden per policy set.
+Note that all the fields in the `policyDefaults` section except for `namespace` can be overridden for each policy, and all the fields in the `policySetDefaults` section can be overridden for each policy set.
 
 .Parameter table
 |===
@@ -152,7 +154,7 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | If multiple policies use the same placement, this name is used to generate a unique name for the resulting `PlacementBinding`, binding the placement with the array of policies that reference it.
 
-| *`policyDefaults`*
+| `policyDefaults`
 | Required
 | Any default value listed here is overridden by an entry in the policies array except for `namespace`.
 
@@ -324,7 +326,7 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | Specify a placement rule by defining a cluster selector using either `key:value`, or providing a `matchExpressions`, `matchLabels`, or both, with appropriate values. See `_placementPath_` to specify an existing file.
 
-| *`policySetDefaults`*
+| `policySetDefaults`
 | Optional
 | Default values for policy sets. Any default value listed for this parameter is overridden by an entry in the `policySets` array.
 
@@ -336,7 +338,7 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | Generate placement manifests for policy sets. Set to `true` by default. When set to `false` the placement manifest generation is skipped, even if a placement is specified.
 
-| *`policies`*
+| `policies`
 | Required 
 | The list of policies to create along with overrides to either the default values, or the values that are set in `policyDefaults`. See `_policyDefaults_` for additional fields and descriptions.
 
@@ -356,7 +358,7 @@ Note that all the fields in the `policyDefaults` section except for `namespace` 
 | Optional
 | A list of Kustomize patches to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so Kustomize can identify the manifest that the patch applies to. If there is a single manifest, the `metadata.name` and `metadata.namespace` fields can be patched.
 
-| *`policySets`*
+| `policySets`
 | Optional
 | The list of policy sets to create, along with overrides to either the default values or the values that are set in `policySetDefaults`. To include a policy in a policy set, use `policyDefaults.policySets`, `policies[].policySets`,  or `policySets.policies`. See `_policySetDefaults_` for additional fields and descriptions.
 


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/ACM-8945

- Remove generator version (now that we have release branches in `stolostron`)
- Change URL to `stolostron` to direct RHACM users to the ACM generator rather than OCM

/cc @mprahl @JustinKuli @gparvin @yiraeChristineKim 