### PR TITLE
Fix the operator policy documentation

### DIFF
--- a/governance/install_operator.adoc
+++ b/governance/install_operator.adoc
@@ -35,7 +35,7 @@ spec:
             sourceNamespace: openshift-marketplace
 ----
 
-After you add the `OperatorPolicy` policy template, the operatorGroup` and `subscription` objects are created on the cluster by using the controller. This prompts the OLM to complete the rest of the installation process. You can view the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
+After you add the `OperatorPolicy` policy template, the `operatorGroup` and `subscription` objects are created on the cluster by using the controller. This prompts the OLM to complete the rest of the installation process. You can view the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
 
 To verify the operator policy status, run the following command on the managed cluster:
 

--- a/governance/install_operator.adoc
+++ b/governance/install_operator.adoc
@@ -35,7 +35,7 @@ spec:
             sourceNamespace: openshift-marketplace
 ----
 
-After the Governance Policy Framework applies the `OperatorPolicy` policy template, the controller creates the `operatorGroup` and `subscription` objects on the cluster. This prompts OLM to handle the rest of the installation process. The controller reports the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
+After you add the `OperatorPolicy` policy template, the operatorGroup` and `subscription` objects are created on the cluster by using the controller. This prompts the OLM to complete the rest of the installation process. You can view the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
 
 To verify the operator policy status, run the following command on the managed cluster:
 

--- a/governance/install_operator.adoc
+++ b/governance/install_operator.adoc
@@ -35,7 +35,7 @@ spec:
             sourceNamespace: openshift-marketplace
 ----
 
-After you add the `OperatorPolicy` policy template, the `operatorGroup` and `subscription` objects are created on the cluster by using the controller. This prompts the OLM to complete the rest of the installation process. You can view the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
+After you add the `OperatorPolicy` policy template, the `operatorGroup` and `subscription` objects are created on the cluster by using the controller. As a result, the rest of the installation is completed by OLM. You can view the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
 
 To verify the operator policy status, run the following command on the managed cluster:
 

