### PR TITLE
https://issues.redhat.com/browse/ACM-16013 - Add missing clusterImageSetNameRef field in ClusterInstance API docs

### DIFF
--- a/apis/clusterinstance.json.adoc
+++ b/apis/clusterinstance.json.adoc
@@ -344,6 +344,8 @@ __required__|Specify the base domain used for the deployed cluster.|string
 |*caBundleRef* +
 __optional__|Reference the `ConfigMap` object that contains the new bundle of trusted certificates for the host.
 The `tls-ca-bundle.pem` entry in the `ConfigMap` object is written to `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`.|string
+|*clusterImageSetNameRef* +
+__required__|Specify the name of the `ClusterImageSet` object that indicates the {ocp-short} version to deploy.|string
 |*clusterName* +
 __required__|Specify the name of the cluster.|string
 |*clusterNetwork* +

--- a/mce_acm_integration/siteconfig/siteconfig_install_clusters.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_install_clusters.adoc
@@ -184,6 +184,8 @@ spec:
   [...]
   clusterName: "example-sno" <4>
   [...]
+  clusterImageSetNameRef: "img4.17-x86-64"
+  [...]
   templateRefs: <5>
     - name: ibi-cluster-templates-v1
       namespace: rhacm


### PR DESCRIPTION
Cherrypicked from https://github.com/stolostron/rhacm-docs/pull/7356