### PR TITLE
ACM-9804 Remove old known issues for search

### DIFF
--- a/release_notes/known_issues_console.adoc
+++ b/release_notes/known_issues_console.adoc
@@ -73,26 +73,6 @@ There are known issues with dark theme styling for older versions of Firefox. Up
 
 For more information, see link:../install/requirements.adoc#supported-browsers[Supported browsers].
 
-[#restrictions-for-storage-size-in-searchcustomization]
-== Restrictions for storage size in search customization
-//2.2:8501
-
-When you update the storage size in the `searchcustomization` CR, the PVC configuration does not change. If you need to update the storage size, update the PVC (`_<storageclassname>-search-redisgraph-0_`) with the following command:
-----
-oc edit pvc <storageclassname>-search-redisgraph-0
-----
-
-[#search-query-issue]
-== Search query parsing error
-//2.5:22391 
-
-If an environment becomes large and requires more tests for scaling, the search queries can timeout which results in a parsing error message being displayed. This error is displayed after 30 seconds of waiting for a search query.
-
-Extend the timeout time with the following command:
-
-----
-kubectl annotate route multicloud-console haproxy.router.openshift.io/timeout=Xs
-----
 
 [#cannot-edit-namespace-bindings-for-cluster-set]
 == Cannot edit namespace bindings for cluster set


### PR DESCRIPTION
Jira issue: https://issues.redhat.com/browse/ACM-9804

## Changes
Removes 2 troubleshoot topics that are no longer valid for search.
1. Redisgraph was removed in 2.7 so troubleshoot topic is no longer valid.
2. The multicloud-console route was also removed several releases back so this troubleshoot topic is no longer valid.