### PR TITLE
No Jira: Fixing broken links to OCP GitOps docs

### DIFF
--- a/gitops/gitops_push_pull.adoc
+++ b/gitops/gitops_push_pull.adoc
@@ -100,7 +100,7 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 
 - Push model implementation only contains the Argo CD application on the hub cluster, which has credentials for managed clusters. The Argo CD application on the hub cluster can deploy the applications to the managed clusters.
 
-- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {ocp-short} GitOps controller memory and CPU usage. To optimize resource management, refer to link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cicd/gitops#configuring-resource-quota[Configuring resource quota or requests].
+- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {ocp-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the Red Hat OpenShift GitOps documentation.
 
 - By default, the Push model is used to deploy the application unless you add the `apps.open-cluster-management.io/ocm-managed-cluster` and `apps.open-cluster-management.io/pull-to-ocm-managed-cluster` annotations to the template section of the `ApplicationSet`.
 
@@ -251,7 +251,7 @@ statuses:
 [#pull-push-resources]
 == Additional resources
 
- - See  link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cicd/gitops#configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the {ocp-short} documentation.
+ - See  link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/declarative_cluster_configuration/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the Red Hat OpenShift GitOps documentation.
 
 
-- See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cicd/gitops#setting-up-argocd-instance[Setting up an Argo CD instance] in the {ocp-short} documentation.
+- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the Red Hat OpenShift GitOps documentation.

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -6,7 +6,7 @@ To configure GitOps with the Push model, you can register a set of one or more {
 [#prerequisites-argo]
 == Prerequisites 
 
-. You need to install the link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cicd/gitops[Red Hat OpenShift GitOps operator] on your {product-title}.
+. You need to install the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/installing_gitops/index[Red Hat OpenShift GitOps operator] on your {product-title}.
 
 . Import one or more managed clusters.
 
@@ -99,4 +99,4 @@ rules:
 
 - See link:../clusters/cluster_lifecycle/create_clustersetbinding.adoc#creating-a-managedclustersetbinding[Creating a _ManagedClusterSetBinding_ resource] documentation for more information.
 
-- See link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/cicd/index#understanding-openshift-gitops[About GitOps] to learn more.
+- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About Red Hat OpenShift GitOps] to learn more.


### PR DESCRIPTION
No Jira. It looks like the docs for OCP GitOps moved to their own area in the portal, so several links were broken. I replaced the broken links with their new equivalents.