### PR TITLE
Update create_clustersetbinding.adoc

### DIFF
--- a/clusters/cluster_lifecycle/create_clustersetbinding.adoc
+++ b/clusters/cluster_lifecycle/create_clustersetbinding.adoc
@@ -35,7 +35,7 @@ apiVersion: cluster.open-cluster-management.io/v1beta2
 kind: ManagedClusterSetBinding
 metadata:
   namespace: <namespace>
-  name: <cluster_name>
+  name: <cluster_set>
 spec:
   clusterSet: <cluster_set>
 ----


### PR DESCRIPTION
As per definition of ManagedClusterSetBinding.spec.clusterSet:

>ClusterSet is the name of the ManagedClusterSet to bind. It must match the instance name of the ManagedClusterSetBinding.