### PR TITLE
ACM#10128 and ACM#9464: Installing the hcp binary using the content gateway and CLI

### DIFF
--- a/clusters/hosted_control_planes/install_hcp_cli.adoc
+++ b/clusters/hosted_control_planes/install_hcp_cli.adoc
@@ -25,6 +25,68 @@ chmod +x hcp
 sudo mv hcp /usr/local/bin/.
 ----
 
+[#hosted-install-console]
+== Installing the hosted control plane command line interface by using the CLI
+
+You can install the hosted control plane command line interface, `hcp`, by using the CLI, by completing the following steps:
+
+. Get the URL to download the `hcp` binary by running the following command:
++
+----
+oc get ConsoleCLIDownload hcp-cli-download -o json | jq -r ".spec"
+----
+
+. Download the `hcp` binary by running the following command:
++
+----
+wget <hcp_cli_download_url> <1>
+----
++
+<1> Replace `hcp_cli_download_url` with the URL that you obtained from the previous step.
+
+. Unpack the downloaded archive by running the following command:
++
+----
+tar xvzf hcp.tar.gz
+----
+
+. Run the following command to make the binary file executable:
++
+----
+chmod +x hcp
+----
+
+. Run the following command to move the binary file to a directory in your path:
++
+----
+sudo mv hcp /usr/local/bin/.
+----
+
+[#hosted-install-gateway]
+== Installing the hosted control plane command line interface by using the content gateway
+
+You can install the hosted control plane command line interface, `hcp`, by using the content gateway. Complete the following steps:
+
+. Navigate to the link:https://developers.redhat.com/content-gateway/rest/browse/pub/mce/clients/hcp-cli/[content gateway] and download the `hcp` binary.
+
+. Unpack the downloaded archive by running the following command:
++
+----
+tar xvzf hcp.tar.gz
+----
+
+. Run the following command to make the binary file executable:
++
+----
+chmod +x hcp
+----
+
+. Run the following command to move the binary file to a directory in your path:
++
+----
+sudo mv hcp /usr/local/bin/.
+----
+
 You can now use the `hcp create cluster` command to create and manage hosted clusters. To list the available parameters, enter the following command:
 
 ----


### PR DESCRIPTION
This  PR adds the content[1] that is also applicable for 2.9_stage.

[1] 2.10_stage PRs are merged:
https://github.com/stolostron/rhacm-docs/pull/6100
https://github.com/stolostron/rhacm-docs/pull/6198

Jira: 
https://issues.redhat.com/browse/ACM-9464
https://issues.redhat.com/browse/ACM-10128

SME and peer review approvals are present in the 2.10_stage PRs.
