### PR TITLE
https://issues.redhat.com/browse/ACM-12898

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -23,5 +23,3 @@
 :quay-short: Quay
 :imagesdir: ../images
 :sno: single-node OpenShift
-:support-matrix: https://access.redhat.com/articles/7073065
-:support-matrix-mce: https://access.redhat.com/articles/7073030


### PR DESCRIPTION
Removing the conrefs for the support matrix again 
Link to the previous PR that was approved: https://github.com/stolostron/rhacm-docs/pull/6709/files