### PR TITLE
Fixing gov book for 2.10

### DIFF
--- a/governance/iam_policy_ctrl.adoc
+++ b/governance/iam_policy_ctrl.adoc
@@ -5,11 +5,7 @@ The Identity and Access Management (IAM) policy controller can be used to receiv
 
 The IAM policy controller monitors for the desired maximum number of users with a particular cluster role (i.e. `ClusterRole`) in your cluster. The default cluster role to monitor is `cluster-admin`. The IAM policy controller communicates with the local Kubernetes API server.
 
-The IAM policy controller runs on your managed cluster. View the following sections to learn more:
-
-* <<iam-policy-yaml-structure,IAM policy YAML structure>>
-* <<iam-policy-yaml-table,IAM policy YAML table>>
-* <<iam-policy-sample,IAM policy sample>>
+The IAM policy controller runs on your managed cluster. Continue reading to learn more:
 
 [#iam-policy-yaml-structure]
 == IAM policy YAML structure
@@ -72,3 +68,9 @@ Enter `inform`. The IAM policy controller only supports the `inform` feature.
 | Required
 | Maximum number of IAM role bindings that are available before a policy is considered non-compliant.
 |===
+
+[#iam-add-resources]
+== Additional resources
+
+- See xref:../governance/create_policy.adoc#managing-security-policies[Managing security policies] for more information.
+- See xref:../governance/policy_controllers.adoc#policy-controllers[Policy controllers] for more topics.


### PR DESCRIPTION
<img width="874" alt="Screenshot 2024-10-10 at 2 52 48 PM" src="https://github.com/user-attachments/assets/44c7d717-e502-471b-9579-ba787b79fcdc">

The link to the repo no longer exists. So i removed the child link that was mentioned earlier in the file and added an Additional resources section. 