### PR TITLE
https://issues.redhat.com/browse/ACM-12721 Standardize naming

### DIFF
--- a/clusters/about/mce_networking.adoc
+++ b/clusters/about/mce_networking.adoc
@@ -19,12 +19,12 @@ For the {mce-short} cluster networking requirements, see the following table:
 
 | Outbound from the {ocp-short} managed cluster to the hub cluster
 | TCP
-| Communication between the ironic agent and the bare metal operator on the hub cluster
+| Communication between the Ironic Python Agent and the bare metal operator on the hub cluster
 | 6180, 6183, 6385, and 5050
 
-| Outbound from the hub cluster to the Ironic Python Agent (IPA) on the managed cluster
+| Outbound from the hub cluster to the Ironic Python Agent on the managed cluster
 | TCP
-| Communication between the bare metal node where IPA is running and the Ironic conductor service
+| Communication between the bare metal node where the Ironic Python Agent is running and the Ironic conductor service
 | 9999
 
 | Outbound and inbound


### PR DESCRIPTION
2.11 and 2.10