### PR TITLE
https://issues.redhat.com/browse/ACM-11746

### DIFF
--- a/clusters/cluster_lifecycle/import_gui.adoc
+++ b/clusters/cluster_lifecycle/import_gui.adoc
@@ -66,7 +66,7 @@ If you import a {ocp-short} Dedicated cluster and do not specify a vendor by add
 The following table provides the available options for _import mode_, which specifies the method for importing the cluster:
 
 |===
-| Run import commands manually | After completing and submitting the information in the console, including any Red Hat {aap-short} templates, run the provided command on the target cluster to import the cluster. If you are importing a cluster in the {ocp-short} Dedicated environment and running the import commands manually, complete the steps in xref:../cluster_lifecycle/import_gui.adoc#run-import-commands-manually[Running import commands manually in an {ocp-short} Dedicated environment] before providing the information in the console.
+| Run import commands manually | After completing and submitting the information in the console, including any Red Hat {aap-short} templates, run the provided command on the target cluster to import the cluster.
 | Enter your server URL and API token for the existing cluster | Provide the server URL and API token of the cluster that you are importing. You can specify a Red Hat {aap-short} template to run when the cluster is upgraded.
 | Provide the `kubeconfig` file | Copy and paste the contents of the `kubeconfig` file of the cluster that you are importing. You can specify a Red Hat {aap-short} template to run when the cluster is upgraded.
 |===
@@ -77,43 +77,6 @@ To configure a cluster API address, see xref:../cluster_lifecycle/import_gui.ado
 
 To configure your managed cluster klusterlet to run on specific nodes, see xref:../cluster_lifecycle/import_gui.adoc#import-configuring-nodeselector-tolerations[Optional: Configuring the klusterlet to run on specific nodes].
 
-[#run-import-commands-manually]
-=== Running import commands manually in an {ocp-short} Dedicated environment
-
-*Note:* The Klusterlet OLM Operator and the following steps are deprecated.
-
-If you are importing a cluster in an {ocp-short} Dedicated environment and running the import commands manually, you must complete some additional steps. 
-
-. Log in to the {ocp-short} console of the cluster that you want to import.
-
-. Create the `open-cluster-management-agent` and `open-cluster-management` namespaces or projects on the cluster that you are importing.
-
-. Find the klusterlet operator in the {ocp-short} catalog. 
-
-. Install the klusterlet operator in the `open-cluster-management` namespace or project that you created. 
-+
-*Important:* Do not install the operator in the `open-cluster-management-agent` namespace.
-
-. Extract the bootstrap secret from the import command by completing the following steps:
-
-.. Paste the import command into a file that you create named `import-command`.
-
-.. Run the following command to insert the content into the new file:
-+
-----
-cat import-command | awk '{split($0,a,"&&"); print a[3]}' | awk '{split($0,a,"|"); print a[1]}' | sed -e "s/^ echo //" | base64 -d
-----
-
-.. Find and copy the secret with the name `bootstrap-hub-kubeconfig` in the output.
-
-.. Apply the secret to the `open-cluster-management-agent` namespace on the managed cluster.
-
-.. Create the klusterlet resource using the example in the installed operator. Change the `clusterName` value to the same name as cluster name that was set during the import.
-+
-*Note:* When the `managedcluster` resource is successfully registered to the hub, there are two klusterlet operators that are installed. One klusterlet operator is in the `open-cluster-management` namespace, and the other is in the `open-cluster-management-agent` namespace. Having multiple operators does not affect the function of the klusterlet.
-
-. Provide the information in the console after selecting *Cluster* > *Import cluster*.
-  
 [#import-configuring-cluster-api]
 === Optional: Configuring the cluster API address
 

--- a/clusters/release_notes/deprecate_remove.adoc
+++ b/clusters/release_notes/deprecate_remove.adoc
@@ -64,4 +64,10 @@ A _removed_ item is typically function that was deprecated in previous releases 
 
 |===
 |Product or category | Affected item | Version | Recommended action | More details and links
+
+| Cluster lifecycle
+| Klusterlet OLM Operator
+| 2.6
+| None
+| None
 |===

--- a/clusters/release_notes/deprecate_remove.adoc
+++ b/clusters/release_notes/deprecate_remove.adoc
@@ -51,7 +51,7 @@ A _deprecated_ component, feature, or service is supported, but no longer recomm
 | None
 
 | Cluster lifecycle
-| Klusterlet OLM Operator
+| Klusterlet {olm} Operator
 | 2.4
 | None
 | None
@@ -66,7 +66,7 @@ A _removed_ item is typically function that was deprecated in previous releases 
 |Product or category | Affected item | Version | Recommended action | More details and links
 
 | Cluster lifecycle
-| Klusterlet OLM Operator
+| Klusterlet {olm} Operator
 | 2.6
 | None
 | None


### PR DESCRIPTION
- Klusterlet OLM operator references are removed from documentation
- Release Note included indicating that the Klusterlet OLM operator has been completely removed and not supported
