### PR TITLE
Update deprecate_remove.adoc misplaced deprecation

### DIFF
--- a/clusters/release_notes/deprecate_remove.adoc
+++ b/clusters/release_notes/deprecate_remove.adoc
@@ -43,7 +43,7 @@ A _deprecated_ component, feature, or service is supported, but no longer recomm
 |===
 | Product or category | Affected item | Version | Recommended action | More details and links
 | Hosted control planes
-| The --aws-creds flag is deprecated.
+| The `--aws-creds` flag is deprecated.
 | 2.6
 | Use the `--sts-creds` and `--role-arn` flags in the `hcp` command line interface.
 | None

--- a/clusters/release_notes/deprecate_remove.adoc
+++ b/clusters/release_notes/deprecate_remove.adoc
@@ -26,12 +26,6 @@ Learn when parts of the product are deprecated or removed from {mce-short}. Cons
 | Use `v1beta1`.
 | None
 
-| Hosted control planes
-| The --aws-creds flag is deprecated.
-| 2.6
-| Use the `--sts-creds` and `--role-arn` flags in the `hcp` command line interface.
-| None
-
 |===
 
 //[#api-removals-cluster]
@@ -41,14 +35,19 @@ Learn when parts of the product are deprecated or removed from {mce-short}. Cons
 //| Product or category | Affected item | Version | Recommended action | More details and links
 //|===
 
-//[#deprecations-cluster]
-//== Deprecations
+[#deprecations-cluster]
+== Deprecations
 
-//A _deprecated_ component, feature, or service is supported, but no longer recommended for use and might become obsolete in future releases. Consider the alternative actions in the _Recommended action_ and details that are provided in the following table:
+A _deprecated_ component, feature, or service is supported, but no longer recommended for use and might become obsolete in future releases. Consider the alternative actions in the _Recommended action_ and details that are provided in the following table:
 
-//|===
-//| Product or category | Affected item | Version | Recommended action | More details and links
-//|===
+|===
+| Product or category | Affected item | Version | Recommended action | More details and links
+| Hosted control planes
+| The --aws-creds flag is deprecated.
+| 2.6
+| Use the `--sts-creds` and `--role-arn` flags in the `hcp` command line interface.
+| None
+|===
 
 [#removals]
 == Removals


### PR DESCRIPTION
Deprecation for product features was commented out because we had none. If we add one, we need to un-comment it out to create that entry, but this was added to the API deprecation, which is different if you look at the description above the table.