### PR TITLE
ACM-12682: update hcp doc

### DIFF
--- a/clusters/hosted_control_planes/create_hosted_aws.adoc
+++ b/clusters/hosted_control_planes/create_hosted_aws.adoc
@@ -66,69 +66,6 @@ hcp create cluster aws \
 <6> Specify the AWS region name, for example, `us-east-1`.
 <7> Specify the Amazon Resource Name (ARN), for example, `arn:aws:iam::820196288204:role/myrole`.
 
-[#create-hosted-multi-zone-aws-cloud-provider-secret]
-=== Providing credentials by using the AWS cloud provider secret
-
-You can use the `hcp create cluster aws` command with the `--secret-creds` flag to provide AWS cloud provider secret. Complete the following steps:
-
-. Create a hosted cluster by running the following command:
-
-+
-[source,bash]
-----
-hcp create cluster aws \
---name <hosted_cluster_name> \ <1>
---region <region> \ <2>
---namespace <hosted_cluster_namespace> \ <3>
---secret-creds <aws_secret_name> <4>
---sts-creds <path_to_sts_credential_file> <5>
---base-domain <basedomain> \ <6>
---pull-secret <path_to_pull_secret> \ <7>
---ssh-key-file <ssh_key> <8>
-----
-
-+
-<1> Specify the name of your hosted cluster, for instance, `example`.
-<2> Specify the AWS region name, for example, `us-east-1`.
-<3> If the secret is not in the default `clusters` namespace, specify your hosted cluster namespace.
-<4> Specify the AWS secret name, for example, `my-aws-cred`.
-<5> Specify the path to your AWS STS credentials file, for example, `/home/user/sts-creds/sts-creds.json`.
-<6> Specify your base domain, for example, `example.com`.
-<7> Specify the path to your pull secret, for example, `/user/name/pullsecret`.
-<8> Specify the SSH public key file to connect to the bastion. The default location for the SSH public key file is `~/.ssh/id_rsa.pub`.
-
-+
-. To create the secret by using the {mce-short} console, from the navigation menu, select *Credentials* and follow the credential creation steps in the console.
-
-. To create the secret on the command line, enter the following command:
-
-+
-[source,bash]
-----
-oc create secret generic <aws_secret_name> -n <namespace> --from-literal=baseDomain=<basedomain> --from-literal=aws_access_key_id=<aws_access_key> --from-literal=aws_secret_access_key=<aws_secret_key> --from-literal=pullSecret='{"auths":{"cloud.openshift.com":{"auth":"<auth>", "email":"<email>"}, "quay.io":{"auth":"<auth>", "email":"<email>"} } }' --from-literal=ssh-publickey=<ssh_public_key> --from-literal=ssh-privatekey=<ssh_private_key>
-----
-
-+
-The secret has the following format:
-
-+
-[source,yaml]
-----
-apiVersion: v1
-metadata:
-  name: <aws_secret_name> <1>
-  namespace: <hosted_cluster_namespace> <2>
-type: Opaque
-kind: Secret
-stringData:
-  ssh-publickey:          # Value
-  ssh-privatekey:         # Value
-  pullSecret:             # Value, required
-  baseDomain:             # Value, required
-  aws_secret_access_key:  # Value, required
-  aws_access_key_id:      # Value, required
-----
-
 [#create-hosted-aws-additional-resources]
 == Additional resources
 

--- a/clusters/hosted_control_planes/create_role_sts_aws.adoc
+++ b/clusters/hosted_control_planes/create_role_sts_aws.adoc
@@ -61,6 +61,7 @@ arn:aws:iam::820196288204:role/myrole
 +
 [source,json]
 ----
+	{
 		"Version": "2012-10-17",
 		"Statement": [
 			{
@@ -190,6 +191,7 @@ arn:aws:iam::820196288204:role/myrole
 				"Resource": "*"
 			}
 		]
+	}
 ----
 
 . Attach the `policy.json` file to your role by running the following command:


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12682
- hcp doc still references secret-creds, which is confusing as it doesn't support STS that is required for HCP in MCE 2.6: https://github.com/stolostron/rhacm-docs/blob/2.11_stage/clusters/hosted_control_planes/create_hosted_aws.adoc#providing-credentials-by-using-the-aws-cloud-provider-secret 
- the policy to apply has a typo, missing outer brackets { }: https://github.com/stolostron/rhacm-docs/blob/2.11_stage/clusters/hosted_control_planes/create_role_sts_aws.adoc#create-role-sts-aws 