### PR TITLE
SiteConfig: fix rendering issues

### DIFF
--- a/apis/clusterinstance.json.adoc
+++ b/apis/clusterinstance.json.adoc
@@ -308,6 +308,12 @@ __required__|The name of the ClusterInstance that you want to query.|string
 [[_rhacm-docs_apis_clusterinstance_jsonclusterinstance]]
 === ClusterInstance
 
+*Important:* Certain fields are only relevant to a specific installation flow. Verify which fields are applicable to your choice of installation method by checking the relevant documentation. For {ai} and Image Based Install, see the following documentation:
+
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_an_on-premise_cluster_with_the_agent-based_installer/index[Installing an on-premise cluster using the {ai}]
+
+* xref:../siteconfig/ibio_intro.adoc#ibio-intro[{ibio}]
+
 [options="header", cols=".^2a,.^3a,.^4a"]
 |===
 |Name|Description|Schema
@@ -365,8 +371,7 @@ __optional__|Specify the list of the `ConfigMap` object references that contain 
 __optional__|Set to `true` to prevent installation when using the {ai}.
 You can complete the inspection and validation steps, but after the `RequirementsMet` condition becomes `true`, the installation does not begin until the `holdInstallation` field is set to `false`.|bool
 |*ignitionConfigOverride* +
-__optional__|Specify the user overrides for the initial Ignition configuration. +
-*Important:* The {sco} ignores the `ignitionConfigOverride` field when cluster are installed with the IBI Operator.|string
+__optional__|Specify the user overrides for the initial Ignition configuration. +|string
 |*installConfigOverrides* +
 __optional__|Define install configuration parameters.|string
 |*machineNetwork* +
@@ -443,8 +448,7 @@ __optional__|Specify the user overrides for the host's :op-system-first: install
 |*ignitionConfigOverride* +
 __optional__|Specify the user overrides for the initial Ignition configuration.
 Use this field to assign partitions for persistent storage.
-Adjust disk ID and size to the specific hardware. +
-*Important:* The {sco} ignores the `ignitionConfigOverride` field when cluster are installed with the IBI Operator.|string
+Adjust disk ID and size to the specific hardware.|string
 |*ironicInspect* +
 __optional__|Specify if automatic introspection runs during registration of the bare metal host.
 |string

--- a/apis/main.adoc
+++ b/apis/main.adoc
@@ -4,6 +4,7 @@ include::modules/common-attributes.adoc[]
 
 include::api.adoc[leveloffset=+1]
 include::cluster.json.adoc[leveloffset=+2]
+include::clusterinstance.json.adoc[leveloffset=+2]
 include::clusterset.json.adoc[leveloffset=+2]
 include::clustersetbinding.json.adoc[leveloffset=+2]
 include::clusterview.json.adoc[leveloffset=+2]

--- a/mce_acm_integration/siteconfig/siteconfig_deprovision_clusters.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_deprovision_clusters.adoc
@@ -33,7 +33,6 @@ oc get clusterinstance <cluster_name> -n <target_namespace>
 
 See the following example output where the `(NotFound)` error indicates that your cluster is deprovisioned.
 
-+
 [source,terminal]
 ----
 Error from server (NotFound): clusterinstances.siteconfig.open-cluster-management.io "<cluster_name>" not found

--- a/mce_acm_integration/siteconfig/siteconfig_enable.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_enable.adoc
@@ -13,24 +13,14 @@ Enable the {sco} to use the default installation templates and install {sno} clu
 [#enable-siteconfig-mch]
 == Enabling the {sco} from the `MultiClusterHub` resource
 
-Edit the `MultiClusterHub` resource, then verify that {sco} is enabled. Complete the following procedure:
+Patch the `MultiClusterHub` resource, then verify that {sco} is enabled. Complete the following procedure:
 
-. Edit the `MultiClusterHub` resource by running the following command:
+. Set the `enabled` field to `true` in the `siteconfig` entry of `spec.overrides.components` in the `Multiclusterhub` resource by running the following command:
 
 +
 [source,terminal]
 ----
-oc -n rhacm edit multiclusterhubs.operator.open-cluster-management.io multiclusterhub
-----
-
-. Set the `enabled` field to `true` in the `siteconfig` entry of `spec.overrides.components`. See the following example:
-
-+
-[source,yaml]
-----
-- configOverrides: {}
-  enabled: true
-  name: siteconfig
+oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n rhacm --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"siteconfig","enabled": true}}]'
 ----
 
 . Verify that the {sco} is enabled by running the following command on the hub cluster:
