### PR TITLE
https://issues.redhat.com/browse/ACM-10400 Update release_notes_intro.adoc wrong version in removal

### DIFF
--- a/clusters/release_notes/release_notes_intro.adoc
+++ b/clusters/release_notes/release_notes_intro.adoc
@@ -3,7 +3,7 @@
 
 Learn about the current release. 
 
-*Note:* The 2.4 and earlier versions of {product-title-short} are _removed_ from service, and are no longer supported. Documentation for versions 2.4 and earlier is not updated. The documentation might remain available, but is deprecated without any Errata or other updates available.
+*Note:* The 2.6 and earlier versions of {product-title-short} are _removed_ from service, and are no longer supported. Documentation for versions 2.4 and earlier is not updated. The documentation might remain available, but is deprecated without any Errata or other updates available.
 
 * xref:../release_notes/whats_new.adoc#whats-new[What's new in {mce-short}]
 * xref:../release_notes/errata.adoc#errata-updates-mce[Errata updates]

--- a/clusters/release_notes/release_notes_intro.adoc
+++ b/clusters/release_notes/release_notes_intro.adoc
@@ -3,7 +3,7 @@
 
 Learn about the current release. 
 
-*Note:* The 2.6 and earlier versions of {product-title-short} are _removed_ from service, and are no longer supported. Documentation for versions 2.4 and earlier is not updated. The documentation might remain available, but is deprecated without any Errata or other updates available.
+*Note:* The 2.6 and earlier versions of {product-title-short} are _removed_ from service, and are no longer supported. Documentation for versions 2.6 and earlier is not updated. The documentation might remain available, but is deprecated without any Errata or other updates available.
 
 * xref:../release_notes/whats_new.adoc#whats-new[What's new in {mce-short}]
 * xref:../release_notes/errata.adoc#errata-updates-mce[Errata updates]


### PR DESCRIPTION
2.6 RHACM has been EOL, but it looks like we forgot one of the release notes.