### PR TITLE
ACM-9979: Remove or make a note about using hypershift CLI

### DIFF
--- a/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
+++ b/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
@@ -106,7 +106,7 @@ To access a private cluster, you use a bastion.
 hypershift create bastion aws --aws-creds=$AWS_CREDS --infra-id=$INFRA_ID --region=$REGION --ssh-key-file=$SSH_KEY
 ----
 
-*Note:* `hypershift` CLI is not available for download. Use the following commands to extract it from the hypershift operator pod. Replace `operator-747645c946-27w5k` with the actual operator pod name in `hypershift` namespace.
+*Note:* The `hypershift` CLI is not available to download. Use the following commands to extract it by using the HyperShift Operator pod present in the `hypershift` namespace. Replace `<hypershift-operator-pod-name>` with your HyperShift Operator pod name.
 +
 ----
 oc project hypershift

--- a/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
+++ b/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
@@ -106,6 +106,14 @@ To access a private cluster, you use a bastion.
 hypershift create bastion aws --aws-creds=$AWS_CREDS --infra-id=$INFRA_ID --region=$REGION --ssh-key-file=$SSH_KEY
 ----
 
+*Note:* `hypershift` CLI is not available for download. Use the following commands to extract it from the hypershift operator pod. Replace `operator-747645c946-27w5k` with the actual operator pod name in `hypershift` namespace.
++
+----
+oc project hypershift
+oc rsync operator-747645c946-27w5k:/usr/bin/hypershift-no-cgo .
+mv hypershift-no-cgo hypershift
+----
+
 . Find the private IPs of nodes in the cluster node pool by entering the following command:
 +
 ----

--- a/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
+++ b/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
@@ -110,7 +110,7 @@ hypershift create bastion aws --aws-creds=$AWS_CREDS --infra-id=$INFRA_ID --regi
 +
 ----
 oc project hypershift
-oc rsync operator-747645c946-27w5k:/usr/bin/hypershift-no-cgo .
+oc rsync <hypershift-operator-pod-name>:/usr/bin/hypershift-no-cgo .
 mv hypershift-no-cgo hypershift
 ----
 

--- a/clusters/hosted_control_planes/enable_ext_dns_aws.adoc
+++ b/clusters/hosted_control_planes/enable_ext_dns_aws.adoc
@@ -115,7 +115,7 @@ dig +short test.user-dest-public.aws.kerberos.com
 
 +
 ----
-hypershift create cluster aws --name=example --endpoint-access=PublicAndPrivate --external-dns-domain=service-provider-domain.com ...
+hcp create cluster aws --name=example --endpoint-access=PublicAndPrivate --external-dns-domain=service-provider-domain.com ...
 ----
 
 This example shows the resulting `services` block for the hosted cluster:

--- a/clusters/hosted_control_planes/manage_aws_infra_iam.adoc
+++ b/clusters/hosted_control_planes/manage_aws_infra_iam.adoc
@@ -488,6 +488,14 @@ hypershift create infra aws --name CLUSTER_NAME \ <1>
 <5> Replace `REGION` with the region where you want to create the infrastructure for your cluster.
 <6> Replace `OUTPUT_INFRA_FILE` with the name of the file where you want to store the IDs of the infrastructure in JSON format. You can use this file as input to the `hcp create cluster aws` command to populate fields in the `HostedCluster` and `NodePool` resouces.
 
+*Note:* `hypershift` CLI is not available for download. Use the following commands to extract it from the hypershift operator pod. Replace `operator-747645c946-27w5k` with the actual operator pod name in `hypershift` namespace.
++
+----
+oc project hypershift
+oc rsync operator-747645c946-27w5k:/usr/bin/hypershift-no-cgo .
+mv hypershift-no-cgo hypershift
+----
+
 After you enter the command, the following resources are created:
 
 * One VPC

--- a/clusters/hosted_control_planes/manage_aws_infra_iam.adoc
+++ b/clusters/hosted_control_planes/manage_aws_infra_iam.adoc
@@ -492,7 +492,7 @@ hypershift create infra aws --name CLUSTER_NAME \ <1>
 +
 ----
 oc project hypershift
-oc rsync operator-747645c946-27w5k:/usr/bin/hypershift-no-cgo .
+oc rsync <hypershift-operator-pod-name>:/usr/bin/hypershift-no-cgo .
 mv hypershift-no-cgo hypershift
 ----
 

--- a/clusters/hosted_control_planes/manage_aws_infra_iam.adoc
+++ b/clusters/hosted_control_planes/manage_aws_infra_iam.adoc
@@ -488,7 +488,7 @@ hypershift create infra aws --name CLUSTER_NAME \ <1>
 <5> Replace `REGION` with the region where you want to create the infrastructure for your cluster.
 <6> Replace `OUTPUT_INFRA_FILE` with the name of the file where you want to store the IDs of the infrastructure in JSON format. You can use this file as input to the `hcp create cluster aws` command to populate fields in the `HostedCluster` and `NodePool` resouces.
 
-*Note:* `hypershift` CLI is not available for download. Use the following commands to extract it from the hypershift operator pod. Replace `operator-747645c946-27w5k` with the actual operator pod name in `hypershift` namespace.
+*Note:* The `hypershift` CLI is not available to download. Use the following commands to extract it by using the HyperShift Operator pod present in the `hypershift` namespace. Replace `<hypershift-operator-pod-name>` with your HyperShift Operator pod name.
 +
 ----
 oc project hypershift


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9979

There are still some references in the doc of using the "hypershift" CLI which is not downloadable by end-users. Remove or make a note about how to get it. 