### PR TITLE
ACM-16840: added missing labels

### DIFF
--- a/mce_acm_integration/discover_hosted/acm_discover_hosted.adoc
+++ b/mce_acm_integration/discover_hosted/acm_discover_hosted.adoc
@@ -283,6 +283,9 @@ kind: ManagedCluster
 metadata:
   annotations:
     agent.open-cluster-management.io/klusterlet-config: mce-import-klusterlet-config <1>
+  labels:
+    cloud: auto-detect
+    vendor: auto-detect
   name: mce-a <2>
 spec:
   hubAcceptsClient: true


### PR DESCRIPTION
To fix https://issues.redhat.com/browse/ACM-16840, I added the following missing labels in creating the ManagedCluster CR.

```
  labels:
    cloud: auto-detect
    vendor: auto-detect
```