### PR TITLE
Add URL checking to the GitHub Actions linter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,15 +6,22 @@ on:
 
 jobs:
   asciidoc:
-    name: 'Build AsciiDocs'
+    name: Build AsciiDocs
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
+
+      - name: Install asciidoctor
+        run: |
+          sudo apt-get install -y asciidoctor
+
       - name: Build each .adoc with Asciidoctor, fail on WARN or above
         run: |
-          FAILED=0
-          if ! docker run --rm -v $(pwd):/rhacm-docs/ asciidoctor/docker-asciidoctor@sha256:59a7e165ed6375dd5dfb930cb90019f1ccaee39787dc97a3918d7022a7503543 find /rhacm-docs/ -name \*.adoc -exec asciidoctor --failure-level WARN --trace --verbose --warnings {} +; then
-            echo "Build errors were detected, see per-file details above."
-            exit 1
-          fi
+          find . -name \*.adoc -exec asciidoctor --failure-level WARN --trace --verbose --warnings {} +
+
+      - name: Link Check
+        uses: lycheeverse/lychee-action@2b973e86fc7b1f6b36a93795fe2c9c6ae1118621
+        with:
+          args: --no-progress --timeout 30 --scheme http --scheme https --require-https "./**/main.html"
+          fail: true

--- a/access_control/rbac.adoc
+++ b/access_control/rbac.adoc
@@ -1,7 +1,7 @@
 [#rbac-rhacm]
 = Role-based access control
 
-{product-title} supports role-based access control (RBAC). Your role determines the actions that you can perform. RBAC is based on the authorization mechanisms in Kubernetes, similar to {ocp}. For more information about RBAC, see the OpenShift _RBAC_ overview in the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/authentication_and_authorization/using-rbac.html[{ocp-short} documentation].
+{product-title} supports role-based access control (RBAC). Your role determines the actions that you can perform. RBAC is based on the authorization mechanisms in Kubernetes, similar to {ocp}. For more information about RBAC, see the OpenShift _RBAC_ overview in the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/authentication_and_authorization/using-rbac[{ocp-short} documentation].
 
 *Note:* Action buttons are disabled from the console if the user-role access is impermissible.
 

--- a/apis/channels.json.adoc
+++ b/apis/channels.json.adoc
@@ -282,7 +282,7 @@ __optional__|Name of the referent. More info: https://kubernetes.io/docs/concept
 |*namespace* +
 __optional__|Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/|string
 |*resourceVersion* +
-__optional__|Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency|string
+__optional__|Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency|string
 |*uid* +
 __optional__|UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids[UIDs]|string
 |===
@@ -350,13 +350,13 @@ __optional__|API version of the referent.|string
 |*fieldPath* +
 __optional__|If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.|string
 |*kind* +
-__optional__|Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds|string
+__optional__|Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds|string
 |*name* +
 __optional__|Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Names]|string
 |*namespace* +
 __optional__|Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/|string
 |*resourceVersion* +
-__optional__|Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency|string
+__optional__|Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency|string
 |*uid* +
 __optional__|UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids[UIIDs]|string
 |===

--- a/clusters/cluster_lifecycle/remove_managed_cluster.adoc
+++ b/clusters/cluster_lifecycle/remove_managed_cluster.adoc
@@ -152,4 +152,4 @@ sh-4.4#etcdctl compact $(etcdctl endpoint status --write-out="json" |  egrep -o 
 $ compacted revision 158774421
 ----
 
-. Defragment the `etcd` database and clear any `NOSPACE` alarms as outlined in link:https://docs.openshift.com/container-platform/latest/scalability_and_performance/recommended-host-practices.html#etcd-defrag[Defragmenting `etcd` data].
+. Defragment the `etcd` database and clear any `NOSPACE` alarms as outlined in link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/scalability_and_performance/recommended-performance-and-scalability-practices#etcd-defrag_recommended-etcd-practices[Defragmenting `etcd` data].

--- a/clusters/cluster_mce_overview.adoc
+++ b/clusters/cluster_mce_overview.adoc
@@ -11,7 +11,7 @@ Access the link:{support-matrix-mce}[Support matrix] to learn about hub cluster 
 
 - With your {ocp-short} cluster, you can use {mce-short} as a standalone cluster manager for cluster lifecycle function, or you can use it as part of a {product-title-short} hub cluster. 
 
-- If you are using {ocp-short} only, the operator is included with subscription. Visit link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/architecture/mce-overview-ocp[About {mce}] from the {ocp-short} documentation.
+- If you are using {ocp-short} only, the operator is included with subscription. Visit link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/architecture/about-the-multicluster-engine-for-kubernetes-operator[About {mce}] from the {ocp-short} documentation.
 
 - If you subscribe to {product-title-short}, you also receive the operator with installation. You can create, manage, and monitor other Kubernetes clusters with the {product-title-short} hub cluster. See the  {product-title-short} link:../install/install_overview.adoc#installing[Installing and upgrading] documentation.
 