--- a/governance/install_operator.adoc
+++ b/governance/install_operator.adoc
@@ -1,55 +1,50 @@
 [#install-operator-with-policy]
 = Installing an operator by using the _OperatorPolicy_ resource (Technology Preview)
 
-To install Operator Lifecycle Manager (OLM) operators on your managed clusters, use the `OperatorPolicy` resource. When you have OLM operators on your managed clusters, OLM operators automate the installation processes of your various applications.  
+To install Operator Lifecycle Manager (OLM) managed operators on your managed clusters, use an `OperatorPolicy` policy template in a `Policy` definition.
 
 [#create-operator-policy]
 == Creating an _OperatorPolicy_ resource to install Quay
-To install the Quay operator on to your cluster, run the following command to create and apply the `OperatorPolicy` resource:
 
-----
-oc apply -f OperatorPolicy.yaml -n <policy-namespace>
-----
-
-Your `OperatorPolicy` resource might resemble the following sample:
+See the following operator policy sample that installs the latest Quay operator in the `stable-3.11` channel using the Red Hat operator catalog:
 
 [source,yaml]
 ----
-apiVersion: policy.open-cluster-management.io/v1beta1
-kind: OperatorPolicy
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
 metadata:
-  name: install-quay-operator
+  name: install-quay
+  namespace: open-cluster-management-global-set
 spec:
-  remediationAction: enforce
-  severity: medium
-  complianceType: musthave
-  operatorGroup:
-    name: scoped-operator-group
-    namespace: quay-operator-ns
-    targetNamespaces:
-      - quay-operator-ns
-  subscription:
-    channel: stable-3.8
-    name: project-quay
-    namespace: quay-operator-ns
-    installPlanApproval: Automatic
-    source: operatorhubio-catalog
-    sourceNamespace: olm
-    startingCSV: quay-operator.v3.8.1
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1beta1
+        kind: OperatorPolicy
+        metadata:
+          name: install-quay
+        spec:
+          remediationAction: enforce
+          severity: critical
+          complianceType: musthave
+          subscription:
+            channel: stable-3.11
+            installPlanApproval: Automatic
+            name: quay-operator
+            source: redhat-operators
+            sourceNamespace: openshift-marketplace
 ----
 
+After the Governance Policy Framework applies the `OperatorPolicy` policy template, the controller creates the `operatorGroup` and `subscription` objects on the cluster. This prompts OLM to handle the rest of the installation process. The controller reports the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
 
-After you apply a valid `OperatorPolicy` resource, the controller creates the `operatorGroup` and `subscription` objects on the cluster. This prompts OLM to handle the rest of the installation process. The controller reports the health of owned resources in the `.status.Conditions` and `.status.relatedObjects` fields of the `OperatorPolicy` resource on the managed cluster.
-
-To verify that the operator policy is created, run the following command:
+To verify the operator policy status, run the following command on the managed cluster:
 
 [source,bash]
 ----
-oc get operatorpolicy install-quay-operator -n <policy-namespace>
+oc -n <managed cluster namespace> get operatorpolicy install-quay
 ----
 
 [#add-resources-install-operator-pol]
 == Additional resources
 
 See xref:../governance/policy_operator.adoc#policy-operator[Operator policy controller (Technology Preview)]
-

--- a/governance/policy_operator.adoc
+++ b/governance/policy_operator.adoc
@@ -62,6 +62,6 @@ a| Define the configurations to create an operator subscription. You must add in
 
 * See xref:../governance/install_operator.adoc#install-operator-with-policy[Installing an operator by using the `OperatorPolicy` resource] for more details.
 
-* See the link:https://docs.openshift.com/container-platform/4.15/operators/understanding/olm/olm-understanding-olm.html#olm-subscription_olm-understanding-olm[Subscription] topic in the {ocp-short} documentation.
+* See the link:https://docs.openshift.com/container-platform/4.13/operators/understanding/olm/olm-understanding-olm.html#olm-subscription_olm-understanding-olm[Subscription] topic in the {ocp-short} documentation.
 
-* See the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html-single/operators/index#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] documentation for general information on OLM.
+* See the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] documentation for general information on OLM.

--- a/governance/policy_operator.adoc
+++ b/governance/policy_operator.adoc
@@ -1,7 +1,7 @@
 [#policy-operator]
 = Operator policy controller (Technology Preview)
 
-The operator policy controller allows you to monitor and install Operator Lifecycle Manager (OLM) operators across your clusters. Use the operator policy controller to monitor the health of various pieces of the operator and to specify how you want to automatically handle updates to the operator. You can also distribute an operator policy to managed clusters by using the Governance Framework and adding the policy to the `policy-templates` field of a policy on the hub cluster.
+The operator policy controller allows you to monitor and install Operator Lifecycle Manager (OLM) operators across your clusters. Use the operator policy controller to monitor the health of various pieces of the operator and to specify how you want to automatically handle updates to the operator. You can also distribute an operator policy to managed clusters by using the governance framework and adding the policy to the `policy-templates` field of a policy on the hub cluster.
 
 [#pre-req-policy-operator]
 == Prerequisites

--- a/governance/policy_operator.adoc
+++ b/governance/policy_operator.adoc
@@ -1,43 +1,13 @@
 [#policy-operator]
 = Operator policy controller (Technology Preview)
 
-The operator policy controller allows you to monitor and install Operator Lifecycle Manager (OLM) operators across your clusters. Use the operator policy controller to monitor the health of various pieces of the operator and to specify how you want to automatically handle updates to the operator. You can also distribute an operator policy to managed clusters by using the governance framework and adding the policy to the `policy-templates` field of a policy on the hub cluster.
+The operator policy controller allows you to monitor and install Operator Lifecycle Manager (OLM) operators across your clusters. Use the operator policy controller to monitor the health of various pieces of the operator and to specify how you want to automatically handle updates to the operator. You can also distribute an operator policy to managed clusters by using the Governance Framework and adding the policy to the `policy-templates` field of a policy on the hub cluster.
 
 [#pre-req-policy-operator]
 == Prerequisites
 
-* You must install OLM on your cluster.  In the _{ocp} documentation_, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].
+* OLM must be available on your managed cluster. This is enabled by default on {ocp}.
 * *Required access:* Cluster administrator
-
-The primary field in an operator policy is `spec.subscription`. 
-
-See the following operator policy sample:
-
-[source,yaml]
-----
-apiVersion: policy.open-cluster-management.io/v1beta1
-kind: OperatorPolicy
-metadata:
-  name: quay-policy
-spec:
-  remediationAction: inform
-  severity: medium
-  complianceType: musthave
-  operatorGroup: [optional]
-    name: scoped-operator-group
-    namespace: quay-opns
-    targetNamespaces:
-      - quay-opns
-  subscription:
-    channel: stable-3.10
-    name: quay-operator
-    namespace: quay-opns
-    installPlanApproval: Automatic
-    source: redhat-operators
-    sourceNamespace: openshift-marketplace
-  versions:
-    - quay-operator.v3.10.3
-----
 
 [#policy-operator-yaml-table]
 == Operator policy YAML table
@@ -69,8 +39,8 @@ If the `remediationAction` set to `inform`, the controller only reports the stat
 
 | `spec.subscription`
 | Required
-| Define the configurations to create an operator subscription. You must add information in the following fields to create an operator subscription:
-+
+a| Define the configurations to create an operator subscription. You must add information in the following fields to create an operator subscription:
+
 - `channel`
 - `name`
 - `namespace`
@@ -92,4 +62,6 @@ If the `remediationAction` set to `inform`, the controller only reports the stat
 
 * See xref:../governance/install_operator.adoc#install-operator-with-policy[Installing an operator by using the `OperatorPolicy` resource] for more details.
 
-* See the link:https://docs.openshift.com/container-platform/4.13/operators/understanding/olm/olm-understanding-olm.html#olm-subscription_olm-understanding-olm[Subscription] topic in the {ocp-short} documentation.
+* See the link:https://docs.openshift.com/container-platform/4.15/operators/understanding/olm/olm-understanding-olm.html#olm-subscription_olm-understanding-olm[Subscription] topic in the {ocp-short} documentation.
+
+* See the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html-single/operators/index#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] documentation for general information on OLM.

--- a/release_notes/whats_new.adoc
+++ b/release_notes/whats_new.adoc
@@ -56,7 +56,7 @@ See link:../observability/observe_environments_intro.adoc#observing-environments
 [#governance-whats-new]
 == Governance
 
-* *Technology Preview* Enable the policy compliance history API to store and query compliance history events for your hub cluster. See link:../apis/compliancehistory.adoc.json[Policy compliance history API (Technology Preview)]. To enable the API see, link:../governance/compliance_history.adoc#compliance-history[Policy compliance history (Technology Preview)].
+* *Technology Preview* Enable the policy compliance history API to store and query compliance history events for your hub cluster. See link:../apis/compliancehistory.json.adoc[Policy compliance history API (Technology Preview)]. To enable the API see, link:../governance/compliance_history.adoc#compliance-history[Policy compliance history (Technology Preview)].
 
 * Configure the operations of the Gatekeeper operator webhook to manage admission events. See link:../governance/create_gatekeeper.adoc#managing-gatekeeper-operator-policies[Managing Gatekeeper operator policies] for details.
 

--- a/release_notes/whats_new.adoc
+++ b/release_notes/whats_new.adoc
@@ -74,8 +74,6 @@ See link:../observability/observe_environments_intro.adoc#observing-environments
 
 * *Technology Preview:* You can monitor and install Operator Lifecycle Manager (OLM) operators across your clusters by using the operator policy controller. See link:../governance/policy_operator.adoc#policy-operator[Operator policy controller (Technology Preview)] for more information.
 
-* *Technology preview:* Create and apply an `OperatorPolicy` resource to install OLM operators. See link:..governance/install_operator.adoc#install-operator-with-policy[Installing an operator by using the _OperatorPolicy_ resource (Technology Preview)].
-
 * Use `Placement` resources to define where you want your policies to be placed. See, link:../governance/policy_overview.adoc#policy-overview[Policy overview] for more details.
 
 See link:../governance/grc_intro.adoc#governance[Governance] to learn more about the dashboard and the policy framework.


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-11351

The instructions were incorrect on how to install an operator using OperatorPolicy since we never recommend deploying a policy template directly. We must always use a Policy object to deliver it.

After correcting this, the documentation was pretty much the same as the policy_operator.adoc file, so I decided to remove it.

This also fixes a syntax error in the "Operator policy YAML table" to allow a list to be rendered correctly in the spec.subscription table cell.