@@ -50,7 +40,7 @@ See the following example output:
 siteconfig-controller-manager-6fdd86cc64-sdg87                    2/2     Running   0             43s
 ----
 
-. Verify that you have the default installation templates by running the following command on the hub cluster:
+. *Optional:* Verify that you have the default installation templates by running the following command on the hub cluster:
 
 +
 [source,terminal]

--- a/mce_acm_integration/siteconfig/siteconfig_install_clusters.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_install_clusters.adoc
@@ -14,7 +14,15 @@ Install your clusters with the {sco} by using the default installation templates
 ** To learn about and install the {ibio} for {sno}, see xref:../siteconfig/ibio_intro.adoc#ibio-intro[{ibio}].
 ** To install the {ai}, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_an_on-premise_cluster_with_the_agent-based_installer/index[Installing an on-premise cluster with the {ai}].
 
-[#install-clusters-target-ns]
+Complete the following steps to install a cluster with the {sco}:
+
+. <<install-create-target-ns,Creating the target namespace>>
+. <<install-create-pull-secret,Creating the pull secret>>
+. <<install-create-bmc-secret,Creating the BMC secret>>
+. <<install-create-extra-manifests,Optional: Creating the extra manifests>>
+. <<install-render-manifests,Rendering the installation manifests>>
+
+[#install-create-target-ns]
 == Creating the target namespace
 
 You need a target namespace when you create the pull secret, the BMC secret, extra manifest `ConfigMap` objects, and the `ClusterInstance` custom resource.
@@ -40,7 +48,7 @@ metadata:
 oc apply -f clusterinstance-namespace.yaml
 ----
 
-[#install-clusters-pull-secret]
+[#install-create-pull-secret]
 == Creating the pull secret
 
 You need a pull secret to enable your clusters to pull images from container registries. Complete the following steps to create a pull secret:
@@ -70,7 +78,7 @@ type: kubernetes.io/dockerconfigjson
 oc apply -f pull-secret.yaml
 ----
 
-[#install-clusters-bmc-secret]
+[#install-create-bmc-secret]
 == Creating the BMC secret
 
 You need a secret to connect to your baseboard management controller (BMC). Complete the following steps to create a secret:
@@ -100,7 +108,7 @@ type: Opaque
 oc apply -f example-bmc-secret.yaml
 ----
 
-[#install-clusters-extra-manifests]
+[#install-create-extra-manifests]
 == Optional: Creating the extra manifests
 
 You can create extra manifests that you need to reference in the `ClusterInstance` custom resource.
@@ -150,8 +158,8 @@ data:
 oc apply -f enable-crun.yaml
 ----
 
-[#install-clusters-reconcile-clusterinstance]
-== Render the installation manifests
+[#install-render-manifests]
+== Rendering the installation manifests
 
 Reference the templates and supporting manifests in the `ClusterInstance` custom resource.
 Complete the following steps to render the installation manifests by using the default cluster and node templates:
@@ -217,7 +225,7 @@ oc get clusterinstance <cluster_name> -n <target_namespace> -o yaml
 ----
 
 +
-See the following example output from the `status.conditions` section for successful manifest generation
+See the following example output from the `status.conditions` section for successful manifest generation:
 
 +
 [source,terminal]
@@ -236,4 +244,4 @@ type: RenderedTemplatesApplied
 oc get clusterinstance <cluster_name> -n <target_namespace> -o jsonpath='{.status.manifestsRendered}'
 ----
 
-For more information about status conditions, see _ClusterInstance CR conditions_.
+For more information about status conditions, see xref:../../apis/clusterinstance.json.adoc#clusterinstance-api[ClusterInstance API].

--- a/mce_acm_integration/siteconfig/siteconfig_installation_templates.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_installation_templates.adoc
@@ -1,18 +1,14 @@
 [#install-templates]
 = Installation templates overview
 
-Installation templates are data-driven templates that are used to generate the set of installation artifacts.
+Installation templates are data-driven templates that are used to generate the set of installation artifacts. These templates follow the Golang `text/template` format, and are instantiated by using data from the `ClusterInstance` custom resource. This enables dynamic creation of installation manifests for each target cluster that has similar configurations, but with different values.
 
-These templates follow the Golang text and template format, and they are instantiated by using data from the `ClusterInstance` custom resource.
-
-This enables dynamic creation of installation manifests for each target cluster that has similar configurations, but with different values.
-
-You can also create multiple sets based on the different installation methods or cluster topologies.
-
-There are two types of installation templates described in the following list:
+You can also create multiple sets based on the different installation methods or cluster topologies. The {sco} supports the following types of installation templates:
 
 Cluster-level:: Templates that must reference only cluster-specific fields.
 Node-level:: Templates that can reference both cluster-specific and node-specific fields.
+
+For more information about installation templates, see the following documentation:
 
 * <<template-functions,Template functions>>
 * <<default-templates,Default set of templates>>
@@ -46,7 +42,7 @@ The {sco} provides the following default, validated, and immutable set of templa
 |===
 |Installation method|Template type|File name|Template content
 
-.2+|Assisted Installer
+.2+|{ai}
 |Cluster-level templates
 |`ai-cluster-templates-v1.yaml`
 |`AgentClusterInstall` +
@@ -71,10 +67,8 @@ The {sco} provides the following default, validated, and immutable set of templa
 |`ibi-node-templates-v1.yaml`
 |`BareMetalHost` +
 `ImageClusterInstall` +
-`NetworkConfigMap`
+`NetworkSecret`
 |===
-
-*Note:* Certain fields are only relevant to either the Assisted Installer or the IBI Operator installation method. For more information, see link:../../apis/clusterinstance.json.adoc#clusterinstance-api[ClusterInstance API].
 
 [#special-template-variables]
 == Special template variables

--- a/mce_acm_integration/siteconfig/siteconfig_intro.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_intro.adoc
@@ -1,7 +1,7 @@
 [#siteconfig-intro]
 = {sco}
 
-The {sco} offers a template-driven cluster provisioning solution, which allows you to provision clusters with all available installation methods.
+The {sco} offers a template-driven cluster provisioning solution, which allows you to provision clusters with various installation methods.
 
 The {sco} introduces the unified `ClusterInstance` API, which comes from the `SiteConfig` API of the `SiteConfig` generator kustomize plugin.
 
@@ -15,7 +15,7 @@ Isolation:: Separates the cluster definition from the installation method. The `
 
 Unification:: The {sco} unifies both Git and non-Git workflows. You can apply the `ClusterInstance` custom resource directly on the hub cluster, or synchronize resources through a GitOps solution, such as ArgoCD.
 
-Consistency:: Maintains a consistent API across all installation methods, whether you are using the {ai}, the {ibio}, or any other custom template-based approach.
+Consistency:: Maintains a consistent API across installation methods, whether you are using the {ai}, the {ibio}, or any other custom template-based approach.
 
 Scalability:: Achieves greater scalability for each cluster than the `SiteConfig` kustomize plugin.
 
@@ -43,6 +43,8 @@ The following is a high-level overview of the process:
 . If the dry run is successful, the manifests are created, then the underlying Operators consume and process the manifests.
 . The installation begins.
 . The {sco} continuously monitors for changes in the associated `ClusterDeployment` resource and updates the `ClusterInstance` custom resource's `status` field accordingly.
+
+To learn more about how to use {sco}, see the following documentation:
 
 * xref:../siteconfig/siteconfig_installation_templates.adoc#install-templates[Installation templates overview]
 * xref:../siteconfig/siteconfig_enable.adoc#enable[Enabling the {sco}]

--- a/mce_acm_integration/siteconfig/siteconfig_scale_in_worker_nodes.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_scale_in_worker_nodes.adoc
@@ -12,14 +12,14 @@ Scale in your managed cluster that was installed by the {sco}. You can scale in 
 * You have the default templates. To get familiar with the default templates, see xref:../siteconfig/siteconfig_installation_templates.adoc#default-templates[Default set of templates]
 * You have installed your cluster with the {sco}. To install a cluster with the {sco}, see xref:../siteconfig/siteconfig_install_clusters.adoc#install-clusters[Installing {sno} clusters with the {sco}]
 
-[#scale-in-annotation]
+[#scale-add-annotation]
 == Adding an annotation to your worker node
 
-Add an annotation to mark the worker node for removal.
+Add an annotation to your worker node for removal.
 
-Complete the following steps to remove a worker node from the managed cluster:
+Complete the following steps to annotate worker node from the managed cluster:
 
-. Add an annotation in the `extraAnnotations` field of the worker node entry in the `ClusterInstance` custom resource:
+. Add an annotation in the `extraAnnotations` field of the worker node entry in the `ClusterInstance` custom resource that is used to provision your cluster:
 
 +
 [source,yaml]
@@ -48,32 +48,36 @@ oc apply -f <clusterinstance>.yaml
 
 .. If you are using GitOps ZTP, push to your Git repository and wait for Argo CD to synchronize the changes.
 
-. Wait for the `BaremetalHost` resource of that worker node to be deleted. Monitor the process by running the following command on the hub cluster:
+. Verify that the annotation is applied to the `BaremetalHost` worker resource by running the following command on the hub cluster:
 
 +
 [source,terminal]
 ----
-oc get bmh -n <managed_cluster_namespace> --watch
+oc get bmh -n <clusterinstance_namespace> worker-node2.example.com -ojsonpath='{.metadata.annotations}' | jq
 ----
 
 +
-See the following example output for successful worker node deletion:
-
-+
+See the following example output for successful application of the annotation:
 [source,terminal]
 ----
-NAME                                STATE            CONSUMER   ONLINE   ERROR   AGE
-master-node1.example.com            provisioned                 true             81m
-worker-node2.example.com            deprovisioning              true             44m
-worker-node2.example.com            deleting                    true             50m
+{
+  "baremetalhost.metal3.io/detached": "assisted-service-controller",
+  "bmac.agent-install.openshift.io/hostname": "worker-node2.example.com",
+  "bmac.agent-install.openshift.io/remove-agent-and-node-on-delete": "true"
+  "bmac.agent-install.openshift.io/role": "master",
+  "inspect.metal3.io": "disabled",
+  "siteconfig.open-cluster-management.io/sync-wave": "1",
+}
 ----
 
-[#scale-in-prunemanifests]
-== Pruning the `BareMetalHost` resource of the worker node
+[#scale-in-delete-baremetal-host]
+== Deleting the `BareMetalHost` resource of the worker node
 
-Prune the `BareMetalHost` resource of the worker node that you want to delete to prevent reprovisioning of the node.
+Delete the `BareMetalHost` resource of the worker node that you want to be removed.
 
-. Specify the API version and kind of the `BareMetalHost` resource in the node-level `pruneManifests` field:
+Complete the following steps to remove a worker node from the managed cluster:
+
+. Update the node object that you want to delete in your existing `ClusterInstance` custom resource with the following configuration:
 
 +
 [source,yaml]
@@ -82,7 +86,7 @@ Prune the `BareMetalHost` resource of the worker node that you want to delete to
 spec:
    ...
    nodes:
-     -hostName: "worker-node2.example.com"
+     - hostName: "worker-node2.example.com"
       ...
       pruneManifests:
         - apiVersion: metal3.io/v1alpha1
@@ -102,19 +106,25 @@ oc apply -f <clusterinstance>.yaml
 
 .. If you are using GitOps ZTP, push to your Git repository and wait for Argo CD to synchronize the changes.
 
-[#scale-in-delete-verification]
-=== Verifying worker node deletion
-
-Verify that the `Node`, `Agent`, and `BareMetalHost` resources are removed.
-
-
-. Verify that the `Node` resources are removed by running the following command on the hub cluster:
+. Verify that the `BareMetalHost` resources are removed by running the following command on the hub cluster:
 
 +
 [source,terminal]
 ----
-oc get managedclusterinfo/<managed_cluster_name> -n <managed_cluster_namespace>  \
--o jsonpath='{range .status.nodeList[*]}{.name}{"\t"}{.conditions}{"\t"}{.labels}{"\n"}{end}'
+oc get bmh -n <clusterinstance_namespace> --watch --kubeconfig <hub_cluster_kubeconfig_filename>
+----
+
++
+See the following example output:
+
++
+[source,terminal]
+----
+NAME                        STATE                        CONSUMER         ONLINE   ERROR   AGE
+master-node1.example.com    provisioned                  true             81m
+worker-node2.example.com    deprovisioning               true             44m
+worker-node2.example.com    powering off before delete   true             20h
+worker-node2.example.com    deleting                     true             50m
 ----
 
 . Verify that the `Agent` resources are removed by running the following command on the hub cluster:
@@ -122,13 +132,40 @@ oc get managedclusterinfo/<managed_cluster_name> -n <managed_cluster_namespace> 
 +
 [source,terminal]
 ----
-oc get agents -n <managed_cluster_namespace> --watch
+oc get agents -n <clusterinstance_namespace> --kubeconfig <hub_cluster_kubeconfig_filename>
 ----
 
-. Verify that the `BareMetalHost` resources are removed by running the following command on the hub cluster:
++
+See the following example output:
 
 +
 [source,terminal]
 ----
-oc get bmh -n <managed_cluster_namespace> --watch
+NAME                       CLUSTER                  APPROVED   ROLE     STAGE
+master-node1.example.com   <managed_cluster_name>   true       master   Done
+master-node2.example.com   <managed_cluster_name>   true       master   Done
+master-node3.example.com   <managed_cluster_name>   true       master   Done
+worker-node1.example.com   <managed_cluster_name>   true       worker   Done
+----
+
+. Verify that the `Node` resources are removed by running the following command on the managed cluster:
+
++
+[source,terminal]
+----
+oc get nodes --kubeconfig <managed_cluster_kubeconfig_filename>
+----
+
++
+See the following example output:
+
++
+[source,terminal]
+----
+NAME                       STATUS                        ROLES                  AGE   VERSION
+worker-node2.example.com   NotReady,SchedulingDisabled   worker                 19h   v1.30.5
+worker-node1.example.com   Ready                         worker                 19h   v1.30.5
+master-node1.example.com   Ready                         control-plane,master   19h   v1.30.5
+master-node2.example.com   Ready                         control-plane,master   19h   v1.30.5
+master-node3.example.com   Ready                         control-plane,master   19h   v1.30.5
 ----

--- a/mce_acm_integration/siteconfig/siteconfig_scale_out_worker_nodes.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_scale_out_worker_nodes.adoc
@@ -15,11 +15,11 @@ Scale out your managed cluster that was installed by the {sco}. You can scale ou
 [#scale-out-annotation]
 == Adding a worker node
 
-Add a worker node by updating your `ClusterInstance` CR.
+Add a worker node by updating your `ClusterInstance` custom resource that is used to provision your cluster.
 
 Complete the following steps to add a worker node to the managed cluster:
 
-. Add a worker node and define the required fields in the `ClusterInstance` CR:
+. Define a new node object in the existing `ClusterInstance` custom resource:
 
 +
 [source,yaml]
@@ -39,10 +39,7 @@ spec:
 ...
 ----
 
-+
-For more information about the required and optional fields, see link:../../apis/clusterinstance.json.adoc#clusterinstance-api[ClusterInstance API].
-
-. Apply the changes.
+. Apply the changes. See the following options:
 
 .. If you are using {acm-short} without {gitops}, run the following command on the hub cluster:
 
@@ -54,51 +51,71 @@ oc apply -f <clusterinstance>.yaml
 
 .. If you are using GitOps ZTP, push to your Git repository and wait for Argo CD to synchronize the changes.
 
-[#scale-out-verification]
-=== Verifying worker node addition
-
-. Wait for the `BaremetalHost` resource of that worker node to be added. Monitor the process by running the following command on the hub cluster:
+. Verify that a new `BareMetalHost` resource is added by running the following command on the hub cluster:
 
 +
 [source,terminal]
 ----
-oc get bmh -n <managed_cluster_namespace> --watch
+oc get bmh -n <clusterinstance_namespace> --watch --kubeconfig <hub_cluster_kubeconfig_filename>
 ----
 
 +
-See the following example output for successful worker node addition:
-
-+
-[source,terminal]
-----
-NAME                                STATE            CONSUMER   ONLINE   ERROR   AGE
-master-node1.example.com            provisioned                 true             81m
-worker-node2.example.com            provisioning                true             44m
-----
-
-. Verify that the `Node`, `Agent`, and `BareMetalHost` resources are created.
-
-.. Verify that the `Node` resources are removed by running the following command on the hub cluster: 
+See the following example output:
 
 +
 [source,terminal]
 ----
-oc get managedclusterinfo/<managed_cluster_name> -n <managed_cluster_namespace> \
--o jsonpath='{range .status.nodeList[*]}{.name}{"\t"}{.conditions}{"\t"}{.labels}{"\n"}{end}'
+NAME                        STATE          CONSUMER   ONLINE   ERROR   AGE
+master-node1.example.com    provisioned               true             81m
+worker-node2.example.com    provisioning              true             44m
 ----
 
-.. Verify that the `Agent` resources are removed by running the following command on the hub cluster:
-
-+
-[source,terminal]
-----
-oc get agents -n <managed_cluster_namespace>
-----
-
-.. Verify that the `BareMetalHost` resources are removed by running the following command on the hub cluster:
+. Verify that a new `Agent` resource is added by running the following command on the hub cluster:
 
 +
 [source,terminal]
 ----
-oc get bmh -n <managed_cluster_namespace>
+oc get agents -n <clusterinstance_namespace> --kubeconfig <hub_cluster_kubeconfig_filename>
+----
+
++
+See the following example output:
+
++
+[source,terminal]
+----
+NAME                       CLUSTER                   APPROVED    ROLE     STAGE
+master-node1.example.com   <managed_cluster_name>    true        master   Done
+master-node2.example.com   <managed_cluster_name>    true        master   Done
+master-node3.example.com   <managed_cluster_name>    true        master   Done
+worker-node1.example.com   <managed_cluster_name>    false       worker 
+worker-node2.example.com   <managed_cluster_name>    true        worker   Starting installation
+worker-node2.example.com   <managed_cluster_name>    true        worker   Installing
+worker-node2.example.com   <managed_cluster_name>    true        worker   Writing image to disk
+worker-node2.example.com   <managed_cluster_name>    true        worker   Waiting for control plane
+worker-node2.example.com   <managed_cluster_name>    true        worker   Rebooting
+worker-node2.example.com   <managed_cluster_name>    true        worker   Joined
+worker-node2.example.com   <managed_cluster_name>    true        worker   Done
+----
+
+. Verify that a new `Node` resource is added by running the following command on the managed cluster:
+
++
+[source,terminal]
+----
+oc get nodes --kubeconfig <managed_cluster_kubeconfig_filename>
+----
+
++
+See the following example output:
+
++
+[source,terminal]
+----
+NAME                       STATUS    ROLES                  AGE   VERSION
+worker-node2.example.com   Ready     worker                 1h    v1.30.5
+worker-node1.example.com   Ready     worker                 19h   v1.30.5
+master-node1.example.com   Ready     control-plane,master   19h   v1.30.5
+master-node2.example.com   Ready     control-plane,master   19h   v1.30.5
+master-node3.example.com   Ready     control-plane,master   19h   v1.30.5
 ----


### PR DESCRIPTION
Preview links with issues:
- [Adding ClusterInstance API to the API main.adoc and updating relevant links](https://content-stage.docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#default-templates)
- [Rendering issue (+) in Deprovisioning SNO clusters](https://content-stage.docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#deprovision-steps)
- [Missing space before `hostname` in Pruning the BareMetalHost resource of the worker node](https://content-stage.docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#scale-in-prunemanifests)
- [Removing whitespaces before + in Verifying worker node addition](https://content-stage.docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.12/html-single/multicluster_engine_operator_with_red_hat_advanced_cluster_management/index#scale-in-prunemanifests)