### PR TITLE
Quick update

### DIFF
--- a/global_hub/global_hub_overview.adoc
+++ b/global_hub/global_hub_overview.adoc
@@ -19,7 +19,7 @@ It is often inconvenient to view the data on multiple hub clusters for the manag
 
 - xref:../global_hub/global_hub_install_connected.adoc#global-hub-install-connected[Installing Multicluster Global Hub in a connected environment]
 
--  xref:../global_hub/global_hub_install_disconnected.adoc#global-hub-install-disconnected[Installing Multicluster Global Hub in a disconnected environment]]
+-  xref:../global_hub/global_hub_install_disconnected.adoc#global-hub-install-disconnected[Installing Multicluster Global Hub in a disconnected environment]
 
 - xref:../global_hub/global_hub_components.adoc#global-hub-integrating-existing-components[Integrating existing components]
 

--- a/global_hub/global_hub_requirements.adoc
+++ b/global_hub/global_hub_requirements.adoc
@@ -80,4 +80,4 @@ Learn about supported platforms and components.
 
 - xref:../global_hub/global_hub_install_connected.adoc#global-hub-install-connected[Installing Multicluster Global Hub in a connected environment]
 
--  xref:../global_hub/global_hub_install_disconnected.adoc#global-hub-install-disconnected[Installing Multicluster Global Hub in a disconnected environment]]
+-  xref:../global_hub/global_hub_install_disconnected.adoc#global-hub-install-disconnected[Installing Multicluster Global Hub in a disconnected environment]


### PR DESCRIPTION
Honestly, I saw a red x and thought the book was broken. However, I remember that it is because of how multicluster global hub referenced. 
<img width="537" alt="Screenshot 2024-01-18 at 11 04 50 PM" src="https://github.com/stolostron/rhacm-docs/assets/60616885/a0e9328f-5017-4324-9841-2bb23e0b245f">

@oafischer will you help with getting that updated? I will create a separate issue for the Pantheon book investigation 

However, I did notice extra brackets in link references