### PR TITLE
Backport link fix from 2.12

### DIFF
--- a/clusters/cluster_lifecycle/scale_managed_intro.adoc
+++ b/clusters/cluster_lifecycle/scale_managed_intro.adoc
@@ -7,5 +7,5 @@ For clusters that you created, you can customize and resize your managed cluster
 
 See the following options if you are using central infrastructure management for cluster deployment:
 
-* xref:../cluster_lifecycle/scale_node_ocp.adoc#add-nodes-ocp-infra-env[Adding worker nodes to {ocp-short} clusters]
+* xref:../cluster_lifecycle/scale_node_ocp.adoc#add-nodes-cim-ocp[Adding worker nodes to {ocp-short} clusters]
 * xref:../cluster_lifecycle/scale_node_ctrl_plane.adoc#adding-ctrl-nodes-managed[Adding control plane nodes to managed clusters]

--- a/clusters/cluster_lifecycle/scale_node_ctrl_plane.adoc
+++ b/clusters/cluster_lifecycle/scale_node_ctrl_plane.adoc
@@ -10,7 +10,7 @@ You can replace a failing control plane by adding control plane nodes to healthy
 
 Complete the following steps to add control plane nodes to healthy managed clusters:
 
-. Complete the steps in xref:scale_node_ocp.adoc#add-nodes-ocp-infra-env[Adding worker nodes to {ocp-short} clusters] for your the new control plane node.
+. Complete the steps in xref:scale_node_ocp.adoc#add-nodes-cim-ocp[Adding worker nodes to {ocp-short} clusters] for your the new control plane node.
 
 . Set the agent to `master` before you approve the agent by running the following command:
 
@@ -33,7 +33,7 @@ Complete the following steps to add control plane nodes to unhealthy managed clu
 
 . If you used the zero-touch provisioning flow for deployment, remove the bare metal host.
 
-. Complete the steps in xref:scale_node_ocp.adoc#add-nodes-ocp-infra-env[Adding worker nodes to {ocp-short} clusters] for your the new control plane node.
+. Complete the steps in xref:scale_node_ocp.adoc#add-nodes-cim-ocp[Adding worker nodes to {ocp-short} clusters] for your the new control plane node.
 
 . Set the agent to `master` before you approve the agent by running the following command:
 

--- a/clusters/cluster_lifecycle/scale_node_ocp.adoc
+++ b/clusters/cluster_lifecycle/scale_node_ocp.adoc
@@ -31,7 +31,7 @@ oc extract secret/$<kubeconfig_name> --keys=kubeconfig --to=- > original-kubecon
 oc --kubeconfig=original-kubeconfig get node
 ----
 
-. If you receive the following error message, you must update your `kubeconfig` secret. If you receive no error message, continue to <<add-nodes-ocp-infra-env-kubeconfig-steps,Adding worker nodes>>:
+. If you receive the following error message, you must update your `kubeconfig` secret. If you receive no error message, continue to <<add-nodes-cim-ocp-procedure,Adding worker nodes>>:
 
 +
 ----

--- a/clusters/cluster_lifecycle/scale_node_ocp.adoc
+++ b/clusters/cluster_lifecycle/scale_node_ocp.adoc
@@ -1,20 +1,20 @@
-[#add-nodes-ocp-infra-env]
+[#add-nodes-cim-ocp]
 = Adding worker nodes to {ocp-short} clusters
 
 If you are using central infrastructure management, you can customize your {ocp-short} clusters by adding additional production environment nodes.
 
 *Required access:* Administrator
 
-* <<add-nodes-ocp-infra-env-prereqs,Prerequisite>>
-* <<add-nodes-ocp-infra-env-kubeconfig,Creating a valid `kubeconfig`>>
-* <<add-nodes-ocp-infra-env-kubeconfig-steps,Adding worker nodes>>
+* <<add-nodes-cim-ocp-prereqs,Prerequisite>>
+* <<add-nodes-cim-ocp-create-config,Creating a valid `kubeconfig`>>
+* <<add-nodes-cim-ocp-procedure,Adding worker nodes>>
 
-[#add-nodes-cim-prereqs]
+[#add-nodes-cim-ocp-prereqs]
 == Prerequisite
 
 You must have the new CA certificates required to trust the managed cluster API.
 
-[#add-nodes-create-config]
+[#add-nodes-cim-ocp-create-config]
 == Creating a valid `kubeconfig`
 
 Before adding production environment worker nodes to {ocp-short} clusters, you must check if you have a valid `kubeconfig`.
@@ -82,7 +82,7 @@ If you receive a successful output, the `kubeconfig` is valid.
 oc patch secret $original-kubeconfig --type='json' -p="[{'op': 'replace', 'path': '/data/kubeconfig', 'value': '$(openssl base64 -A -in <new_kubeconfig_name>)'},{'op': 'replace', 'path': '/data/raw-kubeconfig', 'value': '$(openssl base64 -A -in <new_kubeconfig_name>)'}]"
 ----
 
-[#add-nodes-procedure]
+[#add-nodes-cim-ocp-procedure]
 == Adding worker nodes
 
 If you have a valid `kubeconfig`, complete the following steps to add production environment worker nodes to {ocp-short} clusters:


### PR DESCRIPTION
Instead of https://github.com/stolostron/rhacm-docs/pull/6771