### PR TITLE
ACM-9463: Update the hcp destroy command

### DIFF
--- a/clusters/hosted_control_planes/destroy_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/destroy_hosted_bm.adoc
@@ -28,7 +28,7 @@ where `_cluster_name_` is the name of your cluster.
 
 +
 ----
-hcp destroy cluster aws --name <cluster_name>
+hcp destroy cluster agent --name <cluster_name>
 ----
 
 +


### PR DESCRIPTION
Update the `hcp destroy` command from ` hcp destroy cluster aws --name <cluster_name>` to ` hcp destroy cluster agent --name <cluster_name>`

Jira: https://issues.redhat.com/browse/ACM-9463
