### PR TITLE
(2.10) Added Component Table for MultiClusterEngine

### DIFF
--- a/clusters/install_upgrade/adv_config_install.adoc
+++ b/clusters/install_upgrade/adv_config_install.adoc
@@ -1,23 +1,28 @@
 [#advanced-config-engine]
 = Advanced configuration 
 
-The {mce-short} is installed using an operator that deploys all of the required components. The {mce-short} can be further configured during or after installation by adding one or more of the following attributes to the `MultiClusterEngine` custom resource:
+The {mce-short} is installed using an operator that deploys all of the required components. The {mce-short} can be further configured during or after installation. Learn more about the advanced configuration options.
+
+[#deployed-components]
+== Deployed components
+
+Add one or more of the following attributes to the `MultiClusterEngine` custom resource:
 
 .Table list of the deployed components
 |===
 | Name | Description | Enabled
-| assisted-service | Installs OpenShift with minimal infrastructure prerequisites and comprehensive pre-flight validations. | True
-| cluster-lifecycle | Provides cluster management capabilities for {ocp-short} and {product-title-short} hub clusters. | True
-| cluster-manager | Manages various cluster-related operations within the cluster environment. | True
-| cluster-proxy-addon | Automates the installation of apiserver-network-proxy on both hub and managed clusters using a reverse proxy server. | True
-| console-mce | Enables the {mce-short} console plug-in. | True
-| discovery | Discovers and identifies new clusters within the {ocm}. | True
-| hive | Provisions and performs initial configuration of {ocp-short} clusters. | True
-| hypershift | Hosts OpenShift control planes at scale with cost and time efficiency, and cross-cloud portability. | True
-| hypershift-local-hosting | Enables local hosting capabilities for within the local cluster environment. | True
-| local-cluster | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed. | True
-| managedserviceacccount | Syncronizes service accounts to managed clusters and collects tokens as secret resources back to the hub cluster. | True
-| server-foundation | Provides foundational services for server-side operations within the multi-cluster environment. | True
+| assisted-service | Installs {ocp-short} with minimal infrastructure prerequisites and comprehensive pre-flight validations | True
+| cluster-lifecycle | Provides cluster management capabilities for {ocp-short} and Kubernetes hub clusters | True
+| cluster-manager | Manages various cluster-related operations within the cluster environment | True
+| cluster-proxy-addon | Automates the installation of `apiserver-network-proxy` on both hub and managed clusters using a reverse proxy server | True
+| console-mce | Enables the {mce-short} console plug-in | True
+| discovery | Discovers and identifies new clusters within the {ocm} | True
+| hive | Provisions and performs initial configuration of {ocp-short} clusters | True
+| hypershift | Hosts {ocp-short} control planes at scale with cost and time efficiency, and cross-cloud portability | True
+| hypershift-local-hosting | Enables local hosting capabilities for within the local cluster environment | True
+| local-cluster | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed | True
+| managedserviceacccount | Syncronizes service accounts to managed clusters and collects tokens as secret resources back to the hub cluster | False
+| server-foundation | Provides foundational services for server-side operations within the multicluster environment | True
 |===
 
 When you install {mce-short} on to the cluster, not all of the listed components are enabled by default.

--- a/clusters/install_upgrade/adv_config_install.adoc
+++ b/clusters/install_upgrade/adv_config_install.adoc
@@ -3,6 +3,52 @@
 
 The {mce-short} is installed using an operator that deploys all of the required components. The {mce-short} can be further configured during or after installation by adding one or more of the following attributes to the `MultiClusterEngine` custom resource:
 
+.Table list of the deployed components
+|===
+| Name | Description | Enabled
+| assisted-service | Installs OpenShift with minimal infrastructure prerequisites and comprehensive pre-flight validations. | True
+| cluster-lifecycle | Provides cluster management capabilities for {ocp-short} and {product-title-short} hub clusters. | True
+| cluster-manager | Manages various cluster-related operations within the cluster environment. | True
+| cluster-proxy-addon | Automates the installation of apiserver-network-proxy on both hub and managed clusters using a reverse proxy server. | True
+| console-mce | Enables the {mce-short} console plug-in. | True
+| discovery | Discovers and identifies new clusters within the {ocm}. | True
+| hive | Provisions and performs initial configuration of {ocp-short} clusters. | True
+| hypershift | Hosts OpenShift control planes at scale with cost and time efficiency, and cross-cloud portability. | True
+| hypershift-local-hosting | Enables local hosting capabilities for within the local cluster environment. | True
+| local-cluster | Enables the import and self-management of the local hub cluster where the {mce-short} is deployed. | True
+| managedserviceacccount | Syncronizes service accounts to managed clusters and collects tokens as secret resources back to the hub cluster. | True
+| server-foundation | Provides foundational services for server-side operations within the multi-cluster environment. | True
+|===
+
+When you install {mce-short} on to the cluster, not all of the listed components are enabled by default.
+
+You can further configure {mce-short} during or after installation by adding one or more attributes to the `MultiClusterEngine` custom resource. Continue reading for information about the attributes that you can add.
+
+[#component-config]
+== Console and component configuration
+
+The following example displays the `spec.overrides` default template that you can use to enable or disable the component:
+
+[source,yaml]
+----
+apiVersion: operator.open-cluster-management.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+spec:
+  overrides:
+    components:
+    - name: <name> <1>
+      enabled: true
+----
+1. Replace `name` with the name of the component.
+
+Alternatively, you can run the following command. Replace `namespace` with the name of your project and `name` with the name of the component:
+
+----
+oc patch MultiClusterEngine <multiclusterengine-name> --type=json -p='[{"op": "add", "path": "/spec/overrides/components/-","value":{"name":"<name>","enabled":true}}]'
+----
+
 [#local-cluster]
 == Local-cluster enablement
 
@@ -124,27 +170,3 @@ spec:
 ----
 
 The previous infra-node toleration is set on pods by default without specifying any tolerations in the configuration. Customizing tolerations in the configuration will replace this default behavior.
-
-[#serviceaccount-addon-intro]
-== ManagedServiceAccount add-on
-
-By default, the `Managed-ServiceAccount` add-on is disabled. This component when enabled allows you to create or delete a service account on a managed cluster. To install with this add-on enabled, include the following in the `MultiClusterEngine` specification in `spec.overrides`:
-
-[source,yaml]
-----
-apiVersion: multicluster.openshift.io/v1
-kind: MultiClusterEngine
-metadata:
-  name: multiclusterengine
-spec:
-  overrides:
-    components:
-    - name: managedserviceaccount
-      enabled: true
-----
-
-The `ManagedServiceAccount` add-on can be enabled after creating `MultiClusterEngine` by editing the resource on the command line and setting the `managedserviceaccount` component to `enabled: true`. Alternatively, you can run the following command and replace <multiclusterengine-name> with the name of your `MultiClusterEngine` resource.
-
-----
-oc patch MultiClusterEngine <multiclusterengine-name> --type=json -p='[{"op": "add", "path": "/spec/overrides/components/-","value":{"name":"managedserviceaccount","enabled":true}}]'
-----


### PR DESCRIPTION
Currently, we don't provide a table of components for MCE that describes the components that are being deployed by our operator; therefore, this PR will add it.