### PR TITLE
Add a description for --api-server-address for Agent

### DIFF
--- a/clusters/hosted_control_planes/create_cluster_bm.adoc
+++ b/clusters/hosted_control_planes/create_cluster_bm.adoc
@@ -24,12 +24,12 @@ hcp create cluster agent \
     --pull-secret=<path_to_pull_secret> \ <2>
     --agent-namespace=<hosted_control_plane_namespace> \ <3>
     --base-domain=<basedomain> \ <4>
-    --api-server-address=api.<hosted_cluster_name>.<basedomain> \
-    --etcd-storage-class=<etcd_storage_class> \ <5>
-    --ssh-key  <path_to_ssh_public_key> \ <6>
-    --namespace <hosted_cluster_namespace> \ <7>
+    --api-server-address=api.<hosted_cluster_name>.<basedomain> \ <5>
+    --etcd-storage-class=<etcd_storage_class> \ <6>
+    --ssh-key  <path_to_ssh_public_key> \ <7>
+    --namespace <hosted_cluster_namespace> \ <8>
     --control-plane-availability-policy SingleReplica \
-    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> <8>
+    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> <9>
 ----
 
 +
@@ -37,10 +37,11 @@ hcp create cluster agent \
 <2> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
 <3> Specify your hosted control plane namespace, for example, `clusters-example`. Ensure that agents are available in this namespace by using the `oc get agent -n <hosted_control_plane_namespace>` command.
 <4> Specify your base domain, for example, `krnl.es`.
-<5> Specify the etcd storage class name, for example, `lvm-storageclass`.
-<6> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
-<7> Specify your hosted cluster namespace.
-<8> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {ocp-short} release image digest, see _Extracting the {ocp-short} release image digest_.
+<5> The `--api-server-address` flag defines the IP address that is used for the Kubernetes API communication in the hosted cluster. If you do not set the `--api-server-address` flag, you must log in to connect to the management cluster.
+<6> Specify the etcd storage class name, for example, `lvm-storageclass`.
+<7> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+<8> Specify your hosted cluster namespace.
+<9> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {ocp-short} release image digest, see _Extracting the {ocp-short} release image digest_.
 
 +
 . After a few moments, verify that your hosted control plane pods are up and running by entering the following command:
@@ -136,11 +137,11 @@ hcp create cluster agent \
     --pull-secret=<path_to_pull_secret> \ <2>
     --agent-namespace=<hosted_control_plane_namespace> \ <3>
     --base-domain=<basedomain> \ <4>
-    --api-server-address=api.<hosted_cluster_name>.<basedomain> \
-    --image-content-sources icsp.yaml  \ <5>
-    --ssh-key  <path_to_ssh_key> \ <6>
-    --namespace <hosted_cluster_namespace> \ <7>
-    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> <8>
+    --api-server-address=api.<hosted_cluster_name>.<basedomain> \ <5>
+    --image-content-sources icsp.yaml  \ <6>
+    --ssh-key  <path_to_ssh_key> \ <7>
+    --namespace <hosted_cluster_namespace> \ <8>
+    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp_release_image> <9>
 ----
 
 +
@@ -148,10 +149,11 @@ hcp create cluster agent \
 <2> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
 <3> Specify your hosted control plane namespace, for example, `clusters-example`. Ensure that agents are available in this namespace by using the `oc get agent -n <hosted-control-plane-namespace>` command.
 <4> Specify your base domain, for example, `krnl.es`.
-<5> Specify the `icsp.yaml` file that defines ICSP and your mirror registries.
-<6> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
-<7> Specify your hosted cluster namespace.
-<8> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {ocp-short} release image digest, see _Extracting the {ocp-short} release image digest_.
+<5> The `--api-server-address` flag defines the IP address that is used for the Kubernetes API communication in the hosted cluster. If you do not set the `--api-server-address` flag, you must log in to connect to the management cluster.
+<6> Specify the `icsp.yaml` file that defines ICSP and your mirror registries.
+<7> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+<8> Specify your hosted cluster namespace.
+<9> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`. If you are using a disconnected environment, replace `<ocp_release_image>` with the digest image. To extract the {ocp-short} release image digest, see _Extracting the {ocp-short} release image digest_.
 
 [#hosted-create-bare-metal-additional-resources]
 == Additional resources

--- a/clusters/hosted_control_planes/create_cluster_non_bm.adoc
+++ b/clusters/hosted_control_planes/create_cluster_non_bm.adoc
@@ -22,12 +22,12 @@ hcp create cluster agent \
     --pull-secret=<path-to-pull-secret> \ <2>
     --agent-namespace=<hosted-control-plane-namespace> \ <3>
     --base-domain=<basedomain> \ <4>
-    --api-server-address=api.<hosted-cluster-name>.<basedomain> \
-    --etcd-storage-class=<etcd-storage-class> \ <5>
-    --ssh-key  <path-to-ssh-key> \ <6>
-    --namespace <hosted-cluster-namespace> \ <7>
+    --api-server-address=api.<hosted-cluster-name>.<basedomain> \ <5>
+    --etcd-storage-class=<etcd-storage-class> \ <6>
+    --ssh-key  <path-to-ssh-key> \ <7>
+    --namespace <hosted-cluster-namespace> \ <8>
     --control-plane-availability-policy SingleReplica \
-    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp-release> <8>
+    --release-image=quay.io/openshift-release-dev/ocp-release:<ocp-release> <9>
 ----
 
 +
@@ -35,10 +35,11 @@ hcp create cluster agent \
 <2> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
 <3> Specify your hosted control plane namespace, for example, `clusters-example`. Ensure that agents are available in this namespace by using the `oc get agent -n <hosted-control-plane-namespace>` command.
 <4> Specify your base domain, for example, `krnl.es`.
-<5> Specify the etcd storage class name, for example, `lvm-storageclass`.
-<6> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
-<7> Specify your hosted cluster namespace.
-<8> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`.
+<5> The `--api-server-address` flag defines the IP address that is used for the Kubernetes API communication in the hosted cluster. If you do not set the `--api-server-address` flag, you must log in to connect to the management cluster.
+<6> Specify the etcd storage class name, for example, `lvm-storageclass`.
+<7> Specify the path to your SSH public key. The default file path is `~/.ssh/id_rsa.pub`.
+<8> Specify your hosted cluster namespace.
+<9> Specify the supported {ocp-short} version that you want to use, for example, `4.14.0-x86_64`.
 
 +
 . After a few moments, verify that your hosted control plane pods are up and running by entering the following command:


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12665 

This PRs adds the description for the `--api-server-address` flag:

<5> The `--api-server-address` flag defines the IP address that is used for the Kubernetes API communication in the hosted cluster. If you do not set the `--api-server-address` flag, you must log in to connect to the management cluster.
