### PR TITLE
[ACM-10230] Incorrect documentation link for "Post Installation Storage Configuration" for HCP on virtualization documentation

### DIFF
--- a/clusters/hosted_control_planes/kubevirt_intro.adoc
+++ b/clusters/hosted_control_planes/kubevirt_intro.adoc
@@ -36,7 +36,7 @@ oc patch ingresscontroller -n openshift-ingress-operator default --type=json -p 
 ----
 - The {ocp-short} hosting cluster must have {ocp-virt-short}, version 4.14 or later, installed on it. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/virtualization/installing#installing-virt-web[Installing OpenShift Virtualization using the web console].
 - The {ocp-short} hosting cluster must be configured with OVNKubernetes as the default pod network CNI.
-- The {ocp-short} hosting cluster must have a default storage class. For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/post-installation_configuration/post-install-storage-configuration[Post-installation storage configuration]. The following example shows how to set a default storage class:
+- The {ocp-short} hosting cluster must have a default storage class. For more information, see link:https://docs.openshift.com/container-platform/4.14/post_installation_configuration/storage-configuration.html[Post-installation storage configuration]. The following example shows how to set a default storage class:
 
 +
 ----


### PR DESCRIPTION
[ACM-10230] Incorrect documentation link for "Post Installation Storage Configuration" for HCP on virtualization documentation

Fix Version: 
ACM 2.9

Issue Type: 
Update in the existing documentation

Changes Needed:

Need to update the hyperlink for "Post Installation Storage Configuration" in Prerequisite section 1.7.9.1 of the documentation