--- a/clusters/hosted_control_planes/dr_hosted_cluster.adoc
+++ b/clusters/hosted_control_planes/dr_hosted_cluster.adoc
@@ -3,6 +3,6 @@
 
 The hosted control plane runs on the {mce-short} hub cluster. The data plane runs on a separate platform that you choose. When recovering the {mce-short} hub cluster from a disaster, you might also want to recover the hosted control planes.
 
-See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-backup-restore-dr#hcp-dr-aws[Disaster recovery for a hosted cluster within an AWS region] to learn how to back up a hosted control plane cluster and restore it on a different cluster.
+See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/high-availability-for-hosted-control-planes#hcp-disaster-recovery-aws[Disaster recovery for a hosted cluster within an AWS region] to learn how to back up a hosted control plane cluster and restore it on a different cluster.
 
 *Important:* Disaster recovery for hosted clusters is available on AWS only.

--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -53,7 +53,7 @@ To configure additional networks, guaranteed CPUs, and VM scheduling for node po
 
 For additional resources about hosted control planes, see the following {ocp-short} documentation:
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-overview#hosted-control-planes-architecture_hcp-overview[Architecture of hosted control planes]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-overview#hosted-control-planes-concepts-personas_hcp-overview[Glossary of common concepts and personas for hosted control planes]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-managing#hosted-control-planes-monitoring-dashboard_hcp-managing[Creating monitoring dashboards for hosted clusters]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-backup-restore-dr[Backup, restore, and disaster recovery for hosted control planes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hosted-control-planes-overview#hosted-control-planes-architecture_hcp-overview[Architecture of hosted control planes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hosted-control-planes-overview#hosted-control-planes-concepts-personas_hcp-overview[Glossary of common concepts and personas for hosted control planes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hosted-control-planes-observability#hosted-control-planes-monitoring-dashboard_hcp-observability[Creating monitoring dashboards for hosted clusters]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/high-availability-for-hosted-control-planes[Backup, restore, and disaster recovery for hosted control planes]

--- a/clusters/hosted_control_planes/scale_node_pool_kubevirt.adoc
+++ b/clusters/hosted_control_planes/scale_node_pool_kubevirt.adoc
@@ -118,4 +118,4 @@ Replace `4.x.0` with the supported {ocp-short} version that you want to use.
 
 - xref:../hosted_control_planes/kubevirt_intro.adoc#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization]
 - Return to the beginning of this topic, <<create-hosted-clusters-kubevirt-scaling-node-pool,Scaling a node pool>>.
-- To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/hcp-managing#scale-down-data-plane_hcp-managing[Scaling down the data plane to zero].
+- To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/troubleshooting-hosted-control-planes#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero].

