### PR TITLE
[ACM-2.10] ACM#11454: Add the topology.kubernetes.io/zone label to bare metal hosts

### DIFF
--- a/clusters/hosted_control_planes/bm_intro.adoc
+++ b/clusters/hosted_control_planes/bm_intro.adoc
@@ -19,8 +19,6 @@ A _hosted cluster_ is an {ocp-short} cluster with its API endpoint and control p
 
 - Do not use `clusters` as a hosted cluster name.
 
-- Run the hub cluster and workers on the same platform for hosted control planes.
-
 - A hosted cluster cannot be created in the namespace of a {mce-short} managed cluster.
 
 - To provision hosted control planes on bare metal, you can use the Agent platform. The Agent platform uses the central infrastructure management service to add worker nodes to a hosted cluster. For an introduction to the central infrastructure management service, see xref:../cluster_lifecycle/cim_enable.adoc#enable-cim[Enabling the central infrastructure management service].
@@ -47,6 +45,8 @@ You must have the following prerequisites to configure a hosting cluster:
 ----
 oc get managedclusters local-cluster
 ----
+
+* You must add the `topology.kubernetes.io/zone` label to your bare metal hosts on your management cluster. Otherwise, all of the hosted control plane pods are scheduled on a single node, causing single point of failure.
 
 * You need to enable central infrastructure management. For more information, see xref:../cluster_lifecycle/cim_enable.adoc#enable-cim[Enabling the central infrastructure management service].
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-11454

Delete the duplicate entry "Run the hub....."

Add an entry in  prereqs