### PR TITLE
https://issues.redhat.com/browse/ACM-13434--making necessary changes

### DIFF
--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -55,7 +55,6 @@ oc get infraenv -n <infra env namespace> <infra env name> -o jsonpath='{.status.
 See the following output:
 
 +
-[source,bash]
 ----
 https://assisted-image-service-assisted-installer.apps.example-acm-hub.com/byapikey/eyJhbGciOiJFUzI1NiIsInC93XVCJ9.eyJpbmZyYV9lbnZfaWQcTA0Y38sWVjYi02MTA0LTQ4NDMtODasdkOGIxYTZkZGM5ZTUifQ.3ydTpHaXJmTasd7uDp2NvGUFRKin3Z9Qct3lvDky1N-5zj3KsRePhAM48aUccBqmucGt3g/4.16/x86_64/minimal.iso
 ----
@@ -78,7 +77,6 @@ oc get agent -n <infra env namespace>
 You get an output that is similar to the following output:
 
 +
-[source,bash]
 ----
 NAME                                   CLUSTER   APPROVED   ROLE          STAGE
 24a92a6f-ea35-4d6f-9579-8f04c0d3591e             false      auto-assign   
@@ -104,7 +102,6 @@ oc get agent -n <infra env namespace>
 You get an output that is similar to the following output with a `true` value:
 
 +