--- a/clusters/hosted_control_planes/scale_nodepool_hosted_bm.adoc
+++ b/clusters/hosted_control_planes/scale_nodepool_hosted_bm.adoc
@@ -185,4 +185,4 @@ oc get nodepools --namespace clusters
 [#scale-nodepool-bm-additional-resources]
 == Additional resources
 
-* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/hcp-managing#scale-down-data-plane_hcp-managing[Scaling down the data plane to zero].
+* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/troubleshooting-hosted-control-planes#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero].

--- a/clusters/hosted_control_planes/scale_nodepool_hosted_ibmpower.adoc
+++ b/clusters/hosted_control_planes/scale_nodepool_hosted_ibmpower.adoc
@@ -138,4 +138,4 @@ For an output example, see the link:https://access.redhat.com/documentation/en-u
 [#scale-nodepool-non-ibmpower-additional-resources]
 == Additional resources
 
-* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/hcp-managing#scale-down-data-plane_hcp-managing[Scaling down the data plane to zero].
+* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/troubleshooting-hosted-control-planes#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero].

--- a/clusters/hosted_control_planes/scale_nodepool_hosted_ibmz.adoc
+++ b/clusters/hosted_control_planes/scale_nodepool_hosted_ibmz.adoc
@@ -144,4 +144,4 @@ For an output example, see the link:https://access.redhat.com/documentation/en-u
 [#scale-nodepool-ibmz-additional-resources]
 == Additional resources
 
-* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/hcp-managing#scale-down-data-plane_hcp-managing[Scaling down the data plane to zero].
+* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/troubleshooting-hosted-control-planes#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero].

--- a/clusters/hosted_control_planes/scale_nodepool_non_bm.adoc
+++ b/clusters/hosted_control_planes/scale_nodepool_non_bm.adoc
@@ -180,4 +180,4 @@ oc get nodepools --namespace clusters
 [#scale-nodepool-non-bm-additional-resources]
 == Additional resources
 
-* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/hcp-managing#scale-down-data-plane_hcp-managing[Scaling down the data plane to zero].
+* To scale down the data plane to zero, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.15/html/hosted_control_planes/troubleshooting-hosted-control-planes#scale-down-data-plane_hcp-troubleshooting[Scaling down the data plane to zero].

--- a/clusters/support_troubleshooting/trouble_hosted_cluster_backplane.adoc
+++ b/clusters/support_troubleshooting/trouble_hosted_cluster_backplane.adoc
@@ -66,4 +66,4 @@ oc adm must-gather --image=$IMAGE /usr/bin/gather hosted-cluster-namespace=HOSTE
 [#trouble-hosted-cluster-backplane-additional-resources]
 == Additional resources
 
-* For more information about troubleshooting hosted control planes, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-troubleshooting[Troubleshooting hosted control planes] in the {ocp-short} documentation.
+* For more information about troubleshooting hosted control planes, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/troubleshooting-hosted-control-planes[Troubleshooting hosted control planes] in the {ocp-short} documentation.

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -82,8 +82,8 @@ rules:
 
 [#additional-resources-gitops]
 == Additional resources
-//OF | fix first link | Aug 28 23
-- Refer to xref:../applications/gitops_config.adoc#tolerations-config[Configuring placement tolerations for {product-title-short} and OpenShift GitOps] for more details.
+
+- Refer to xref:../gitops/gitops_tolerations_config.adoc#tolerations-config[Configuring application placement tolerations for GitOps] for more details.
 
 - See the link:https://github.com/stolostron/multicloud-integrations/blob/main/examples/managedclustersetbinding.yaml[`multicloud-integrations` managed cluster set binding] example.
 

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -15,8 +15,6 @@ To configure GitOps with the Push model, you can register a set of one or more {
 
 Complete the following steps to register managed clusters to GitOps:
 
-. Create managed cluster sets and add managed clusters to those managed cluster sets. See the example for managed cluster sets in the link:https://github.com/stolostron/multicloud-integrations/blob/main/examples/openshift-gitops/managedclusterset.yaml[`multicloud-integrations managedclusterset`].
-
 +
 See the link:../clusters/cluster_lifecycle/create_clusterset.adoc#creating-a-managedclusterset[Creating a _ManagedClusterSet_] documentation for more information.
 
@@ -87,7 +85,7 @@ rules:
 //OF | fix first link | Aug 28 23
 - Refer to xref:../applications/gitops_config.adoc#tolerations-config[Configuring placement tolerations for {product-title-short} and OpenShift GitOps] for more details.
 
-- See the link:https://github.com/open-cluster-management/multicloud-integrations/blob/main/examples/managedclusterset.yaml[`multicloud-integrations` managed cluster set] example.
+- See the link:https://github.com/stolostron/multicloud-integrations/blob/main/examples/managedclustersetbinding.yaml[`multicloud-integrations` managed cluster set binding] example.
 
 - Refer to link:../clusters/cluster_lifecycle/create_clusterset.adoc#creating-a-managedclusterset[Creating a _ManagedClusterSet_] 
 

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -85,7 +85,7 @@ rules:
 
 - Refer to xref:../gitops/gitops_tolerations_config.adoc#tolerations-config[Configuring application placement tolerations for GitOps] for more details.
 
-- See the link:https://github.com/stolostron/multicloud-integrations/blob/main/examples/managedclustersetbinding.yaml[`multicloud-integrations` managed cluster set binding] example.
+- See the link:https://github.com/open-cluster-management-io/multicloud-integrations/blob/main/examples/managedclustersetbinding.yaml[`multicloud-integrations` managed cluster set binding] example.
 
 - Refer to link:../clusters/cluster_lifecycle/create_clusterset.adoc#creating-a-managedclusterset[Creating a _ManagedClusterSet_] 
 

--- a/governance/iam_policy_ctrl.adoc
+++ b/governance/iam_policy_ctrl.adoc
@@ -77,4 +77,4 @@ Enter `inform`. The IAM policy controller only supports the `inform` feature.
 [#iam-policy-sample]
 == IAM policy sample
 
-See link:https://github.com/open-cluster-management/policy-collection/blob/main/stable/AC-Access-Control/policy-limitclusteradmin.yaml[`policy-limitclusteradmin.yaml`] to view the IAM policy sample. See xref:../governance/create_policy.adoc#managing-security-policies[Managing security policies] for more information. Refer to xref:../governance/policy_controllers.adoc#policy-controllers[Policy controllers] for more topics.
+See xref:../governance/create_policy.adoc#managing-security-policies[Managing security policies] for more information. Refer to xref:../governance/policy_controllers.adoc#policy-controllers[Policy controllers] for more topics.

--- a/troubleshooting/trouble_hosted_cluster.adoc
+++ b/troubleshooting/trouble_hosted_cluster.adoc
@@ -66,6 +66,6 @@ oc adm must-gather --image=$IMAGE /usr/bin/gather hosted-cluster-namespace=HOSTE
 [#trouble-hosted-cluster-additional-resources]
 == Additional resources
 
-* For more information about troubleshooting hosted control planes, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hcp-troubleshooting[Troubleshooting hosted control planes] in the {ocp-short} documentation.
+* For more information about troubleshooting hosted control planes, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/troubleshooting-hosted-control-planes[Troubleshooting hosted control planes] in the {ocp-short} documentation.
 
 


### PR DESCRIPTION
Adds a link checker to the GitHub Action linting.

Also resolves the broken links that were reported (since otherwise this PR would merge with a failing workflow).

ref: https://issues.redhat.com/browse/ACM-11442