### PR TITLE
[MERGE AFTER 2.12 PUBLISH] [2.11_stage] Add `containerArguments` docs to Gatekeeper

### DIFF
--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -30,6 +30,9 @@ spec:
     auditFromCache: Enabled
     auditChunkSize: 66
     emitAuditEvents: Enabled
+    containerArguments: <4>
+    - name: ""
+      value: ""
     resources:
       limits:
         cpu: 500m
@@ -50,6 +53,9 @@ spec:
      - "UPDATE"
      - "CONNECT"
     failurePolicy: Fail
+    containerArguments: <4>
+    - name: ""
+      value: ""
     resources:
       limits:
         cpu: 480m
@@ -74,11 +80,18 @@ spec:
     some-annotation: "this is a test"
     other-annotation: "another test"
 ----
-*Note:* For versions 3.14 or later, you can implement the following features from this YAML:
-
-<1> Enable the `auditEventsInvolvedNamespace` parameter to manage the namespace audit event you want to create. When you enable this parameter, the Gatekeeper controller deployment runs with the following argument: `--audit-events-involved-namespace=true`.
-<2> Enable the `admissionEventsInvolvedNamespace` parameter to manage the namespace admission event you want to create. When you enable this parameter, the Gatekeeper controller deployment runs with the following argument: `--admission-events-involved-namespace=true`.
-<3> To manage your webhook operations, you can use the following values for the `operations` parameter, `"CREATE"`, `"UPDATE"`, `"CONNECT"`, and `"DELETE"`.
+<1> For version 3.14 and later, enable the `auditEventsInvolvedNamespace` parameter to manage the namespace audit event you want to create. When you enable this parameter, the Gatekeeper controller deployment runs with the following argument: `--audit-events-involved-namespace=true`.
+<2> For version 3.14 and later, enable the `admissionEventsInvolvedNamespace` parameter to manage the namespace admission event you want to create. When you enable this parameter, the Gatekeeper controller deployment runs with the following argument: `--admission-events-involved-namespace=true`.
+<3> For version 3.14 and later, to manage your webhook operations, use the following values for the `operations` parameter, `"CREATE"`, `"UPDATE"`, `"CONNECT"`, and `"DELETE"`.
+<4> For version 3.17 and later, specify `containerArguments` by providing a list of argument names and values to pass to the container. Omit leading dashes from the argument name. An omitted value is treated as `true`. Arguments that you provide are ignored if the argument is set previously by the operator or configurations from other fields. See the following list of flags that are deny-listed and are not currently supported:
+- `port`
+- `prometheus-port`
+- `health-addr`
+- `validating-webhook-configuration-name`
+- `mutating-webhook-configuration-name`
+- `disable-cert-rotation`
+- `client-cert-name`
+- `tls-min-version`
 
 [#config-audit-sync]
 == Configuring _auditFromCache_ for sync details


### PR DESCRIPTION
* Add `containerArguments` docs to Gatekeeper

ref: https://issues.redhat.com/browse/ACM-14700

Cherry-pick:
- #7011