### PR TITLE
ACM#9464: Add instructions to download  by using the CLI

### DIFF
--- a/clusters/hosted_control_planes/install_hcp_cli.adoc
+++ b/clusters/hosted_control_planes/install_hcp_cli.adoc
@@ -32,3 +32,48 @@ hcp create cluster <platform> --help <1>
 ----
 
 <1> The supported platforms are `aws`, `agent`, and `kubevirt`.
+
+[#hosted-install-console]
+== Installing the hosted control plane command line interface by using the CLI
+
+You can install the hosted control plane command line interface, `hcp`, by using the CLI, by completing the following steps:
+
+. Get the URL to download the `hcp` binary by running the following command:
++
+----
+oc get ConsoleCLIDownload hcp-cli-download -o json | jq -r ".spec"
+----
+
+. Download the `hcp` binary by running the following command:
++
+----
+wget <hcp_cli_download_url> <1>
+----
++
+<1> Replace `hcp_cli_download_url` with the URL that you obtained from the previous step.
+
+. Unpack the downloaded archive by running the following command:
++
+----
+tar xvzf hcp.tar.gz
+----
+
+. Run the following command to make the binary file executable:
++
+----
+chmod +x hcp
+----
+
+. Run the following command to move the binary file to a directory in your path:
++
+----
+sudo mv hcp /usr/local/bin/.
+----
+
+You can now use the `hcp create cluster` command to create and manage hosted clusters. To list the available parameters, enter the following command:
+
+----
+hcp create cluster <platform> --help <1>
+----
+
+<1> The supported platforms are `aws`, `agent`, and `kubevirt`.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/ACM-9464

This PR adds the instructions to install the `hcp` binary by using the CLI.