### PR TITLE
ACM-16051: importing cluster resources

### DIFF
--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -179,7 +179,7 @@ oc get infraenv -n managed-cluster some-other-infraenv -ojson | jq ".status.<url
 
 If your {ocp-short} managed cluster was installed by the {ai}, you can move the managed cluster and its resources from one hub cluster to another hub cluster. 
 
-You can manage a cluster from a new hub cluster by creating a copy of the original resources and applying them to the new hub cluster. You can then scale down or scale up your managed cluster from the new hub cluster.
+You can manage a cluster from a new hub cluster by saving a copy of the original resources and applying them to the new hub cluster. You can then scale down or scale up your managed cluster from the new hub cluster.
 
 *Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
 
@@ -196,8 +196,8 @@ You can import the following resources and continue to manage your cluster with 
 - `Secret`
 ** Includes `admin-kubeconfig` and `bmc-secret`
 
-[#copy-apply-cluster-resources]
-=== Copying and applying managed cluster resources
+[#store-apply-cluster-resources]
+=== Saving and applying managed cluster resources
 
 Complete the following steps to import managed cluster resources and apply them to a new hub cluster: 
 

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -184,7 +184,7 @@ You can manage a cluster from a new hub cluster by saving a copy of the original
 *Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
 
 [#import-ocp-cluster-resources-table]
-== Manage cluster resource table
+=== Manage cluster resource table
 
 You can import the following resources and continue to manage your cluster with them:
 

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -231,13 +231,15 @@ You can import the following resources and continue to manage your cluster with 
 
 To save a copy of your managed cluster resources and apply them to a new hub cluster, complete the following steps:
 
-. Get your resources from your source hub cluster by running the following command. Repeat the command for every resource you want to import by replacing `<resource_name>` with the name of the resource. Replace other values where needed:
+. Get your resources from your source hub cluster by running the following command. Replace values where needed:
 
 +
 [source,bash]
 ----
 oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get <resource_name> <cluster_provisioning_namespace> -oyaml > <resource_name>.yaml
 ----
+
+.. Repeat the command for every resource you want to import by replacing `<resource_name>` with the name of the resource.
 
 . Remove the `ownerReferences` property from the following resources by running the following commands:
 +
@@ -255,7 +257,7 @@ yq --in-place -y 'del(.metadata.ownerReferences)' AgentClusterInstall.yaml
 yq --in-place -y 'del(.metadata.ownerReferences)' AdminKubeconfigSecret.yaml
 ----
 
-. Detach the managed cluster from the source hub cluster by running the following command to your `ManagedCluster` resource. Replace values where needed:
+. Detach the managed cluster from the source hub cluster by running the following command. Replace values where needed:
 
 +
 [source,bash]
@@ -265,7 +267,7 @@ oc –kubeconfig <target_hub_kubeconfig> delete ManagedCluster <cluster_name>
 
 . Create a namespace on the target hub cluster for the managed cluster. Use a similar name as the source hub cluster.
 
-. Apply your stored resources on the target hub cluster individually by running the following command. Repalce values where needed:
+. Apply your stored resources on the target hub cluster individually by running the following command. Replace values where needed:
 +
 *Note:* Replace `<resource_name>.yaml` with `.` if you want to apply all the resources as a group instead of individually.
 +

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -179,22 +179,53 @@ oc get infraenv -n managed-cluster some-other-infraenv -ojson | jq ".status.<url
 
 If your {ocp-short} managed cluster was installed by the {ai}, you can move the managed cluster and its resources from one hub cluster to another hub cluster. 
 
-You can manage a cluster from a new hub cluster by saving a copy of the original resources and applying them to the new hub cluster. You can then scale down or scale up your managed cluster from the new hub cluster.
+You can manage a cluster from a new hub cluster by saving a copy of the original resources, applying them to the new hub cluster, and deleting the original resources. You can then scale down or scale up your managed cluster from the new hub cluster.
 
 *Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
 
+[#import-ocp-cluster-resources-table]
+== Manage cluster resource table
+
 You can import the following resources and continue to manage your cluster with them:
 
-- `Agent`
-- `AgentClassification`
-- `AgentClusterInstall`
-- `BareMetalHost`
-- `ClusterDeployment`
-- `InfraEnv`
-- `NMStateConfig`
-- `ManagedCluster`
-- `Secret`
-** Includes `admin-kubeconfig` and `bmc-secret`
+|===
+| Resource | Optional or required | Description
+
+| `Agent`
+| Required
+| 
+
+| `AgentClassification`
+| Optional
+| 
+
+| `AgentClusterInstall`
+| Required
+| 
+
+| `BareMetalHost`
+| Required
+| 
+
+| `ClusterDeployment`
+| Required
+| 
+
+| `InfraEnv`
+| Required
+| 
+
+| `NMStateConfig`
+| Optional
+| 
+
+| `ManagedCluster`
+| Required
+| 
+
+| `Secret`
+| Required
+| Includes `admin-kubeconfig` and `bmc-secret`
 
 [#save-apply-cluster-resources]
 === Saving and applying managed cluster resources

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -226,6 +226,7 @@ You can import the following resources and continue to manage your cluster with 
 | `Secret`
 | Required
 | Includes `admin-kubeconfig` and `bmc-secret`
+|===
 
 [#save-apply-cluster-resources]
 === Saving and applying managed cluster resources

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -188,27 +188,76 @@ You can import the following resources and continue to manage your cluster with 
 - `ClusterDeployment`
 - `InfraEnv`
 - `NMStateConfig`
+- `ManagedCluster`
+- `Secret` (admin-kubeconfig and bmc-secret)
 
 You can manage a cluster from a new hub cluster by creating a copy of the original resources and applying them to the new hub cluster. You can then scale down or scale up your managed cluster from the new hub cluster.
 
 *Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
 
-Import your cluster resources by creating a copy of your resources on your target hub cluster. See the following example to learn how to create a copy of the `Agent` resource and apply similar steps to your other resources:
+[#store-resources-source-hub]
+=== Store resources from the source hub
 
-. Get the `Agent` resource from your source hub cluster by running the following command. Replace values where needed:
+See the following example to learn how to create a copy of the `Agent` resource and apply it similarly with your other resources:
 
-+
+Get the `Agent` resource from your source hub cluster by running the following command. Replace values where needed:
+
 [source,bash]
 ----
 oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get agent <cluster_provisioning_namespace> -oyaml > agent.yaml
 ----
 
-. Apply your `Agent` resource on your target hub cluster by running the following command. Replace values where needed:
+[#modify-resources-source-hub]
+=== Modify resources from the source hub
+
+The `ownerReferences` property should be removed from the following resources before applying on the target hub:
+
+. `AgentClusterInstall`
++
+[source,bash]
+----
+yq --in-place -y 'del(.metadata.ownerReferences)' AgentClusterInstall.yaml
+----
+
+. `Secret` (admin-kubeconfig)
 
 +
 [source,bash]
 ----
-oc –kubeconfig <target_hub_kubeconfig> apply -f agent.yaml
+yq --in-place -y 'del(.metadata.ownerReferences)' AdminKubeconfigSecret.yaml
 ----
 
-After importing your cluster resources, delete your original cluster resources on your source hub cluster.
+[#detach-cluster-source-hub]
+=== Detach cluster from the source hub
+Detach the cluster by removing the relevant ManagedCluster resource (replace values where needed):
+
+[source,bash]
+----
+oc –kubeconfig <target_hub_kubeconfig> delete ManagedCluster <cluster_name>
+----
+
+[#apply-resources-target-hub]
+=== Apply resources on the target hub
+
+*Important:* Before applying the resources, create a Namespace on the target hub for the managed cluster (with a similar name as in the source hub).
+
+Stored resources can be applied one by one (replace values where needed):
+
+[source,bash]
+----
+oc –kubeconfig <target_hub_kubeconfig> apply -f <resource_name>.yaml
+----
+
+Or, as a group:
+
+[source,bash]
+----
+oc –kubeconfig <target_hub_kubeconfig> apply -f .
+----
+
+*Note:* 
+
+After importing your cluster resources, you can safely remove the cluster from the source hub with the following steps:
+
+. To prevent destroying the managed cluster, set the `spec.preserveOnDelete` parameter to `true` in the `ClusterDeployment` custom resource.
+. Follow instructions for xref:../cluster_lifecycle/remove_managed_cluster.adoc#remove-managed-cluster[Removing a cluster from management]

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -201,12 +201,12 @@ You can import the following resources and continue to manage your cluster with 
 
 Complete the following steps to import managed cluster resources and apply them to a new hub cluster: 
 
-. Get the `Agent` resource from your source hub cluster by running the following command. Replace values where needed:
+. Get your resources from your source hub cluster by running the following command. Repeat the command for every resource you want to import by replacing `<resource_name>` with the name of the resource. Replace other values where needed:
 
 +
 [source,bash]
 ----
-oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get agent <cluster_provisioning_namespace> -oyaml > agent.yaml
+oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get <resource_name> <cluster_provisioning_namespace> -oyaml > <resource_name>.yaml
 ----
 
 . Remove the `ownerReferences` property from the following resources before applying them on the target hub cluster:
@@ -219,7 +219,7 @@ oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get agent <cl
 yq --in-place -y 'del(.metadata.ownerReferences)' AgentClusterInstall.yaml
 ----
 
-.. `Secret` (admin-kubeconfig)
+.. `Secret` (`admin-kubeconfig`)
 
 +
 [source,bash]
@@ -241,7 +241,6 @@ oc –kubeconfig <target_hub_kubeconfig> delete ManagedCluster <cluster_name>
 
 *Note:* Replace `<resource_name>.yaml` with `.` if you want to apply the resources as a group instead of individually.
 
-+
 [source,bash]
 ----
 oc –kubeconfig <target_hub_kubeconfig> apply -f <resource_name>.yaml

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -196,7 +196,7 @@ You can import the following resources and continue to manage your cluster with 
 - `Secret`
 ** Includes `admin-kubeconfig` and `bmc-secret`
 
-[#store-apply-cluster-resources]
+[#save-apply-cluster-resources]
 === Saving and applying managed cluster resources
 
 Complete the following steps to import managed cluster resources and apply them to a new hub cluster: 

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -239,7 +239,7 @@ oc –kubeconfig <target_hub_kubeconfig> delete ManagedCluster <cluster_name>
 
 . Apply your stored resources on the target hub cluster individually by running the following command. Repalce values where needed:
 
-*Note:* Replace `<resource_name>.yaml` with `.` if you want to apply the resources as a group instead of individually.
+*Note:* Replace `<resource_name>.yaml` with `.` if you want to apply all the resources as a group instead of individually.
 
 [source,bash]
 ----

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -241,7 +241,7 @@ To save a copy of your managed cluster resources and apply them to a new hub clu
 oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get <resource_name> <cluster_provisioning_namespace> -oyaml > <resource_name>.yaml
 ----
 
-. Remove the `ownerReferences` property from the following resources before applying them on the target hub cluster:
+. Remove the `ownerReferences` property from the following resources by running the following commands:
 
 .. `AgentClusterInstall`
 

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -242,17 +242,15 @@ oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get <resource
 ----
 
 . Remove the `ownerReferences` property from the following resources by running the following commands:
-
++
 .. `AgentClusterInstall`
-
 +
 [source,bash]
 ----
 yq --in-place -y 'del(.metadata.ownerReferences)' AgentClusterInstall.yaml
 ----
-
++
 .. `Secret` (`admin-kubeconfig`)
-
 +
 [source,bash]
 ----
@@ -270,9 +268,9 @@ oc –kubeconfig <target_hub_kubeconfig> delete ManagedCluster <cluster_name>
 . Create a namespace on the target hub cluster for the managed cluster. Use a similar name as the source hub cluster.
 
 . Apply your stored resources on the target hub cluster individually by running the following command. Repalce values where needed:
-
++
 *Note:* Replace `<resource_name>.yaml` with `.` if you want to apply all the resources as a group instead of individually.
-
++
 [source,bash]
 ----
 oc –kubeconfig <target_hub_kubeconfig> apply -f <resource_name>.yaml
@@ -285,4 +283,4 @@ After importing your cluster resources, remove your managed cluster from the sou
 
 . Set the `spec.preserveOnDelete` parameter to `true` in the `ClusterDeployment` custom resource to prevent destroying the managed cluster.
 
-. Complete the steps in xref:../cluster_lifecycle/remove_managed_cluster.adoc#remove-managed-cluster[Removing a cluster from management]
+. Complete the steps in xref:../cluster_lifecycle/remove_managed_cluster.adoc#remove-managed-cluster[Removing a cluster from management].

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -179,6 +179,10 @@ oc get infraenv -n managed-cluster some-other-infraenv -ojson | jq ".status.<url
 
 If your {ocp-short} managed cluster was installed by the {ai}, you can move the managed cluster and its resources from one hub cluster to another hub cluster. 
 
+You can manage a cluster from a new hub cluster by creating a copy of the original resources and applying them to the new hub cluster. You can then scale down or scale up your managed cluster from the new hub cluster.
+
+*Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
+
 You can import the following resources and continue to manage your cluster with them:
 
 - `Agent`
@@ -189,37 +193,33 @@ You can import the following resources and continue to manage your cluster with 
 - `InfraEnv`
 - `NMStateConfig`
 - `ManagedCluster`
-- `Secret` (admin-kubeconfig and bmc-secret)
+- `Secret`
+** Includes `admin-kubeconfig` and `bmc-secret`
 
-You can manage a cluster from a new hub cluster by creating a copy of the original resources and applying them to the new hub cluster. You can then scale down or scale up your managed cluster from the new hub cluster.
+[#copy-apply-cluster-resources]
+=== Copying and applying managed cluster resources
 
-*Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
+Complete the following steps to import managed cluster resources and apply them to a new hub cluster: 
 
-[#store-resources-source-hub]
-=== Store resources from the source hub
+. Get the `Agent` resource from your source hub cluster by running the following command. Replace values where needed:
 
-See the following example to learn how to create a copy of the `Agent` resource and apply it similarly with your other resources:
-
-Get the `Agent` resource from your source hub cluster by running the following command. Replace values where needed:
-
++
 [source,bash]
 ----
 oc –kubeconfig <source_hub_kubeconfig> -n <managed_cluster_name> get agent <cluster_provisioning_namespace> -oyaml > agent.yaml
 ----
 
-[#modify-resources-source-hub]
-=== Modify resources from the source hub
+. Remove the `ownerReferences` property from the following resources before applying them on the target hub cluster:
 
-The `ownerReferences` property should be removed from the following resources before applying on the target hub:
+.. `AgentClusterInstall`
 
-. `AgentClusterInstall`
 +
 [source,bash]
 ----
 yq --in-place -y 'del(.metadata.ownerReferences)' AgentClusterInstall.yaml
 ----
 
-. `Secret` (admin-kubeconfig)
+.. `Secret` (admin-kubeconfig)
 
 +
 [source,bash]
@@ -227,37 +227,31 @@ yq --in-place -y 'del(.metadata.ownerReferences)' AgentClusterInstall.yaml
 yq --in-place -y 'del(.metadata.ownerReferences)' AdminKubeconfigSecret.yaml
 ----
 
-[#detach-cluster-source-hub]
-=== Detach cluster from the source hub
-Detach the cluster by removing the relevant ManagedCluster resource (replace values where needed):
+. Detach the managed cluster from the source hub cluster by running the following command to your `ManagedCluster` resource. Replace values where needed:
 
++
 [source,bash]
 ----
 oc –kubeconfig <target_hub_kubeconfig> delete ManagedCluster <cluster_name>
 ----
 
-[#apply-resources-target-hub]
-=== Apply resources on the target hub
+. Create a namespace on the target hub cluster for the managed cluster. Use a similar name as the source hub cluster.
 
-*Important:* Before applying the resources, create a Namespace on the target hub for the managed cluster (with a similar name as in the source hub).
+. Apply your stored resources on the target hub cluster individually by running the following command. Repalce values where needed:
 
-Stored resources can be applied one by one (replace values where needed):
+*Note:* Replace `<resource_name>.yaml` with `.` if you want to apply the resources as a group instead of individually.
 
++
 [source,bash]
 ----
 oc –kubeconfig <target_hub_kubeconfig> apply -f <resource_name>.yaml
 ----
 
-Or, as a group:
+[#remove-cluster-source-hub]
+=== Removing the managed cluster from the source hub cluster
 
-[source,bash]
-----
-oc –kubeconfig <target_hub_kubeconfig> apply -f .
-----
+After importing your cluster resources, remove your managed cluster from the source hub cluster by completing the following steps:
 
-*Note:* 
+. Set the `spec.preserveOnDelete` parameter to `true` in the `ClusterDeployment` custom resource to prevent destroying the managed cluster.
 
-After importing your cluster resources, you can safely remove the cluster from the source hub with the following steps:
-
-. To prevent destroying the managed cluster, set the `spec.preserveOnDelete` parameter to `true` in the `ClusterDeployment` custom resource.
-. Follow instructions for xref:../cluster_lifecycle/remove_managed_cluster.adoc#remove-managed-cluster[Removing a cluster from management]
+. Complete the steps in xref:../cluster_lifecycle/remove_managed_cluster.adoc#remove-managed-cluster[Removing a cluster from management]

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -183,11 +183,9 @@ You can manage a cluster from a new hub cluster by saving a copy of the original
 
 *Important:* You can only scale down imported {ocp-short} managed clusters if they were installed by the {ai}.
 
-[#import-ocp-cluster-resources-table]
-=== Manage cluster resource table
-
 You can import the following resources and continue to manage your cluster with them:
 
+.Managed cluster resource table
 |===
 | Resource | Optional or required | Description
 

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -197,15 +197,15 @@ You can import the following resources and continue to manage your cluster with 
 
 | `AgentClassification`
 | Optional
-| 
+| Required if you want to classify Agents with a filter query.
 
 | `AgentClusterInstall`
 | Required
 | 
 
 | `BareMetalHost`
-| Required
-| 
+| Optional
+| Required if you are using the `baremetal` platform.
 
 | `ClusterDeployment`
 | Required
@@ -217,7 +217,7 @@ You can import the following resources and continue to manage your cluster with 
 
 | `NMStateConfig`
 | Optional
-| 
+| Required if you want to apply your network configuration on the hosts.
 
 | `ManagedCluster`
 | Required
@@ -225,7 +225,7 @@ You can import the following resources and continue to manage your cluster with 
 
 | `Secret`
 | Required
-| Includes `admin-kubeconfig` and `bmc-secret`
+| The `admin-kubeconfig` secret is required. The `bmc-secret` secret is only required if you are using `BareMetalHosts`.
 |===
 
 [#save-apply-cluster-resources]

--- a/clusters/cluster_lifecycle/import_ocp.adoc
+++ b/clusters/cluster_lifecycle/import_ocp.adoc
@@ -199,7 +199,7 @@ You can import the following resources and continue to manage your cluster with 
 [#save-apply-cluster-resources]
 === Saving and applying managed cluster resources
 
-Complete the following steps to import managed cluster resources and apply them to a new hub cluster: 
+To save a copy of your managed cluster resources and apply them to a new hub cluster, complete the following steps:
 
 . Get your resources from your source hub cluster by running the following command. Repeat the command for every resource you want to import by replacing `<resource_name>` with the name of the resource. Replace other values where needed:
 


### PR DESCRIPTION
Following https://github.com/stolostron/rhacm-docs/pull/7121, added further information and steps for the flow of moving a managed cluster between ACM hubs (i.e. by importing cluster resources).