### PR TITLE
https://issues.redhat.com/browse/ACM-14609 for 2.11

### DIFF
--- a/business_continuity/backup_restore/backup_restore.adoc
+++ b/business_continuity/backup_restore/backup_restore.adoc
@@ -71,7 +71,7 @@ Before running the restore operation on a new hub cluster, you need to manually 
 
 Use the same configuration as on the initial hub cluster for the `MultiClusterHub` resource created by the {acm-short} operator, including any changes to the `MultiClusterEngine` resource.
 
-For example, if the initial hub cluster has any other operators installed, such as {aap-short}, Red Hat OpenShift GitOps, `cert-manager`, you have to install them before running the restore operation. This ensures that the new hub cluster is configured in the same way as the initial hub cluster.
+For example, if the initial hub cluster has any other operators installed, such as {aap-short}, {gitops}, `cert-manager`, you have to install them before running the restore operation. This ensures that the new hub cluster is configured in the same way as the initial hub cluster.
 
 [#clean-hub-restore]
 == Cleaning the hub cluster after restore

--- a/gitops/gitops_manage_policy_def.adoc
+++ b/gitops/gitops_manage_policy_def.adoc
@@ -1,9 +1,25 @@
 [#gitops-policy-definitions]
-= Managing policy definitions with {ocp-short} GitOps (Argo CD)
+= Managing policy definitions with {gitops} 
+
+With the `ArgoCD` resource, you can use {gitops} to manage policy definitions by granting {gitops-short} access to create policies on the {acm-short} hub cluster.
+
+- <<gitops-pol-def-prereq,Prerequisite>>
+- <<create-clusterrole-gitops,Creating a _ClusterRole_ resource for {gitops-short}>>
+- <<integrate-pol-gen-ocp-gitops,Integrating the Policy Generator with {gitops-short}>>
+
+[#gitops-pol-def-prereq]
+== Prerequisite
+
+You must log in to your hub cluster.
+
+*Required access:* Cluster administrator
 
 *Deprecated:* `PlacementRule`
 
-Based on Argo CD, you can use {ocp-short} GitOps to manage policy definitions. To allow this workflow, you must grant {ocp-short} GitOps access for you to create policies on the {acm-short} hub cluster. Complete the following steps to create a `ClusterRole` resource for {ocp-short} GitOps, with access to create, read, update, and delete policies and placements:
+[#create-clusterrole-gitops]
+== Creating a _ClusterRole_ resource for {gitops-short}
+
+To create a `ClusterRole` resource for {gitops-short}, with access to create, read, update, and delete policies and placements:
 
 . Create a `ClusterRole` from the console. Your `ClusterRole` might resemble the following example:
 
@@ -27,6 +43,9 @@ rules:
       - policy.open-cluster-management.io
     resources:
       - policies
+      - configurationpolicies
+      - certificatepolicies
+      - operatorpolicies
       - policysets
       - placementbindings
   - verbs:
@@ -58,7 +77,7 @@ rules:
       - placementdecisions/status
 ----
 
-. Create a `ClusterRoleBinding` object to grant the {ocp-short} GitOps service account access to the `openshift-gitops-policy-admin` `ClusterRole` object. Your `ClusterRoleBinding` might resemble the following example:
+. Create a `ClusterRoleBinding` object to grant the {gitops-short} service account access to the `openshift-gitops-policy-admin` `ClusterRole` object. Your `ClusterRoleBinding` might resemble the following example:
 
 +
 [source,yaml]
@@ -76,19 +95,32 @@ roleRef:
   kind: ClusterRole
   name: openshift-gitops-policy-admin
 ----
++
+*Notes:* 
+- When a {acm-short} policy definition is deployed with {gitops-short}, a copy of the policy is created in each managed cluster namespace for resolving hub template differences. These copies are called replicated policies.
+- To prevent {gitops-short} from repeatedly deleting this replicated policy or show that the Argo CD `Application` is out of sync, the `argocd.argoproj.io/compare-options: IgnoreExtraneous` annotation is automatically set on each replicated policy by the {acm-short} policy framework.
 
-When a {acm-short} policy definition is deployed with {ocp-short} GitOps, a copy of the policy is created in each managed cluster namespace. These copies are called replicated policies. To prevent {ocp-short} GitOps from repeatedly deleting this replicated policy or show that the ArgoCD `Application` is out of sync, the `argocd.argoproj.io/compare-options: IgnoreExtraneous` annotation is automatically set on each replicated policy by the {acm-short} policy framework.
+. There are labels and annotations used by Argo CD to track objects. For replicated policies to not show up at all in Argo CD, disable the Argo CD tracking labels and annotations by setting `spec.copyPolicyMetadata` to `false` on the {acm-short} policy definition.
 
-There are labels and annotations used by Argo CD to track objects. For replicated policies to not show up at all in Argo CD, you can set `spec.copyPolicyMetadata` to `false` on the {acm-short} policy definition to disable the Argo CD tracking labels and annotations from being copied to the replicated policy.
+[#integrate-pol-gen-ocp-gitops]
+== Integrating the Policy Generator with {gitops-short}
 
-[#policy-gen-install-on-openshift-gitops]
-== Integrating the Policy Generator with {ocp-short} GitOps (Argo CD)
+You can use {gitops-short} to generate policies by using the Policy Generator through GitOps. Since the Policy Generator does not come preinstalled in the {gitops-short} container image, you must complete customizations. 
 
-Based on Argo CD, you can use {ocp-short} GitOps to generate policies by using the Policy Generator through GitOps. Since the Policy Generator does not come preinstalled in the {ocp-short} GitOps container image, some customization must take place. In order to follow along, you must have the {ocp-short} GitOps Operator installed on the {acm-short} hub cluster and be sure to log in to the hub cluster.
+[#integrate-pol-gen-prereq]
+=== Prerequisites
 
-For {ocp-short} GitOps to have access to the Policy Generator when you run Kustomize, an Init Container is required to copy the Policy Generator binary from the {acm-short} Application Subscription container image to the {ocp-short} GitOps container. Additionally, {ocp-short} GitOps must be configured to provide the `--enable-alpha-plugins` flag when it runs Kustomize. Complete the following steps:
+* You must install {gitops-short} on your {acm-short} hub cluster.
+* You must log in to the hub cluster.
 
-. Start editing the {ocp-short} GitOps `argocd` object with the following command:
+[#access-policy-gen-gitops]
+== Accessing the Policy Generator from {gitops-short}
+
+To access the Policy Generator from {gitops-short}, you must configure the Init Container to copy the Policy Generator binary from the {acm-short} Application Subscription container image. You must also configure {gitops-short} by providing the `--enable-alpha-plugins` flag when it runs Kustomize.
+
+To create, read, update, and delete policies and placements with the Policy Generator, grant access to the Policy Generator from {gitops-short}. Complete the following steps:
+
+. Edit the {gitops-short} `argocd` object with the following command:
 
 +
 [source,bash]
@@ -96,7 +128,9 @@ For {ocp-short} GitOps to have access to the Policy Generator when you run Kusto
 oc -n openshift-gitops edit argocd openshift-gitops
 ----
 
-. Modify the {ocp-short} GitOps `argocd` object to contain the following additional YAML content. When a new major version of {acm-short} is released and you want to update the Policy Generator to a newer version, you need to update the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9` image used by the Init Container to a newer tag. View the following example and replace `<version>` with {product-version} or your desired {acm-short} version:
+. To update the Policy Generator to a newer version, add the `registry.redhat.io/rhacm2/multicluster-operators-subscription-rhel9` image used by the Init Container to a newer tag. Replace the `<version>` parameter with the latest {acm-short} version in your `ArgoCD` resource.
++
+Your `ArgoCD` resource might resemble the following YAML file:
 
 +
 [source,yaml]
@@ -138,8 +172,8 @@ spec:
 ----
 image: '{{ (index (lookup "apps/v1" "Deployment" "open-cluster-management" "multicluster-operators-hub-subscription").spec.template.spec.containers 0).image }}'
 ----
-+
-If you want to enable the processing of Helm charts inside of a Kustomize directory before generating policies, set the environment variable `POLICY_GEN_ENABLE_HELM` to `"true"` in the `spec.repo.env` field:
+
+. If you want to enable the processing of Helm charts within the Kustomize directory before generating policies, set the `POLICY_GEN_ENABLE_HELM` environment variable to `"true"` in the `spec.repo.env` field:
 
 +
 [source,yaml]
@@ -149,9 +183,7 @@ env:
   value: "true"
 ----
 
-. Now that {ocp-short} GitOps can use the Policy Generator, {ocp-short} GitOps must be granted access to create policies on the {acm-short} hub cluster. Create the `ClusterRole` resource called `openshift-gitops-policy-admin`, with access to create, read, update, and delete policies and placements. Refer to the ealier `ClusterRole` resource example.
-
-. Create a `ClusterRoleBinding` object to grant the {ocp-short} GitOps service account access to the `openshift-gitops-policy-admin` `ClusterRole`. Your `ClusterRoleBinding` might resemble the following resource:
+. To create, read, update, and delete policies and placements, create a `ClusterRoleBinding` object to grant the {gitops-short} service account access to {acm-short} hub cluster. Your `ClusterRoleBinding` might resemble the following resource:
 
 +
 [source,yaml]
@@ -173,6 +205,6 @@ roleRef:
 [#additional-resource-policy-def]
 == Additional resources
 
-* Refer to link:https://argoproj.github.io/argo-cd/[Argo CD] documentation.
+* See the link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.11/html/understanding_openshift_gitops/index[Understanding {gitops-short}] documentation.
 
 

--- a/gitops/gitops_manage_policy_def.adoc
+++ b/gitops/gitops_manage_policy_def.adoc
@@ -43,9 +43,6 @@ rules:
       - policy.open-cluster-management.io
     resources:
       - policies
-      - configurationpolicies
-      - certificatepolicies
-      - operatorpolicies
       - policysets
       - placementbindings
   - verbs:

--- a/gitops/gitops_push_pull.adoc
+++ b/gitops/gitops_push_pull.adoc
@@ -100,7 +100,7 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 
 - Push model implementation only contains the Argo CD application on the hub cluster, which has credentials for managed clusters. The Argo CD application on the hub cluster can deploy the applications to the managed clusters.
 
-- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {ocp-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the {gitops} documentation.
+- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {ocp-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.11/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the {gitops} documentation.
 
 - By default, the Push model is used to deploy the application unless you add the `apps.open-cluster-management.io/ocm-managed-cluster` and `apps.open-cluster-management.io/pull-to-ocm-managed-cluster` annotations to the template section of the `ApplicationSet`.
 
@@ -254,4 +254,4 @@ statuses:
  - See  link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/declarative_cluster_configuration/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the {gitops} documentation.
 
 
-- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the {gitops} documentation.
+- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.11/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the {gitops} documentation.

--- a/gitops/gitops_push_pull.adoc
+++ b/gitops/gitops_push_pull.adoc
@@ -100,7 +100,7 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 
 - Push model implementation only contains the Argo CD application on the hub cluster, which has credentials for managed clusters. The Argo CD application on the hub cluster can deploy the applications to the managed clusters.
 
-- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {ocp-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the Red Hat OpenShift GitOps documentation.
+- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {ocp-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the {gitops} documentation.
 
 - By default, the Push model is used to deploy the application unless you add the `apps.open-cluster-management.io/ocm-managed-cluster` and `apps.open-cluster-management.io/pull-to-ocm-managed-cluster` annotations to the template section of the `ApplicationSet`.
 
@@ -251,7 +251,7 @@ statuses:
 [#pull-push-resources]
 == Additional resources
 
- - See  link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/declarative_cluster_configuration/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the Red Hat OpenShift GitOps documentation.
+ - See  link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/declarative_cluster_configuration/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the {gitops} documentation.
 
 
-- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the Red Hat OpenShift GitOps documentation.
+- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the {gitops} documentation.

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -6,7 +6,7 @@ To configure GitOps with the Push model, you can register a set of one or more {
 [#prerequisites-argo]
 == Prerequisites 
 
-. You need to install the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/installing_gitops/index[{gitops} operator] on your {acm}.
+. You need to install the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.11/html/installing_gitops/index[{gitops} operator] on your {acm}.
 
 . Import one or more managed clusters.
 
@@ -99,4 +99,4 @@ rules:
 
 - See link:../clusters/cluster_lifecycle/create_clustersetbinding.adoc#creating-a-managedclustersetbinding[Creating a _ManagedClusterSetBinding_ resource] documentation for more information.
 
-- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About {gitops}] to learn more.
+- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.11/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About {gitops}] to learn more.

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -6,7 +6,7 @@ To configure GitOps with the Push model, you can register a set of one or more {
 [#prerequisites-argo]
 == Prerequisites 
 
-. You need to install the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/installing_gitops/index[Red Hat OpenShift GitOps operator] on your {acm}.
+. You need to install the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/installing_gitops/index[{gitops} operator] on your {acm}.
 
 . Import one or more managed clusters.
 
@@ -18,7 +18,7 @@ Complete the following steps to register managed clusters to GitOps:
 +
 See the link:../clusters/cluster_lifecycle/create_clusterset.adoc#creating-a-managedclusterset[Creating a _ManagedClusterSet_] documentation for more information.
 
-. Create a managed cluster set binding to the namespace where Red Hat OpenShift GitOps is deployed. For an example of binding the managed cluster to the `openshift-gitops` namespace, see the link:https://github.com/stolostron/multicloud-integrations/blob/main/examples/managedclustersetbinding.yaml[`multicloud-integrations`] managed clusterset binding example. In the _Additional resources_ section, see _Creating a ManagedClusterSetBinding resource_ for more general information about creating a `ManagedClusterSetBinding`. See link:../clusters/cluster_lifecycle/placement_filter.adoc[Filtering ManagedClusters from ManagedClusterSets] for placement information. 
+. Create a managed cluster set binding to the namespace where {gitops} is deployed. For an example of binding the managed cluster to the `openshift-gitops` namespace, see the link:https://github.com/stolostron/multicloud-integrations/blob/main/examples/managedclustersetbinding.yaml[`multicloud-integrations`] managed clusterset binding example. In the _Additional resources_ section, see _Creating a ManagedClusterSetBinding resource_ for more general information about creating a `ManagedClusterSetBinding`. See link:../clusters/cluster_lifecycle/placement_filter.adoc[Filtering ManagedClusters from ManagedClusterSets] for placement information. 
 
 . In the namespace that is used in managed cluster set binding, create a `Placement` custom resource to select a set of managed clusters to register to an {ocp-short} GitOps operator instance. Use the `multicloud-integration` placement example as a template. See _Using ManagedClusterSets with Placement_ for placement information. 
 +
@@ -99,4 +99,4 @@ rules:
 
 - See link:../clusters/cluster_lifecycle/create_clustersetbinding.adoc#creating-a-managedclustersetbinding[Creating a _ManagedClusterSetBinding_ resource] documentation for more information.
 
-- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About Red Hat OpenShift GitOps] to learn more.
+- See link:https://access.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About {gitops}] to learn more.

--- a/gitops/gitops_tolerations_config.adoc
+++ b/gitops/gitops_tolerations_config.adoc
@@ -2,7 +2,7 @@
 = Configuring application placement tolerations for GitOps
 //Please review this file.
 
-{acm-short} provides a way for you to register managed clusters that deploy applications to Red Hat OpenShift GitOps.
+{acm-short} provides a way for you to register managed clusters that deploy applications to {gitops}.
 
 In some unstable network scenarios, the managed clusters might be temporarily placed in `Unavailable` state. If a `Placement` resource is being used to facilitate the deployment of applications, add the following tolerations for the `Placement` resource to continue to include unavailable clusters. The following example shows a `Placement` resource with tolerations:
 

--- a/install/perform_scale.adoc
+++ b/install/perform_scale.adoc
@@ -20,7 +20,7 @@ The maximum number of clusters that {acm-short} can manage varies based on sever
 * Number of resources in the cluster, which depends on factors like the number of policies and applications that are deployed.
 * Configuration of the hub cluster, such as how many pods are used for scaling.
 
-The managed clusters are {sno} virtual machines hosted on Red Hat Enterprise Linux hypervisors. Virtual machines are used to achieve high-density counts of clusters per single bare metal machine in the testbed. Sushy-emulator is used with libvirt for virtual machines to have an accessible bare metal cluster by using Redfish APIs. The following operators are a part of the test installation, Topology Aware Lifecycle Manager, Local Storage Operator, and Red Hat OpenShift GitOps. The following table shows the lab environment scaling information:
+The managed clusters are {sno} virtual machines hosted on Red Hat Enterprise Linux hypervisors. Virtual machines are used to achieve high-density counts of clusters per single bare metal machine in the testbed. Sushy-emulator is used with libvirt for virtual machines to have an accessible bare metal cluster by using Redfish APIs. The following operators are a part of the test installation, Topology Aware Lifecycle Manager, Local Storage Operator, and {gitops}. The following table shows the lab environment scaling information:
 
 .Table for environment scaling
 |===

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -24,3 +24,5 @@
 :quay-short: Quay
 :imagesdir: ../images
 :sno: single-node OpenShift
+:gitops: Red Hat OpenShift GitOps
+:gitops-short: OpenShift GitOps


### PR DESCRIPTION
I also made updates to improve the Managing policy definitions for RH GitOps from 2.12. Reminder that only [Configuring policy health checks in Red Hat OpenShift GitOps](https://github.com/stolostron/rhacm-docs/blob/2.12_stage/gitops/gitops_manage_policy_def.adoc#config-gitops-healthcheck) is a 2.12 feature. This PR is to add the conref and replace the instances, along with improve the structure of Managing policy definitions.