-[source,bash]
 ----
 NAME                                   CLUSTER   APPROVED   ROLE          STAGE
 173e3a84-88e2-4fe1-967f-1a9242503bec             true       auto-assign    

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -1,9 +1,15 @@
 [#add-host-host-inventory]
 = Adding hosts to the host inventory by using the Discovery Image
 
-After creating your host inventory (infrastructure environment), you can discover your hosts and add them to your inventory. To add hosts to your inventory, choose a method to download an ISO file and attach it to each server. For example, you can download ISO files by using a virtual media, or by writing the ISO to a USB drive.
+After you create your host inventory (infrastructure environment), you can discover your hosts and add them to your inventory. 
 
-*Important:* To prevent the installation from failing, keep the Discovery ISO media connected to the device during the installation process and set each host to boot from the device one time.
+To add hosts to your inventory, choose a method to download an ISO file and attach it to each server. For example, you can download ISO files by using a virtual media, or by writing the ISO to a USB drive.
+
+*Important:* To prevent the installation from failing, keep the Discovery ISO media connected to the device during the installation process, and set each host to boot from the device one time.
+
+* <<add-host-prereqs,Prerequisites>>
+* <<add-host-steps-console,Adding hosts by using the console>>
+* <<add-host-steps-cli,Adding hosts by using the command line interface>>
 
 [#add-host-prereqs]
 == Prerequisites
@@ -37,7 +43,7 @@ The URL to download the ISO file in the `isoDownloadURL` property is in the stat
 
 Each booted host creates an `Agent` resource in the same namespace. 
 
-1. Run the following command to view the download URL in the `InfraEnv` custom resource:
+. Run the following command to view the download URL in the `InfraEnv` custom resource:
 
 +
 [source,bash]
@@ -66,6 +72,7 @@ Next, you need to approve each host. See the following procedure:
 oc get agent -n <infra env namespace>
 ----
 
++
 You get an output that is similar to the following output:
 
 +
@@ -91,6 +98,7 @@ oc patch agent -n <infra env namespace> <agent name> -p '{"spec":{"approved":tru
 oc get agent -n <infra env namespace>
 ----
 
++
 You get an output that is similar to the following output with a `true` value:
 
 +

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -30,9 +30,29 @@ You now see a URL to download the ISO file. Booted hosts appear in the host inve
 [#add-host-steps-cli]
 == Adding hosts by using the command line interface
 
-You can see the URL to download the ISO file in the `isoDownloadURL` property in the status of your `InfraEnv` resource. See _Creating a host inventory by using the command line interface_ for more information about the `InfraEnv` resource.
+The URL to download the ISO file in the `isoDownloadURL` property is in the status of your `InfraEnv` resource. See _Creating a host inventory by using the command line interface_ for more information about the `InfraEnv` resource.
 
-Each booted host creates an `Agent` resource in the same namespace. Approve each host so that you can use it.
+Each booted host creates an `Agent` resource in the same namespace. 
+
+1. Run the following command to view the download URL in the `InfraEnv` custom resource:
+
++
+[source,bash]
+----
+oc get infraenv -n <infra env namespace> <infra env name> -o jsonpath='{.status.isoDownloadURL}'
+----
+
+See the following output:
+
++
+[source,bash]
+----
+https://assisted-image-service-assisted-installer.apps.example-acm-hub.com/byapikey/eyJhbGciOiJFUzI1NiIsInC93XVCJ9.eyJpbmZyYV9lbnZfaWQcTA0Y38sWVjYi02MTA0LTQ4NDMtODasdkOGIxYTZkZGM5ZTUifQ.3ydTpHaXJmTasd7uDp2NvGUFRKin3Z9Qct3lvDky1N-5zj3KsRePhAM48aUccBqmucGt3g/4.16/x86_64/minimal.iso
+----
+
+. Use the URL to download the ISO file and boot your hosts with the ISO file.
+
+. Approve each host.
 
 [#additional-resources-add-host]
 == Additional resources

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -1,7 +1,7 @@
 [#add-host-host-inventory]
 = Adding hosts to the host inventory by using the Discovery Image
 
-After creating your host inventory (infrastructure environment) you can discover your hosts and add them to your inventory. To add hosts to your inventory, choose a method to download an ISO and attach it to each server. For example, you can download ISOs by using a virtual media or writing the ISO to a USB drive.
+After creating your host inventory (infrastructure environment), you can discover your hosts and add them to your inventory. To add hosts to your inventory, choose a method to download an ISO file and attach it to each server. For example, you can download ISO files by using a virtual media, or by writing the ISO to a USB drive.
 
 *Important:* To prevent the installation from failing, keep the Discovery ISO media connected to the device during the installation process and set each host to boot from the device one time.
 
@@ -14,7 +14,7 @@ After creating your host inventory (infrastructure environment) you can discover
 [#add-host-steps-console]
 == Adding hosts by using the console
 
-Download the ISO by completing the following steps:
+Download the ISO file by completing the following steps:
 
 . Select *Infrastructure* > *Host inventory* in the console.
 
@@ -22,14 +22,17 @@ Download the ISO by completing the following steps:
 
 . Click *Add hosts* and select *With Discovery ISO*.
 
-You now see a URL to download the ISO. Booted hosts appear in the host inventory table. Hosts might take a few minutes to appear. You must approve each host before you can use it. You can select hosts from the inventory table by clicking *Actions* and selecting *Approve*.
++
+You now see a URL to download the ISO file. Booted hosts appear in the host inventory table. Hosts might take a few minutes to appear. 
+
+. Approve each host so that you can use it. You can select hosts from the inventory table by clicking *Actions* and selecting *Approve*.
 
 [#add-host-steps-cli]
 == Adding hosts by using the command line interface
 
-You can see the URL to download the ISO in the `isoDownloadURL` property in the status of your `InfraEnv` resource. See Creating a host inventory by using the command line interface for more information about the `InfraEnv` resource.
+You can see the URL to download the ISO file in the `isoDownloadURL` property in the status of your `InfraEnv` resource. See _Creating a host inventory by using the command line interface_ for more information about the `InfraEnv` resource.
 
-Each booted host creates an `Agent` resource in the same namespace. You must approve each host before you can use it.
+Each booted host creates an `Agent` resource in the same namespace. Approve each host so that you can use it.
 
 [#additional-resources-add-host]
 == Additional resources

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -60,6 +60,8 @@ See the following output:
 https://assisted-image-service-assisted-installer.apps.example-acm-hub.com/byapikey/eyJhbGciOiJFUzI1NiIsInC93XVCJ9.eyJpbmZyYV9lbnZfaWQcTA0Y38sWVjYi02MTA0LTQ4NDMtODasdkOGIxYTZkZGM5ZTUifQ.3ydTpHaXJmTasd7uDp2NvGUFRKin3Z9Qct3lvDky1N-5zj3KsRePhAM48aUccBqmucGt3g/4.16/x86_64/minimal.iso
 ----
 
+*Note:* By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To display full ISO, replace `minimal.iso` in the URL with `full.iso`.
+
 . Use the URL to download the ISO file and boot your hosts with the ISO file.
 
 Next, you need to approve each host. See the following procedure:

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -3,7 +3,7 @@
 
 After you create your host inventory (infrastructure environment), you can discover your hosts and add them to your inventory. 
 
-To add hosts to your inventory, choose a method to download an ISO file and attach it to each server. For example, you can download ISO files by using a virtual media, or by writing the ISO to a USB drive.
+To add hosts to your inventory, choose a method to download an ISO file and attach it to each server. For example, you can download ISO files by using a virtual media, or by writing the ISO file to a USB drive.
 
 *Important:* To prevent the installation from failing, keep the Discovery ISO media connected to the device during the installation process, and set each host to boot from the device one time.
 

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -25,6 +25,9 @@ Download the ISO file by completing the following steps:
 +
 You now see a URL to download the ISO file. Booted hosts appear in the host inventory table. Hosts might take a few minutes to appear. 
 
++
+*Note:* By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To display full ISO, replace `minimal.iso` in the URL with `full.iso`.
+
 . Approve each host so that you can use it. You can select hosts from the inventory table by clicking *Actions* and selecting *Approve*.
 
 [#add-host-steps-cli]
@@ -53,41 +56,6 @@ https://assisted-image-service-assisted-installer.apps.example-acm-hub.com/byapi
 . Use the URL to download the ISO file and boot your hosts with the ISO file.
 
 . Approve each host.
-
-[#add-host-full-iso]
-== Changing your ISO
-
-By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To change your ISO, see the following procedure:
-
-. Create a config map in the `multicluster-engine` namespace to override the `assisted-service` environment variable. See the following sample where `ISO_IMAGE_TYPE` is `"full-iso"`.
-
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: assisted-service-config-override
-  namespace: multicluster-engine
-data:
-  ISO_IMAGE_TYPE: "full-iso"
-----
-
-. Annotate the `AgentServiceConfig` to reference the config map that you created.
-
-+
-[source,bash]
-----
-oc annotate --overwrite AgentServiceConfig agent unsupported.agent-install.openshift.io/assisted-service-configmap=assisted-service-config-override
-----
-
-. Run the following command to verify that the `assisted-service` pod has restarted:
-
-+
-[source,bash]
-----
-oc get po -n multicluster-engine | grep assisted
-----
 
 [#additional-resources-add-host]
 == Additional resources

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -26,7 +26,7 @@ Download the ISO file by completing the following steps:
 You now see a URL to download the ISO file. Booted hosts appear in the host inventory table. Hosts might take a few minutes to appear. 
 
 +
-*Note:* By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To get the full ISO, replace `minimal.iso` in the URL with `full.iso`.
+*Note:* By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To display full ISO, replace `minimal.iso` in the URL with `full.iso`.
 
 . Approve each host so that you can use it. You can select hosts from the inventory table by clicking *Actions* and selecting *Approve*.
 
@@ -56,7 +56,49 @@ https://assisted-image-service-assisted-installer.apps.example-acm-hub.com/byapi
 
 . Use the URL to download the ISO file and boot your hosts with the ISO file.
 
-. Approve each host.
+Next, you need to approve each host. See the following procedure:
+
+. Run the following command to list all of your `Agents`:
+
++
+[source,bash]
+----
+oc get agent -n <infra env namespace>
+----
+
+You get an output that is similar to the following output:
+
++
+[source,bash]
+----
+NAME                                   CLUSTER   APPROVED   ROLE          STAGE
+24a92a6f-ea35-4d6f-9579-8f04c0d3591e             false      auto-assign   
+----
+
+. Approve any `Agent` from the list with a `false` approval status. Run the following command:
+
++
+[source,bash]
+----
+oc patch agent -n <infra env namespace> <agent name> -p '{"spec":{"approved":true}}' --type merge
+----
+
+. Run the following command to confirm approval status:
+
++
+[source,bash]
+----
+oc get agent -n <infra env namespace>
+----
+
+You get an output that is similar to the following output with a `true` value:
+
++
+[source,bash]
+----
+NAME                                   CLUSTER   APPROVED   ROLE          STAGE
+173e3a84-88e2-4fe1-967f-1a9242503bec             true       auto-assign    
+----
 
 [#additional-resources-add-host]
 == Additional resources

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -54,6 +54,41 @@ https://assisted-image-service-assisted-installer.apps.example-acm-hub.com/byapi
 
 . Approve each host.
 
+[#add-host-full-iso]
+== Changing your ISO
+
+By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To change your ISO, see the following procedure:
+
+. Create a config map in the `multicluster-engine` namespace to override the `assisted-service` environment variable. See the following sample where `ISO_IMAGE_TYPE` is `"full-iso"`.
+
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: assisted-service-config-override
+  namespace: multicluster-engine
+data:
+  ISO_IMAGE_TYPE: "full-iso"
+----
+
+. Annotate the `AgentServiceConfig` to reference the config map that you created.
+
++
+[source,bash]
+----
+oc annotate --overwrite AgentServiceConfig agent unsupported.agent-install.openshift.io/assisted-service-configmap=assisted-service-config-override
+----
+
+. Run the following command to verify that the `assisted-service` pod has restarted:
+
++
+[source,bash]
+----
+oc get po -n multicluster-engine | grep assisted
+----
+
 [#additional-resources-add-host]
 == Additional resources
 

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -26,7 +26,7 @@ Download the ISO file by completing the following steps:
 You now see a URL to download the ISO file. Booted hosts appear in the host inventory table. Hosts might take a few minutes to appear. 
 
 +
-*Note:* By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To display full ISO, replace `minimal.iso` in the URL with `full.iso`.
+*Note:* By default, the ISO that is provided is a _minimal_ ISO. The minimal ISO does not contain the root file system, `RootFS`. The `RootFS` is downloaded later. To get the full ISO, replace `minimal.iso` in the URL with `full.iso`.
 
 . Approve each host so that you can use it. You can select hosts from the inventory table by clicking *Actions* and selecting *Approve*.
 

--- a/clusters/cluster_lifecycle/cim_add_host.adoc
+++ b/clusters/cluster_lifecycle/cim_add_host.adoc
@@ -45,6 +45,7 @@ Each booted host creates an `Agent` resource in the same namespace.
 oc get infraenv -n <infra env namespace> <infra env name> -o jsonpath='{.status.isoDownloadURL}'
 ----
 
++
 See the following output:
 
 +


### PR DESCRIPTION
1. This file had a citation not properly italicized.
2. We were calling it "an ISO" and ISO is the type of file or type of media, so we need to be specific.
3. Approve each host is a step in the procedure, but buried.

I am not sure what this is, because there are no steps but this begins with a gerund:

Adding...

You can....

See this...

Approve...

Is the only thing to do here is approve. I would go here looking for a procedure. Seems we are missing some info:

```
== Adding hosts by using the command line interface

You can see the URL to download the ISO file in the `isoDownloadURL` property in the status of your `InfraEnv` resource. See _Creating a host inventory by using the command line interface_ for more information about the `InfraEnv` resource.

Each booted host creates an `Agent` resource in the same namespace. 

Approve each host so that you can use it.
```
Then we need to address the issue:

```
The documentation is not thorough around the possible options for the discovery ISO.

The UI download link automatically encodes the minimal.iso in the URL, so this is the one the user gets by default.

The minimal.iso does not contain the full rootfs.  This makes it easier and faster to transport across a network.  However, as a result of the changes applied to make it lightweight, it is less compatible with systems, especially older ones.  It strips the UEFI secondary partition that some older bootloaders are looking for.  Older systems may still make use of the full.iso file, but we need to let users know it is possible. 
```