### PR TITLE
https://issues.redhat.com/browse/ACM-8847 Add KI: rm SubM before removing Cluster from CSet

### DIFF
--- a/release_notes/known_issues_network.adoc
+++ b/release_notes/known_issues_network.adoc
@@ -121,7 +121,6 @@ To make sure automatic upgrades work when installing Submariner on managed clust
 
 [#submariner-uninstall-before-move]
 === Uninstall Submariner before removing _ManagedCluster_ from a _ManageClusterSet_
-//2.10:ACM-7803
 //2.10:ACM-8847
 
 If you remove a cluster from a `ClusterSet`, or move a cluster to a different `ClusterSet`, the Submariner installation is no longer valid.

--- a/release_notes/known_issues_network.adoc
+++ b/release_notes/known_issues_network.adoc
@@ -127,5 +127,3 @@ If you remove a cluster from a `ClusterSet`, or move a cluster to a different `C
 
 You must uninstall Submariner before moving or removing a `ManagedCluster` from a `ManageClusterSet`. If you don't uninstall Submariner, you cannot uninstall or reinstall Submariner anymore and Submariner stops working on your `ManagedCluster`.
 
-//[#known-issues-network]
-//== Networking known issues

--- a/release_notes/known_issues_network.adoc
+++ b/release_notes/known_issues_network.adoc
@@ -119,5 +119,14 @@ Submariner is automatically upgraded when {product-title} is upgraded. The autom
 
 To make sure automatic upgrades work when installing Submariner on managed clusters, you must set the `spec.subscriptionConfig.channel` field to `stable-0.15` in the `SubmarinerConfig` custom resource for each managed cluster.
 
+[#submariner-uninstall-before-move]
+=== Uninstall Submariner before removing _ManagedCluster_ from a _ManageClusterSet_.
+//2.10:ACM-7803
+//2.10:ACM-8847
+
+If a cluster is moved out of _ClusterSet_, or moved to another _ClusterSet_, Submariner's installation is no longer valid.
+
+Submariner must be uninstalled before a _ManagedCluster_ is removed/moved from a _ManageClusterSet_. If not, it can’t be uninstalled/reinstalled and won’t work on that ManagedCluster.
+
 //[#known-issues-network]
 //== Networking known issues

--- a/release_notes/known_issues_network.adoc
+++ b/release_notes/known_issues_network.adoc
@@ -120,13 +120,13 @@ Submariner is automatically upgraded when {product-title} is upgraded. The autom
 To make sure automatic upgrades work when installing Submariner on managed clusters, you must set the `spec.subscriptionConfig.channel` field to `stable-0.15` in the `SubmarinerConfig` custom resource for each managed cluster.
 
 [#submariner-uninstall-before-move]
-=== Uninstall Submariner before removing _ManagedCluster_ from a _ManageClusterSet_.
+=== Uninstall Submariner before removing _ManagedCluster_ from a _ManageClusterSet_
 //2.10:ACM-7803
 //2.10:ACM-8847
 
-If a cluster is moved out of _ClusterSet_, or moved to another _ClusterSet_, Submariner's installation is no longer valid.
+If you remove a cluster from a `ClusterSet`, or move a cluster to a different `ClusterSet`, the Submariner installation is no longer valid.
 
-Submariner must be uninstalled before a _ManagedCluster_ is removed/moved from a _ManageClusterSet_. If not, it can’t be uninstalled/reinstalled and won’t work on that ManagedCluster.
+You must uninstall Submariner before moving or removing a `ManagedCluster` from a `ManageClusterSet`. If you don't uninstall Submariner, you cannot uninstall or reinstall Submariner anymore and Submariner stops working on your `ManagedCluster`.
 
 //[#known-issues-network]
 //== Networking known issues


### PR DESCRIPTION
Document that Submariner must be uninstalled before a Cluster is removed from a ClusterSet or Submariner's install will be invalid and it will not function.

Relates-to: https://issues.redhat.com/browse/ACM-8847
Relates-to: https://issues.redhat.com/browse/ACM-7803
Relates-to: https://issues.redhat.com/browse/ACM-9810