### PR TITLE
[ACM-14264]: Backport proxy prereq to HCP docs

### DIFF
--- a/clusters/hosted_control_planes/hosted_intro.adoc
+++ b/clusters/hosted_control_planes/hosted_intro.adoc
@@ -22,6 +22,8 @@ The hosting cluster and workers must run on the same infrastructure. For example
 
 The control plane is associated with a hosted cluster and runs as pods in a single namespace. When the cluster service consumer creates a hosted cluster, it creates a worker node that is independent of the control plane.
 
+If you are using a proxy and you want traffic from pods to the Kubernetes API server to not use the proxy, add the default Kubernetes API server address, 172.20.0.1, to the `no_proxy` list.
+
 The following table indicates which {ocp-short} versions are supported for each platform. In the table, _Hosting {ocp-short} version_ refers to the {ocp-short} version where {mce-short} is enabled:
 
 |===

--- a/clusters/hosted_control_planes/kubevirt_intro.adoc
+++ b/clusters/hosted_control_planes/kubevirt_intro.adoc
@@ -57,6 +57,8 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 oc get managedclusters local-cluster
 ----
 
+- If you are using a proxy, the `NO_PROXY` environment variable in {ocp-virt-short} must have an IP address of at least 172.20.0.1.
+
 [#firewall-port-reqs-kubevirt]
 == Firewall and port requirements
 

--- a/clusters/hosted_control_planes/kubevirt_intro.adoc
+++ b/clusters/hosted_control_planes/kubevirt_intro.adoc
@@ -57,8 +57,6 @@ oc patch storageclass ocs-storagecluster-ceph-rbd -p '{"metadata": {"annotations
 oc get managedclusters local-cluster
 ----
 
-- If you are using a proxy, the `NO_PROXY` environment variable in {ocp-virt-short} must have an IP address of at least 172.20.0.1.
-
 [#firewall-port-reqs-kubevirt]
 == Firewall and port requirements
 


### PR DESCRIPTION
Related Jira: https://issues.redhat.com/browse/ACM-14264

After the wording is approved, it needs to also be backported to the following versions:
- 2.10
- 2.9