### PR TITLE
updates for Pantheon

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -49,7 +49,7 @@ Then, see the documentation related to the platform that you plan to use:
 
 To configure additional networks, guaranteed CPUs, and VM scheduling for node pools, see the following documentation:
 
-* xref:../hosted_control_planes/managing_nodepools_kubevirt.adoc#managing-nodepools-hosted-cluster-kubevirt[Configuring additional networks, guaranteed CPUs, and VM scheduling for node pools]
+* link:../hosted_control_planes/managing_nodepools_kubevirt.adoc#managing-nodepools-hosted-cluster-kubevirt[Configuring additional networks, guaranteed CPUs, and VM scheduling for node pools]
 
 For additional resources about hosted control planes, see the following {ocp-short} documentation:
 

--- a/troubleshooting/troubleshooting_intro.adoc
+++ b/troubleshooting/troubleshooting_intro.adoc
@@ -44,7 +44,7 @@ To view the main documentation about managing your clusters, see link:../cluster
 - xref:../troubleshooting/trouble_cluster_remove_namespace.adoc#trouble-cluster-remove-namespace[Namespace remains after deleting a cluster]
 - xref:../troubleshooting/trouble_auto_import_secret_exists.adoc#trouble-auto-import-secret-exists[Auto-import-secret-exists error when importing a cluster]
 - xref:../troubleshooting/trouble_cinder_csi_driver_volsync.adoc#troubleshooting-the-cinder-csi-driver-for-volsync[Troubleshooting the cinder Container Storage Interface (CSI) driver for VolSync]
-- xref:../troubleshooting/trouble_cluster_ignoring_addon.adoc#troubleshooting-cluster-ignoring-addon[Troubleshooting the cluster proxy add-on ignoring the add-on toleration]
+- link:../troubleshooting/trouble_cluster_ignoring_addon.adoc#troubleshooting-cluster-ignoring-addon[Troubleshooting the cluster proxy add-on ignoring the add-on toleration]
 
 
 *{global-hub}*


### PR DESCRIPTION
Adding screen captures of the log. This seems inaccurate. The links that are internal should have the `xref:` syntax. I made changes in a previous [PR](https://github.com/stolostron/rhacm-docs/pull/6500). Seems like the log is a bit inaccurate, @oafischer FYI @swopebe 

![Screenshot 2024-06-06 at 11 57 48 AM](https://github.com/stolostron/rhacm-docs/assets/60616885/90e8f1f3-f4ef-4427-833d-ed57038e512a)
![Screenshot 2024-06-06 at 11 58 40 AM](https://github.com/stolostron/rhacm-docs/assets/60616885/7662a382-01d8-4406-957b-a6cfef6c8971)
