### PR TITLE
[ACM-12000] Updated uninstall topic for MCH

### DIFF
--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -8,9 +8,9 @@ When you uninstall {product-title}, you see two different levels of the uninstal
 - The second level is a more complete uninstall that removes most operator components, excluding components such as custom resource definitions. When you continue with this step, it removes all of the components and subscriptions that were not removed with the custom resource removal. After this uninstall, you must reinstall the operator before reinstalling the custom resource.
 
 [#prerequisite-detach]
-== Prerequisite: Detach enabled services
+== Prerequisites
 
-Before you uninstall the {product-title-short} hub cluster, you must detach all of the clusters that are managed by that hub cluster. To resolve errors, detach all clusters that are still managed by the hub cluster, then try to uninstall again.
+Before you uninstall the {product-title-short} hub cluster, you must detach all of the clusters that are managed by that hub cluster. Detach all clusters that are still managed by the hub cluster, then try to uninstall again.
 
 * If you use Discovery, you might see the following error when you attempt uninstall:
 +
@@ -26,8 +26,9 @@ To disable Discovery, complete the following steps:
 - You can also use the terminal. Run the following command to disable Discover:
 
 +
+[source,bash]
 ----
-$ oc delete discoveryconfigs --all --all-namespaces
+oc delete discoveryconfigs --all --all-namespaces
 ----
 
 * If you have agent service configurations attached, you might see the following message:
@@ -43,15 +44,17 @@ Cannot delete MultiClusterHub resource because AgentServiceConfig resource(s) ex
 .. Log in to your hub cluster.
 
 .. Delete the `AgentServiceConfig` custom resource by entering the following command:
+
 +
 [source,bash]
 ----
-$ oc delete agentserviceconfig --all
+oc delete agentserviceconfig --all
 ----
 
 * If you have managed clusters attached, you might see the following message. *Note:* This does not include the `local-cluster`, which is your self-managed hub cluster:
  
 +
+[source,bash]
 ----
 Cannot delete MultiClusterHub resource because ManagedCluster resource(s) exist
 ----
@@ -59,9 +62,10 @@ Cannot delete MultiClusterHub resource because ManagedCluster resource(s) exist
 +
 For more information about detaching clusters, see the _Removing a cluster from management_ section by selecting the information for your provider in link:../clusters/cluster_lifecycle/create_intro.adoc#create-intro[Cluster creation introduction]. 
 
-* If you have Observability, you might see the following:
+* If you have Observability, you might see the following message:
 
 +
+[source,bash]
 ----
 Cannot delete MultiClusterHub resource because MultiClusterObservability resource(s) exist
 ----
@@ -71,7 +75,9 @@ Cannot delete MultiClusterHub resource because MultiClusterObservability resourc
 .. Log in to your hub cluster.
 
 .. Delete the `MultiClusterObservability` custom resource by entering the following command:
+
 +
+[source,bash]
 ----
 oc delete mco observability
 ----
@@ -81,12 +87,11 @@ oc delete mco observability
 
 .. If the `MultiClusterObservability` custom resource is installed, select the tab for _MultiClusterObservability_.
 
-.. Select the _Options_ menu for the `MultiClusterObservability` custom resource. 
+.. Select the *Options* menu for the `MultiClusterObservability` custom resource. 
 
 .. Select *Delete MultiClusterObservability*. 
 +
 When you delete the resource, the pods in the `open-cluster-management-observability` namespace on {product-title-short} hub cluster, and the pods in `open-cluster-management-addon-observability` namespace on all managed clusters are removed. 
-
 +
 *Note:* Your object storage is not affected after you remove the observability service.
 
@@ -96,19 +101,25 @@ When you delete the resource, the pods in the `open-cluster-management-observabi
 . If you have not already. ensure that your {ocp-short} CLI is configured to run `oc` commands. See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands. 
 
 . Change to your project namespace by entering the following command. Replace _namespace_ with the name of your project namespace:
+
 +
+[source,bash]
 ----
 oc project <namespace>
 ----
 
 . Enter the following command to remove the `MultiClusterHub` custom resource:
+
 +
+[source,bash]
 ----
 oc delete multiclusterhub --all
 ----
+
+. To view the progress, enter the following command: 
+
 +
-You can view the progress by entering the following command: 
-+
+[source,bash]
 ----
 oc get mch -o yaml
 ----
@@ -118,7 +129,9 @@ oc get mch -o yaml
 .. Install the Helm CLI binary version 3.2.0 or later, by following the instructions at link:https://helm.sh/docs/intro/install/[Installing Helm].
 
 .. Copy the following script into a file:
+
 +
+[source,bash]
 ----
 #!/bin/bash
 ACM_NAMESPACE=<namespace>
@@ -130,31 +143,36 @@ oc delete crd klusterletaddonconfigs.agent.open-cluster-management.io placementb
 oc delete mutatingwebhookconfiguration ocm-mutating-webhook managedclustermutators.admission.cluster.open-cluster-management.io multicluster-observability-operator
 oc delete validatingwebhookconfiguration channels.apps.open.cluster.management.webhook.validator application-webhook-validator multiclusterhub-operator-validating-webhook ocm-validating-webhook multicluster-observability-operator multiclusterengines.multicluster.openshift.io
 ----
+
 +
 Replace `<namespace>` in the script with the name of the namespace where {product-title-short} was installed.
 
++
 *Important:* Ensure that you specify the correct namespace, as the namespace is cleaned out and deleted.
 
++
 .. Run the script to remove any possible artifacts that remain from the previous installation. If there are no remaining artifacts, a message is returned that no resources were found.
 +
 *Note:* If you plan to reinstall the same {product-title-short} version, you can skip the next steps in this procedure and reinstall the custom resource. Proceed for a complete operator uninstall.
 
-+
 . Enter the following commands to delete the {product-title-short} `ClusterServiceVersion` and `Subscription` in the namespace where it is installed. Replace the `2.x.0` value with the current major or minor release:
+
++
+[source,bash]
 ----
-❯ oc get csv
+oc get csv
 NAME                                 DISPLAY                                      VERSION   REPLACES   PHASE
 advanced-cluster-management.v2.x.0   Advanced Cluster Management for Kubernetes   2.x.0                Succeeded
 
-❯ oc delete clusterserviceversion advanced-cluster-management.v2.x.0
+oc delete clusterserviceversion advanced-cluster-management.v2.x.0
 
-❯ oc get sub
+oc get sub
 NAME                        PACKAGE                       SOURCE                CHANNEL
 acm-operator-subscription   advanced-cluster-management   acm-custom-registry   release-2.x
 
-❯ oc delete sub acm-operator-subscription
+oc delete sub acm-operator-subscription
 ----
-
++
 *Note:* The name of the subscription and version of the CSV might differ.
 
 [#deleting-the-components-by-using-the-console]

--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -35,7 +35,7 @@ $ oc delete discoveryconfigs --all --all-namespaces
 +
 ----
 Cannot delete MultiClusterHub resource because AgentServiceConfig resource(s) exist
----
+----
 +
 - To disable and remove the `AgentServiceConfig` using the terminal, see the following procedure:
 

--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -30,7 +30,7 @@ To disable Discovery, complete the following steps:
 $ oc delete discoveryconfigs --all --all-namespaces
 ----
 
-* If you have agent service configs attached, you might see the following message:
+* If you have agent service configurations attached, you might see the following message:
 
 +
 [source,bash]
@@ -38,7 +38,7 @@ $ oc delete discoveryconfigs --all --all-namespaces
 Cannot delete MultiClusterHub resource because AgentServiceConfig resource(s) exist
 ----
 +
-- To disable and remove the `AgentServiceConfig` from by using the command line interface, complete the following steps:
+- To disable and remove the `AgentServiceConfig` resource by using the command line interface, complete the following steps:
 
 .. Log in to your hub cluster.
 

--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -30,6 +30,23 @@ To disable Discovery, complete the following steps:
 $ oc delete discoveryconfigs --all --all-namespaces
 ----
 
+* If you have agent service configs attached, you might see the following message.
+
++
+----
+Cannot delete MultiClusterHub resource because AgentServiceConfig resource(s) exist
+---
++
+- To disable and remove the `AgentServiceConfig` using the terminal, see the following procedure:
+
+.. Log in to your hub cluster.
+
+.. Delete the `AgentServiceConfig` custom resource by entering the following command:
++
+----
+$ oc delete agentserviceconfig --all
+----
+
 * If you have managed clusters attached, you might see the following message. *Note:* This does not include the `local-cluster`, which is your self-managed hub cluster:
  
 +

--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -30,19 +30,21 @@ To disable Discovery, complete the following steps:
 $ oc delete discoveryconfigs --all --all-namespaces
 ----
 
-* If you have agent service configs attached, you might see the following message.
+* If you have agent service configs attached, you might see the following message:
 
 +
+[source,bash]
 ----
 Cannot delete MultiClusterHub resource because AgentServiceConfig resource(s) exist
 ----
 +
-- To disable and remove the `AgentServiceConfig` using the terminal, see the following procedure:
+- To disable and remove the `AgentServiceConfig` from by using the command line interface, complete the following steps:
 
 .. Log in to your hub cluster.
 
 .. Delete the `AgentServiceConfig` custom resource by entering the following command:
 +
+[source,bash]
 ----
 $ oc delete agentserviceconfig --all
 ----


### PR DESCRIPTION
In ACM, when preparing to remove the MCH resources there is a prereq step that needs to be taken. This PR will add the missing step for the `AgentServiceConfig` resource that needs to be removed before MCH can be safely removed.

Related issue: https://issues.redhat.com/browse/ACM-12000
/cc @swopebe 