### PR TITLE
ACM-10088: update support for hcp and replace hypershift text

### DIFF
--- a/clusters/hosted_control_planes/access_hosted_cluster.adoc
+++ b/clusters/hosted_control_planes/access_hosted_cluster.adoc
@@ -1,7 +1,7 @@
 [#access-hosted-cluster]
 = Accessing the hosted cluster
 
-You can access the hosted cluster by either getting the `kubeconfig` file and `kubeadmin` credential directly from resources, or by using the `hypershift` command line interface to generate a `kubeconfig` file.
+You can access the hosted cluster by either getting the `kubeconfig` file and `kubeadmin` credential directly from resources, or by using the `hcp` command line interface to generate a `kubeconfig` file.
 
 * To access the hosted cluster by getting the `kubeconfig` file and credentials directly from resources, you need to be familiar with the access secrets for hosted control plane clusters. The secrets are stored in the hosted cluster (hosting) namespace. The _hosted cluster (hosting)_ namespace contains hosted cluster resources, and the _hosted control plane_ namespace is where the hosted control plane runs.
 +
@@ -20,7 +20,7 @@ oc --kubeconfig ${HOSTED_CLUSTER_NAME}.kubeconfig get nodes
 +
 The `kubeadmin` password secret is also Base64-encoded. You can decode it and use the password to log in to the API server or console of the hosted cluster.
 
-* To access the hosted cluster by using the `hypershift` CLI to generate the `kubeconfig` file, take the following steps:
+* To access the hosted cluster by using the `hcp` CLI to generate the `kubeconfig` file, take the following steps:
 
 . Generate the `kubeconfig` file by entering the following command:
 

--- a/clusters/hosted_control_planes/create_aws_secret.adoc
+++ b/clusters/hosted_control_planes/create_aws_secret.adoc
@@ -63,7 +63,7 @@ aws s3api put-bucket-policy --bucket $BUCKET_NAME --policy file://policy.json
 | Field name | Description
 
 | `bucket`
-| Contains an S3 bucket with public access to host OIDC discovery documents for your HyperShift clusters.
+| Contains an S3 bucket with public access to host OIDC discovery documents for your hosted clusters.
 
 | `credentials`
 | A reference to a file that contains the credentials of the `default` profile that can access the bucket. By default, HyperShift only uses the `default` profile to operate the `bucket`. 

--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -12,9 +12,9 @@ The following table indicates which {ocp-short} versions are supported for each 
 
 |===
 | Platform | Hosting {ocp-short} version | Hosted {ocp-short} version
-| Bare metal | 4.14 | 4.14 (only)
-| {ocp-virt} | 4.14 | 4.14 (only)
-| AWS (Technology Preview) | 4.11 - 4.14 | 4.14 (only)
+| Bare metal | 4.14 - 4.15 | 4.14 - 4.15 (only)
+| {ocp-virt} | 4.14 - 4.15 | 4.14 - 4.15 (only)
+| AWS (Technology Preview) | 4.11 - 4.15 | 4.14 - 4.15 (only)
 |===
 
 **Note:** Run the hub cluster and workers on the same platform for hosted control planes.


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10088
- use hcp and hosted cluster language instead of hypershift
- update support level