### PR TITLE
Moving a few entries since we have the Console section now

### DIFF
--- a/release_notes/acm_whats_new.adoc
+++ b/release_notes/acm_whats_new.adoc
@@ -61,8 +61,6 @@ The following new summary cards are available:
 
 * You can now export data in a CSV file by using selecting the *Export* button. See link:../console/console_access.adoc#accessing-your-console[Accessing your console].
 
-* You can now use the _Advanced search_ from the console by selecting the *Advanced search* drop-down button. Specify your query and receive results that match the exact strings that you enter and range-based search parameters. See link:../observability/search_console.adoc#search-customization[Search customization and configurations].
-
 * You can now view virtual machine resources from the console and your search results. Configure actions for the virtual machine resources. See link:../console/enable_vm_actions.adoc#enable-vm-actions[Enabling virtual machine actions (Technology Preview)].
 
 [#cluster-whats-new]
@@ -96,6 +94,8 @@ For other Application topics, see link:../applications/app_management_overview.a
 * To create and mount secrets to your `alertmanager` pods for access to arbitrary content, you can add the contents to your `MultiClusterObservability` resource. See link:../observability/observability_alerts.adoc#mount-secrets-alertmanager[Mounting secrets within the Alertmanager pods].
 
 * Grafana is updated to version 11.1.5. See link:../observability/design_grafana.adoc#using-grafana-dashboards[Using Grafana dashboards].
+
+* You can now use the _Advanced search_ from the console by selecting the *Advanced search* drop-down button. Specify your query and receive results that match the exact strings that you enter and range-based search parameters. See link:../observability/search_console.adoc#search-customization[Search customization and configurations].
 
 See link:../observability/observe_environments_intro.adoc#observing-environments-intro[Observability service introduction].
 

--- a/release_notes/acm_whats_new.adoc
+++ b/release_notes/acm_whats_new.adoc
@@ -42,6 +42,29 @@ Learn about what is new in the {acm-short} integrated console.
 
 * Command line interface (CLI) downloads are now available in the console, which are available from the `acm-cli` container image and are specified with the operating system and architecture. See link:../console/console.adoc#command-line-tools[Command line tools] to access command line interface (CLI) downloads, such as the `PolicyGenerator` and `policytools`.
 
+* You can now view more information about your cluster when you enable the _Fleet view_ switch. The following summary cards are redisigned:
+
++
+- Cluster
+- Application types
+- Policies
+- Cluster versions
+
++
+The following new summary cards are available: 
+
+- Cluster version
+- Nodes
+- Cluster recommendations
+- Cluster health
+- Personalized view of your resources
+
+* You can now export data in a CSV file by using selecting the *Export* button. See link:../console/console_access.adoc#accessing-your-console[Accessing your console].
+
+* You can now use the _Advanced search_ from the console by selecting the *Advanced search* drop-down button. Specify your query and receive results that match the exact strings that you enter and range-based search parameters. See link:../observability/search_console.adoc#search-customization[Search customization and configurations].
+
+* You can now view virtual machine resources from the console and your search results. Configure actions for the virtual machine resources. See link:../console/enable_vm_actions.adoc#enable-vm-actions[Enabling virtual machine actions (Technology Preview)].
+
 [#cluster-whats-new]
 == Clusters
 
@@ -75,34 +98,6 @@ For other Application topics, see link:../applications/app_management_overview.a
 * Grafana is updated to version 11.1.5. See link:../observability/design_grafana.adoc#using-grafana-dashboards[Using Grafana dashboards].
 
 See link:../observability/observe_environments_intro.adoc#observing-environments-intro[Observability service introduction].
-
-[search-whats-new]
-=== Search in the console
-
-* You can now view more information about your cluster when you enable the _Fleet view_ switch. The following summary cards are redisigned:
-
-+
-- Cluster
-- Application types
-- Policies
-- Cluster versions
-
-+
-The following new summary cards are available: 
-
-- Cluster version
-- Nodes
-- Cluster recommendations
-- Cluster health
-- Personalized view of your resources
-
-* You can now export data in a CSV file by using selecting the *Export* button. See link:../console/console_access.adoc#accessing-your-console[Accessing your console].
-
-* You can now use the _Advanced search_ from the console by selecting the *Advanced search* drop-down button. Specify your query and receive results that match the exact strings that you enter and range-based search parameters. See link:../observability/search_console.adoc#search-customization[Search customization and configurations].
-
-* You can now view virtual machine resources from the console and your search results. Configure actions for the virtual machine resources. See link:../console/enable_vm_actions.adoc#enable-vm-actions[Enabling virtual machine actions (Technology Preview)].
-
-See link:../console/console.adoc#home-page[Console overview].
 
 [#governance-whats-new]
 == Governance


### PR DESCRIPTION
Thanks for adding the console section Brandi. I figured it be best to move the entries out of Observability. In a refresh, I plan to move the search_console.adoc file to console per development request