### PR TITLE
https://issues.redhat.com/browse/ACM-10223--removing content

### DIFF
--- a/clusters/install_upgrade/install_connected.adoc
+++ b/clusters/install_upgrade/install_connected.adoc
@@ -11,7 +11,7 @@ The {mce-short} is installed with Operator Lifecycle Manager, which manages the 
 
 - By default, the {mce-short} components are installed on worker nodes of your {ocp-short} cluster without any additional configuration. You can install {mce-short} onto worker nodes by using the {ocp-short} OperatorHub web console interface, or by using the {ocp-short} CLI.
 
-- If you have configured your {ocp-short} cluster with infrastructure nodes, you can install {mce-short} onto those infrastructure nodes by using the {ocp-short} CLI with additional resource parameters. Not all of the {mce-short} components have infrastructure node support, so some worker nodes are still required when installing {mce-short} on infrastructure nodes. See the _Installing multicluster engine on infrastructure nodes_ section for those details.
+- If you have configured your {ocp-short} cluster with infrastructure nodes, you can install {mce-short} onto those infrastructure nodes by using the {ocp-short} CLI with additional resource parameters. See the _Installing multicluster engine on infrastructure nodes_ section for those details.
 
 - If you plan to import Kubernetes clusters that were not created by {ocp-short} or 
 {mce}, you will need to configure an image pull secret. For information on how to configure an image pull secret and other advanced configurations, see options in the xref:./adv_config_install#advanced-config-engine[Advanced configuration] section of this documentation. 


### PR DESCRIPTION
Not all of the {mce-short} components have infrastructure node support, so some worker nodes are still required when installing {mce-short} on infrastructure nodes.

REMOVED