### PR TITLE
ACM#9987: Adding relase notes entries for hosted control planes

### DIFF
--- a/clusters/release_notes/whats_new.adoc
+++ b/clusters/release_notes/whats_new.adoc
@@ -26,7 +26,7 @@ You can now configure the proxy settings for cluster proxy add-ons to allow a ma
 [#hosted-control-plane]
 == Hosted control planes
 
-* Technology Preview: You can provision a hosted control plane cluster by using the non bare metal agent machines. For more information, see xref:../hosted_control_planes/non_bm_intro.adoc#configuring-hosting-service-cluster-configure-agent-non-bm[Configuring hosted control plane clusters using non bare metal agent machines].
+* **Technology Preview:** You can provision a hosted control plane cluster by using the non bare metal agent machines. For more information, see xref:../hosted_control_planes/non_bm_intro.adoc#configuring-hosting-service-cluster-configure-agent-non-bm[Configuring hosted control plane clusters using non bare metal agent machines].
 
 * You can now create a hosted cluster with the KubeVirt platform by using the console. For more information, see xref:../hosted_control_planes/create_cluster_kubevirt.adoc#hosted-create-kubevirt-console[Creating a hosted cluster by using the console].
 

--- a/clusters/release_notes/whats_new.adoc
+++ b/clusters/release_notes/whats_new.adoc
@@ -8,14 +8,26 @@ Learn more about what is new this release:
 * The open source _Open Cluster Management_ repository is ready for interaction, growth, and contributions from the open community. To get involved, see link:https://open-cluster-management.io/[open-cluster-management.io]. You can access the link:https://github.com/open-cluster-management-io[GitHub repository] for more information, as well.
 
 * <<cluster-lifecycle, Cluster lifecycle>>
+* <<credential, Credentials>>
 * <<hosted-control-plane, Hosted control planes>>
 
 [#cluster-lifecycle]
 == Cluster lifecycle
- 
+
 Learn about what's new relating to Cluster lifecycle with {mce-short}.
 
 You can now configure the proxy settings for cluster proxy add-ons to allow a managed cluster to communicate with the hub cluster through a HTTP and HTTPS proxy server. See xref:../cluster_lifecycle/cluster_proxy_addon.adoc#cluster-proxy-addon-settings[Configuring proxy settings for cluster proxy add-ons] to learn more.
 
+[#credential]
+== Credentials
+
+* You can now configure the _Cluster OS image_ field to create a credential by using the {mce-short} console for disconnected installations on VMware vSphere. For more information, see xref:../credentials/credential_vm.adoc#vsphere_cred[Managing a credential by using the console].
+
 [#hosted-control-plane]
 == Hosted control planes
+
+* Technology Preview: You can provision a hosted control plane cluster by using the non bare metal agent machines. For more information, see xref:../hosted_control_planes/non_bm_intro.adoc#configuring-hosting-service-cluster-configure-agent-non-bm[Configuring hosted control plane clusters using non bare metal agent machines].
+
+* You can now create a hosted cluster with the KubeVirt platform by using the console. For more information, see xref:../hosted_control_planes/create_cluster_kubevirt.adoc#hosted-create-kubevirt-console[Creating a hosted cluster by using the console].
+
+* You can now configure additional networks, request a guaranteed CPU access for Virtual Machines (VMs), and manage scheduling of KubeVirt VMs for node pools. For more information, see xref:../hosted_control_planes/managing_nodepools_kubevirt.adoc#managing-nodepools-hosted-cluster-kubevirt[Configuring additional networks, guaranteed CPUs, and VM scheduling for node pools].


### PR DESCRIPTION
Adding whats new entries for:

1. https://issues.redhat.com/browse/ACM-9987: Managing node pools on hosted clusters 
2. https://issues.redhat.com/browse/ACM-9621: Configuring HCP on non bare metal agent machines
3. https://issues.redhat.com/browse/ACM-9850: Creating a hosted cluster with the KubeVirt platform by using the console
4. https://issues.redhat.com/browse/ACM-9255: Adding description for the Cluster Os Image field

Additional information: The content is approved by SMEs in the main PRs:
1. https://github.com/stolostron/rhacm-docs/pull/6122
2. https://github.com/stolostron/rhacm-docs/pull/6073
3. https://github.com/stolostron/rhacm-docs/pull/6133
4. https://github.com/stolostron/rhacm-docs/pull/6098

