### PR TITLE
Update support matrix link to 2.12 for SubM

### DIFF
--- a/networking/submariner/subm_intro.adoc
+++ b/networking/submariner/subm_intro.adoc
@@ -3,7 +3,7 @@
 
 Submariner is an open source tool that you can use with {acm} to provide direct networking and service discovery between two or more managed clusters in your environment, either on-premises or in the cloud. Submariner is compatible with Multi-Cluster Services API (link:https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api[Kubernetes Enhancements Proposal #1645]). For more information about Submariner, see the link:https://submariner.io/[Submariner site].
 
-Submariner is not supported with all of the infrastructure providers that {acm-short} can manage. Refer to the link:https://access.redhat.com/articles/7073065[{acm-short} support matrix] for more details about the support levels of infrastructure providers, including which providers support xref:../submariner/deploy_subm_console.adoc#deploying-submariner-console[automated console deployments] or require xref:../submariner/deploy_subm_manual.adoc#deploying-submariner-manually[manual deployment].
+Submariner is not supported with all of the infrastructure providers that {acm-short} can manage. Refer to the link:https://access.redhat.com/articles/7086905[{acm-short} support matrix] for more details about the support levels of infrastructure providers, including which providers support xref:../submariner/deploy_subm_console.adoc#deploying-submariner-console[automated console deployments] or require xref:../submariner/deploy_subm_manual.adoc#deploying-submariner-manually[manual deployment].
 
 See the following topics to learn more about how to use Submariner:
 

--- a/networking/submariner/subm_intro.adoc
+++ b/networking/submariner/subm_intro.adoc
@@ -3,7 +3,7 @@
 
 Submariner is an open source tool that you can use with {acm} to provide direct networking and service discovery between two or more managed clusters in your environment, either on-premises or in the cloud. Submariner is compatible with Multi-Cluster Services API (link:https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api[Kubernetes Enhancements Proposal #1645]). For more information about Submariner, see the link:https://submariner.io/[Submariner site].
 
-Submariner is not supported with all of the infrastructure providers that {acm-short} can manage. Refer to the link:https://access.redhat.com/articles/7086905[{acm-short} support matrix] for more details about the support levels of infrastructure providers, including which providers support xref:../submariner/deploy_subm_console.adoc#deploying-submariner-console[automated console deployments] or require xref:../submariner/deploy_subm_manual.adoc#deploying-submariner-manually[manual deployment].
+Submariner is not supported with all of the infrastructure providers that {acm-short} can manage. For full support information, see the link:https://access.redhat.com/articles/7086905[{acm-short} support matrix] for more details about the support levels of infrastructure providers, including which providers support xref:../submariner/deploy_subm_console.adoc#deploying-submariner-console[automated console deployments] or require xref:../submariner/deploy_subm_manual.adoc#deploying-submariner-manually[manual deployment].
 
 See the following topics to learn more about how to use Submariner:
 

--- a/networking/submariner/subm_intro.adoc
+++ b/networking/submariner/subm_intro.adoc
@@ -3,7 +3,7 @@
 
 Submariner is an open source tool that you can use with {acm} to provide direct networking and service discovery between two or more managed clusters in your environment, either on-premises or in the cloud. Submariner is compatible with Multi-Cluster Services API (link:https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api[Kubernetes Enhancements Proposal #1645]). For more information about Submariner, see the link:https://submariner.io/[Submariner site].
 
-Submariner is not supported with all of the infrastructure providers that {acm-short} can manage. For full support information, see the link:https://access.redhat.com/articles/7086905[{acm-short} support matrix] for more details about the support levels of infrastructure providers, including which providers support xref:../submariner/deploy_subm_console.adoc#deploying-submariner-console[automated console deployments] or require xref:../submariner/deploy_subm_manual.adoc#deploying-submariner-manually[manual deployment].
+Submariner is not supported with all of the infrastructure providers that {acm-short} can manage. For full support information, see the link:https://access.redhat.com/articles/7086905[{acm-short} support matrix] for details about the supported levels of infrastructure providers, including which providers support xref:../submariner/deploy_subm_console.adoc#deploying-submariner-console[automated console deployments] or require xref:../submariner/deploy_subm_manual.adoc#deploying-submariner-manually[manual deployment].
 
 See the following topics to learn more about how to use Submariner:
 


### PR DESCRIPTION
The 2.12 docs should link to the 2.12 support matrix, not 2.11.