### PR TITLE
Fix broken link in CIM docs

### DIFF
--- a/clusters/cluster_lifecycle/cim_enable.adoc
+++ b/clusters/cluster_lifecycle/cim_enable.adoc
@@ -34,7 +34,7 @@ oc get crd baremetalhosts.metal3.io
 Error from server (NotFound): customresourcedefinitions.apiextensions.k8s.io "baremetalhosts.metal3.io" not found
 ----
 
-. If you do not have a bare metal host custom resource definition, download the link:https://raw.githubusercontent.com/openshift/baremetal-operator/master/config/crd/bases/metal3.io_baremetalhosts.yaml[metal3.io_baremetalhosts.yaml] file and apply the content by running the following command to create the resource:
+. If you do not have a bare metal host custom resource definition, download the link:https://raw.githubusercontent.com/openshift/baremetal-operator/master/config/base/crds/bases/metal3.io_baremetalhosts.yaml[metal3.io_baremetalhosts.yaml] file and apply the content by running the following command to create the resource:
 +
 ----
 oc apply -f


### PR DESCRIPTION
A commit on the openshift/baremetal-operator repo moved the CRD to a
slightly different location, leading to a link in the CIM docs to break

This change fixes that link to point at the newer location