### PR TITLE
Fixing release notes book for 2.12

### DIFF
--- a/release_notes/acm_whats_new.adoc
+++ b/release_notes/acm_whats_new.adoc
@@ -18,7 +18,7 @@ See the following information about using CNFC providers:
 
 Learn specific details about new features for components within {acm-short}:
 
-* <<installation-whats-new,Installation>>
+* <<install-acm-whats-new,Installation>>
 * <<cluster-whats-new,Clusters>>
 * <<global-hub-whats-new,multicluster global hub>>
 * <<observability-whats-new,Observability>>
@@ -32,14 +32,14 @@ Access the link:https://access.redhat.com/articles/7086905[{acm-short} Support m
 [#install-acm-whats-new]
 == Installation
 
-* You can enable the `SiteConfig` component from the `MultiClusterHub` custom resource that is deployed on your cluster. By default, the `SiteConfig` component is disabled. Learn more at xref:../install/adv_config_install.adoc#advanced-config-hub[MultiClusterHub advanced configuration]. Learn more about {sco} at xref:../mce_acm_integration/siteconfig/siteconfig_intro.adoc#siteconfig-intro[{sco}]
+* You can enable the `SiteConfig` component from the `MultiClusterHub` custom resource that is deployed on your cluster. By default, the `SiteConfig` component is disabled. Learn more at link:../install/adv_config_install.adoc#advanced-config-hub[MultiClusterHub advanced configuration]. Learn more about {sco} at link:../mce_acm_integration/siteconfig/siteconfig_intro.adoc#siteconfig-intro[{sco}]
 
 [#cluster-whats-new]
 == Cluster lifecycle
 
 Cluster lifecycle components and features are within the {mce-short}, which is a software operator that enhances cluster fleet management. Learn about new {mce-short}-specific features and enhancements at link:../clusters/release_notes/mce_whats_new.adoc#whats-new-mce[What's new for Cluster lifecycle with {mce-short}].
 
-You can now enable and use {sco} as a template-driven cluster provisioning solution, which allows you to provision clusters with all available installation methods. Learn more about {sco} at xref:../mce_acm_integration/siteconfig/siteconfig_intro.adoc#siteconfig-intro[{sco}]
+You can now enable and use {sco} as a template-driven cluster provisioning solution, which allows you to provision clusters with all available installation methods. Learn more about {sco} at link:../mce_acm_integration/siteconfig/siteconfig_intro.adoc#siteconfig-intro[{sco}]
 
 View other Cluster lifecycle tasks and support information at link:../clusters/about/cluster_mce_overview.adoc#cluster_mce_overview[Cluster lifecycle with {mce-short} overview].
 


### PR DESCRIPTION
Links that send users to a different folder must use the following syntax: `link:`

<img width="881" alt="Screenshot 2024-10-21 at 7 55 34 PM" src="https://github.com/user-attachments/assets/a2998e93-e5da-4795-b2c7-3a3315a0300d">
