### PR TITLE
No-Jira: Update the hosted cluster namespace parameter and secret name for consistency

### DIFF
--- a/clusters/hosted_control_planes/autoscale_node_non_bm.adoc
+++ b/clusters/hosted_control_planes/autoscale_node_non_bm.adoc
@@ -7,7 +7,7 @@ When you need more capacity in your hosted cluster and spare agents are availabl
 
 +
 ----
-oc -n ${CLUSTERS_NAMESPACE} patch nodepool ${HOSTED_CLUSTER_NAME} --type=json -p '[{"op": "remove", "path": "/spec/replicas"},{"op":"add", "path": "/spec/autoScaling", "value": { "max": 5, "min": 2 }}]'
+oc -n ${HOSTED_CLUSTER_NAMESPACE} patch nodepool ${HOSTED_CLUSTER_NAME} --type=json -p '[{"op": "remove", "path": "/spec/replicas"},{"op":"add", "path": "/spec/autoScaling", "value": { "max": 5, "min": 2 }}]'
 ----
 
 . Create a workload that requires a new node.
@@ -55,11 +55,11 @@ status: {}
 oc apply -f workload-config.yaml
 ----
 
-. Extract the `hosted-admin-kubeconfig` secret by entering the following command:
+. Extract the `admin-kubeconfig` secret by entering the following command:
 
 +
 ----
-oc extract -n clusters secret/hosted-admin-kubeconfig --to=./hostedcluster-secrets --confirm
+oc extract -n <hosted-cluster-namespace> secret/<hosted-cluster-name>admin-kubeconfig --to=./hostedcluster-secrets --confirm
 ----
 
 +
@@ -97,7 +97,7 @@ oc --kubeconfig ${HOSTED_CLUSTER_NAME}.kubeconfig get nodes
 To disable node auto-scaling, enter the following command:
 
 ----
-oc -n ${CLUSTERS_NAMESPACE} patch nodepool ${HOSTED_CLUSTER_NAME} --type=json -p '[\{"op":"remove", "path": "/spec/autoScaling"}, \{"op": "add", "path": "/spec/replicas", "value": $SOME_INT_VALUE_FOR_SCALING_TO}]'
+oc -n ${HOSTED_CLUSTER_NAMESPACE} patch nodepool ${HOSTED_CLUSTER_NAME} --type=json -p '[\{"op":"remove", "path": "/spec/autoScaling"}, \{"op": "add", "path": "/spec/replicas", "value": $SOME_INT_VALUE_FOR_SCALING_TO}]'
 ----
 
 The command removes `"spec.autoScaling"` from the YAML file, adds `"spec.replicas"`, and sets `"spec.replicas"` to the value that you specify.

--- a/clusters/hosted_control_planes/create_cluster_non_bm.adoc
+++ b/clusters/hosted_control_planes/create_cluster_non_bm.adoc
@@ -7,9 +7,9 @@ You can create a hosted cluster or import one. For instructions to import a host
 
 +
 ----
-export CLUSTERS_NAMESPACE="clusters"
+export HOSTED_CLUSTER_NAMESPACE="clusters"
 export HOSTED_CLUSTER_NAME="example"
-export HOSTED_CONTROL_PLANE_NAMESPACE="${CLUSTERS_NAMESPACE}-${HOSTED_CLUSTER_NAME}" <1>
+export HOSTED_CONTROL_PLANE_NAMESPACE="${HOSTED_CLUSTER_NAMESPACE}-${HOSTED_CLUSTER_NAME}" <1>
 export BASEDOMAIN="krnl.es"
 export PULL_SECRET_FILE=$PWD/pull-secret
 export MACHINE_CIDR=192.168.122.0/24
@@ -26,7 +26,7 @@ hcp create cluster agent \
     --api-server-address=api.${HOSTED_CLUSTER_NAME}.${BASEDOMAIN} \
     --etcd-storage-class=${ETCD_STORAGE} \
     --ssh-key  ${SSH_KEY} \
-    --namespace ${CLUSTERS_NAMESPACE} \
+    --namespace ${HOSTED_CLUSTER_NAMESPACE} \
     --control-plane-availability-policy SingleReplica \
     --release-image=quay.io/openshift-release-dev/ocp-release:${OCP_RELEASE} \
     --api-server-address=api.${HOSTED_CLUSTER_NAME}.${BASEDOMAIN}

--- a/clusters/hosted_control_planes/destroy_non_bm.adoc
+++ b/clusters/hosted_control_planes/destroy_non_bm.adoc
@@ -18,8 +18,8 @@ To destroy a hosted cluster, complete the following step:
 
 +
 ----
-hcp destroy cluster agent --name <cluster_name>
+hcp destroy cluster agent --name <hosted_cluster_name>
 ----
 
 +
-Replace `<cluster_name>` with the name of your cluster.
+Replace `<hosted_cluster_name>` with the name of your cluster.

--- a/clusters/hosted_control_planes/scale_nodepool_non_bm.adoc
+++ b/clusters/hosted_control_planes/scale_nodepool_non_bm.adoc
@@ -7,7 +7,7 @@ You add nodes to your hosted cluster by scaling the `NodePool` object.
 
 +
 ----
-oc -n <cluster-namespace> scale nodepool <nodepool-name> --replicas 2
+oc -n <hosted-cluster-namespace> scale nodepool <nodepool-name> --replicas 2
 ----
 
 +
@@ -148,11 +148,11 @@ hcp create nodepool agent \
 oc get nodepools --namespace clusters
 ----
 
-. Extract the `hosted-admin-kubeconfig` secret by entering the following command:
+. Extract the `admin-kubeconfig` secret by entering the following command:
 
 +
 ----
-oc extract -n clusters secret/hosted-admin-kubeconfig --to=./hostedcluster-secrets --confirm
+oc extract -n <hosted-cluster-namespace> secret/<hosted-cluster-name>-admin-kubeconfig --to=./hostedcluster-secrets --confirm
 ----
 
 +


### PR DESCRIPTION
This PR updates the hosted cluster namespace related parameter to `<hosted-cluster-namespace>` and updates secret name from `hosted-admin-kubeconfig` to `admin-kubeconfig` as per https://github.com/stolostron/rhacm-docs/pull/6152#discussion_r1553798126