### PR TITLE
No Jira: Clarifying support for HCP platforms, updating links to OCP 4.16

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -3,7 +3,7 @@
 
 With {mce-short} cluster management, you can deploy {ocp-short} clusters by using two different control plane configurations: standalone or hosted control planes. The standalone configuration uses dedicated virtual machines or physical machines to host the {ocp-short} control plane. With hosted control planes for {ocp-short}, you create control planes as pods on a hosting cluster without the need for dedicated physical machines for each control plane.
 
-Hosted control planes for {ocp-short} are available on Amazon Web Services (AWS), IBM Power, IBM Z, {ocp-virt}, bare metal, and non bare metal agent machines. The hosted control planes feature is enabled by default.
+Hosted control planes for {ocp-short} is available on Amazon Web Services (AWS), {ocp-virt}, and bare metal. In addition, hosted control planes is available as a Technology Preview feature on IBM Power, IBM Z, and non bare metal agent machines. The hosted control planes feature is enabled by default.
 
 Hosted control plane clusters offer several advantages:
 
@@ -38,8 +38,8 @@ The following table indicates which {ocp-short} versions are supported for each 
 === Additional resources
 
 *  xref:../hosted_control_planes/managing_nodepools_kubevirt.adoc#managing-nodepools-hosted-cluster-kubevirt[Configuring additional networks, guaranteed CPUs, and VM scheduling for node pools]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hosted-control-planes-overview#hosted-control-planes-architecture_hcp-overview[Architecture of hosted control planes]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hosted-control-planes-overview#hosted-control-planes-concepts-personas_hcp-overview[Glossary of common concepts and personas for hosted control planes]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/hosted-control-planes-observability#hosted-control-planes-monitoring-dashboard_hcp-observability[Creating monitoring dashboards for hosted clusters]
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/hosted_control_planes/high-availability-for-hosted-control-planes[Backup, restore, and disaster recovery for hosted control planes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.16/html/hosted_control_planes/hosted-control-planes-overview#hosted-control-planes-architecture_hcp-overview[Architecture of hosted control planes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.16/html/hosted_control_planes/hosted-control-planes-overview#hosted-control-planes-concepts-personas_hcp-overview[Glossary of common concepts and personas for hosted control planes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.16/html/hosted_control_planes/hosted-control-planes-observability#hosted-control-planes-monitoring-dashboard_hcp-observability[Creating monitoring dashboards for hosted clusters]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.16/html/hosted_control_planes/high-availability-for-hosted-control-planes[Backup, restore, and disaster recovery for hosted control planes]
 * xref:../hosted_control_planes/non_bm_intro.adoc#configuring-hosting-service-cluster-configure-agent-non-bm[Configuring hosted control plane clusters using non bare metal agent machines (Technology Preview)]

--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -7,13 +7,13 @@ Hosted control planes for {ocp-short} is available on Amazon Web Services (AWS),
 
 Hosted control plane clusters offer several advantages:
 
-* Saves cost by removing the need to host dedicated control plane nodes
+* Save cost by removing the need to host dedicated control plane nodes
 
-* Introduces separation between the control plane and the workloads, which improves isolation and reduces configuration errors that can require changes
+* Introduce separation between the control plane and the workloads, which improves isolation and reduces configuration errors that can require changes
 
-* Decreases the cluster creation time by removing the requirement for control plane node bootstrapping
+* Decrease the cluster creation time by removing the requirement for control plane node bootstrapping
 
-* Supports turn-key deployments or fully customized {ocp-short} provisioning
+* Support turn-key deployments or fully customized {ocp-short} provisioning
 
 [#hosted-control-requirements]
 == Requirements


### PR DESCRIPTION
No Jira.

This PR updates the hosted control planes intro to specify which platforms are available and which are TP features. It also updates any links to the OCP docs to point to the latest (4.16) version.