### PR TITLE
Fixing the cluster book for 2.11

### DIFF
--- a/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
+++ b/clusters/hosted_control_planes/deploy_aws_private_clusters.adoc
@@ -12,14 +12,13 @@ For private clusters on AWS, all communication with the guest cluster occurs ove
 * <<prerequisites-aws-private-clusters,Prerequisites>>
 * <<create-aws-private-hosted-cluster,Creating a private hosted cluster on AWS>>
 * <<access-aws-private-hosted-cluster,Accessing a private hosting cluster on AWS>>
-* <<additional-resources-private-hosted-cluster-aws,Additional resources>>
 
 [#prerequisites-aws-private-clusters]
 == Prerequisites
 
 * To enable private hosted clusters for AWS, you must first enable AWS PrivateLink. For more information, see xref:../hosted_control_planes/enable_aws_private_link.adoc#hosted-enable-private-link[Enabling AWS PrivateLink].
 
-* You must create an AWS Identity and Access Management (IAM) role and AWS Security Token Service (STS) credentials. For more information, see xref:../hosted_control_planes/create_role_sts_aws.adoc#create-role-sts-aws[Creating an AWS IAM role and STS credentials] and xref:../hosted_control_planes/manage_aws_infra_iam.adoc#iam_aws[Identity and Access Management (IAM) permissions].
+* You must create an AWS Identity and Access Management (IAM) role and AWS Security Token Service (STS) credentials. For more information, see xref:../hosted_control_planes/create_role_sts_aws.adoc#create-role-sts-aws[Creating an AWS IAM role and STS credentials] and link:../hosted_control_planes/manage_aws_infra_iam.adoc#iam_aws[Identity and Access Management (IAM) permissions]. 
 
 * To access a private cluster, you need a bastion instance on AWS. For more information, see link:https://aws.amazon.com/solutions/implementations/linux-bastion/[Linux Bastion Hosts on AWS] in the AWS documentation.
 
@@ -65,7 +64,7 @@ The API endpoints for the cluster are accessible through a private DNS zone:
 
 * For more information about deploying a public hosted cluster on AWS, see xref:../hosted_control_planes/managing_hosted_aws.adoc#hosted-deploy-cluster-aws[Deploying a hosted cluster on AWS].
 
-* For more information about the ARN roles that you need to create a hosted cluster, see xref:../hosted_control_planes/manage_aws_infra_iam.adoc#iam_aws[Identity and Access Management (IAM) permissions].
+* For more information about the ARN roles that you need to create a hosted cluster, see link:../hosted_control_planes/manage_aws_infra_iam.adoc#iam_aws[Identity and Access Management (IAM) permissions].
 
 [#access-aws-private-hosted-cluster]
 == Accessing a private hosting cluster on AWS


### PR DESCRIPTION
Not sure why this came up as broken because the link syntax is correct. I would consider this an internal link (`xref`) because it is within the same folder. Hopefully this works. i also removed the child link to the Additional resources section. We agreed as a team that we didn't need to link that section in the TOC of the file 

<img width="597" alt="Screenshot 2024-07-15 at 6 30 51 PM" src="https://github.com/user-attachments/assets/3c614c89-c6ed-4fb9-81e7-04a2eb94a2b4">
