### PR TITLE
ACM-18041: Adjust `ConfigurationPolicy` `customMessage` doc (GRC)

### DIFF
--- a/apis/policy.json.adoc
+++ b/apis/policy.json.adoc
@@ -85,14 +85,9 @@ __required__|Parameters describing the policy to be created.|<<_rhacm-docs_apis_
   "kind": "Policy",
   "metadata": {
     "name": "test-policy-swagger",
-    "description": "Example body for Policy API Swagger docs"
   },
   "spec": {
     "remediationAction": "enforce",
-    "customMessage": {
-      "compliant": [],
-      "noncompliant": []
-    },
     "namespaces": {
       "include": [
         "default"
@@ -104,16 +99,8 @@ __required__|Parameters describing the policy to be created.|<<_rhacm-docs_apis_
     "policy-templates": {
     "kind": "ConfigurationPolicy",
     "apiVersion": "policy.open-cluster-management.io/v1",
-    "complianceType": "musthave",
-    "metadataComplianceType": "musthave",
     "metadata": {
-      "namespace": null,
       "name": "test-role"
-    },
-    "selector": {
-      "matchLabels": {
-        "cloud": "IBM"
-      }
     },
     "spec" : {
       "object-templates": {
@@ -336,13 +323,6 @@ __required__|<<_rhacm-docs_apis_policy_jsonpolicy_spec,spec>>
 |Name|Description|Schema
 |*remediationAction* +
 __optional__|Value that represents how violations are handled as defined in the resource. | string
-|*customMessage* +
-_optional_|Parameter field where you can configure custom messages from your configuration policies, based on the compliance status. You can use the default message from the `.DefaultMessage` parameter and `.Policy` object variable of the current state of the policy from the configuration policy controller. The state of each related object is available at the `.Policy.status.relatedObjects[*].object` parameter section of the configuration policy controller. If you set an `evaluationInterval`, only identifiable information is available. |string
-
-|*namespaceSelector* +
-__required__|Value that represents which namespaces the policy is applied.|string
-|<<_rhacm-docs_apis_policy_jsonpolicy_policytemplates, *policy-templates*>> +
-__optional__|array
 |===
 
 [[_rhacm-docs_apis_policy_jsonpolicy_policytemplates]]
@@ -357,25 +337,8 @@ __required__|The versioned schema of Policy.| string
 __optional__|String value that represents the REST resource.|string
 |*metadata* +
 __required__|Describes rules that define the policy. |object
-| *complianceType* | Used to list expected behavior for roles and other Kubernetes object that must be evaluated or applied to the managed clusters.| string
-| *metadataComplianceType* +
-__optional__| Provides a way for users to process labels and annotations of an object differently than the other fields. The parameter value defaults to the same value of the `ComplianceType` parameter.  | string
-|<<_rhacm-docs_apis_policy_jsonpolicy_selector,*clusterConditions*>> +
-__optional__| Section to define labels.|string
 |<<_rhacm-docs_apis_policy_jsonpolicy_rules,*rules*>> +
 __optional__| |string
-|===
-
-[[_rhacm-docs_apis_policy_jsonpolicy_selector]]
-*clusterConditions*
-
-[options="header", cols=".^2a,.^3a,.^4a"]
-|===
-|Name|Description|Schema
-|*matchLabels* +
-__optional__| The label that is required for the policy to be applied to a namespace.|object
-|*cloud* +
-__optional__|The label that is required for the policy to be applied to a cloud provider. |string
 |===
 
 [[_rhacm-docs_apis_policy_jsonpolicy_rules]]

--- a/governance/config_policy_ctrl.adoc
+++ b/governance/config_policy_ctrl.adoc
@@ -96,7 +96,7 @@ spec:
 
 | `spec.customMessage`
 | Optional
-| Use this section to configure the compliance message sent by the configuration policy based on the current compliance. Each message configuration is a string that can contain Go templates. The context variables `.DefaultMessage` and `.Policy` are available for use in the templates. You can access the default message using the `.DefaultMessage` parameter. The `.Policy` context variable contains the current policy object, including its status. For example, you can access the state of each related object by specifying `.Policy.status.relatedObjects[*].object`. If you set an `evaluationInterval` other than `watch`, only the kind, name, and namespace of the related objects are available.
+| Configure the compliance message sent by the configuration policy based on the current compliance. Each message configuration is a string that can contain Go templates. The `.DefaultMessage` and `.Policy` context variables are available for use in the templates. You can access the default message by using the `.DefaultMessage` parameter. The `.Policy` context variable contains the current policy object, including its status. For example, you can access the state of each related object by specifying the `.Policy.status.relatedObjects[*].object` field. If you set a value for the `evaluationInterval` field other than `watch`, only the kind, name, and namespace of the related objects are available.
 
 | `spec.customMessage.compliant`
 | Optional

--- a/governance/config_policy_ctrl.adoc
+++ b/governance/config_policy_ctrl.adoc
@@ -12,7 +12,7 @@ If you have existing Kubernetes manifests that you want to put in a policy, the 
 [#configuration-policy-yaml]
 == Configuration policy YAML structure
 
-To find the description of a field on your managed cluster, run the command `oc explain --api-version=policy.open-cluster-management.io/v1 ConfigurationPolicy.<field-path>`, and replace `<field-path>` with the path to the field that you need.
+You can find the description of a field on your managed cluster by running the `oc explain --api-version=policy.open-cluster-management.io/v1 ConfigurationPolicy.<field-path>` command. Replace `<field-path>` with the path to the field that you need.
 
 [source,yaml]
 ----

--- a/governance/config_policy_ctrl.adoc
+++ b/governance/config_policy_ctrl.adoc
@@ -9,8 +9,10 @@ When the `remediationAction` for the configuration policy controller is set to `
 
 If you have existing Kubernetes manifests that you want to put in a policy, the Policy Generator is a useful tool to accomplish this.
 
-[#configuration-policy-sample]
-== Configuration policy sample
+[#configuration-policy-yaml]
+== Configuration policy YAML structure
+
+To find the description of a field on your managed cluster, run the command `oc explain --api-version=policy.open-cluster-management.io/v1 ConfigurationPolicy.<field-path>`, and replace `<field-path>` with the path to the field that you need.
 
 [source,yaml]
 ----
@@ -30,35 +32,40 @@ spec:
     noncompliant: {}
   severity: low
   evaluationInterval:
-    compliant:
-    noncompliant:
+    compliant: ""
+    noncompliant: ""
+  object-templates-raw: ""
   object-templates: <2>
-  - complianceType: musthave
-    objectDefinition:
-      apiVersion: v1
-      kind: Pod
-      metadata:
-        name: pod
-      spec:
-        containers:
-        - image: pod-image
-          name: pod-name
-          ports:
-          - containerPort: 80
-  - complianceType: musthave
-    objectDefinition:
-    apiVersion: v1
-    kind: ConfigMap
-    metadata:
-      name: myconfig
-      namespace: default
-      data:
-      testData: hello
-    spec:
-...
+   - complianceType: musthave
+     metadataComplianceType:
+     recordDiff: ""
+     recreateOption: ""
+     objectSelector:
+       matchLabels: {}
+       matchExpressions: []
+     objectDefinition:
+       apiVersion: v1
+       kind: Pod
+       metadata:
+         name: pod
+       spec:
+         containers:
+          - image: pod-image
+            name: pod-name
+            ports:
+             - containerPort: 80
+   - complianceType: mustonlyhave
+     objectDefinition:
+       apiVersion: v1
+       kind: ConfigMap
+       metadata:
+         name: myconfig
+         namespace: default
+         data:
+           testData: hello
 ----
 <1> Configuration policies that specify an object without a name can only be set to `inform`. When the `remediationAction` for the configuration policy is set to `enforce`, the controller applies the specified configuration to the target managed cluster.
-<2> A Kubernetes object is defined in the `object-templates` array in the configuration policy, where fields of the configuration policy controller is compared with objects on the managed cluster. You can also use templated values within configuration policies. For more information, see _Template processing_.
+<2> A Kubernetes object is defined in the `object-templates` array in the configuration policy, where fields of the configuration policy controller is compared with objects on the managed cluster. You can also use templated values within configuration policies. For more advanced use cases, specify a string in `object-templates-raw` to create the `object-templates` that you want. For more information, see _Template processing_.
 
 [#configuration-policy-yaml-table]
 == Configuration policy YAML table
@@ -89,22 +96,15 @@ spec:
 
 | `spec.customMessage`
 | Optional
-a| Based on the current compliance, use this section to configure the compliance messages sent by the configuration policy to use one of the specified Go templates. You can use the default message from the `.DefaultMessage` parameter and `.Policy` object variable of the current state of the policy from the configuration policy controller. See the state of each related object in the following parameter section of the configuration policy controller:
-
-[source,yaml]
-----
-.Policy.status.relatedObjects[*].object
-----  
-
-If you set an `evaluationInterval`, only identifiable information is available.
+| Use this section to configure the compliance message sent by the configuration policy based on the current compliance. Each message configuration is a string that can contain Go templates. The context variables `.DefaultMessage` and `.Policy` are available for use in the templates. You can access the default message using the `.DefaultMessage` parameter. The `.Policy` context variable contains the current policy object, including its status. For example, you can access the state of each related object by specifying `.Policy.status.relatedObjects[*].object`. If you set an `evaluationInterval` other than `watch`, only the kind, name, and namespace of the related objects are available.
 
 | `spec.customMessage.compliant`
 | Optional
-| Use this field to configure custom messages for configuration policies that are compliant. UTF-8 encoded characters, including emoji and foreign characters are supported values.
+| Use this field to configure custom messages for configuration policies that are compliant. Go templates and UTF-8 encoded characters, including emoji and foreign characters, are supported values.
 
 | `spec.customMessage.noncompliant`
 | Optional
-| Use this field to configure custom messages for configuration policies that are non-compliant. UTF-8 encoded characters, along with emoji and foreign characters are supported values.
+| Use this field to configure custom messages for configuration policies that are non-compliant. Go templates and UTF-8 encoded characters, along with emoji and foreign characters, are supported values.
 
 | `spec.severity`
 | Required

--- a/governance/config_policy_ctrl.adoc
+++ b/governance/config_policy_ctrl.adoc
@@ -100,7 +100,7 @@ spec:
 
 | `spec.customMessage.compliant`
 | Optional
-| Use this field to configure custom messages for configuration policies that are compliant. Go templates and UTF-8 encoded characters, including emoji and foreign characters, are supported values.
+| Configure custom messages for configuration policies that are compliant. Go templates and UTF-8 encoded characters, including emoji and foreign characters, are supported values.
 
 | `spec.customMessage.noncompliant`
 | Optional

--- a/governance/config_policy_ctrl.adoc
+++ b/governance/config_policy_ctrl.adoc
@@ -104,7 +104,7 @@ spec:
 
 | `spec.customMessage.noncompliant`
 | Optional
-| Use this field to configure custom messages for configuration policies that are non-compliant. Go templates and UTF-8 encoded characters, along with emoji and foreign characters, are supported values.
+| Configure custom messages for configuration policies that are non-compliant. Go templates and UTF-8 encoded characters, including emoji and foreign characters, are supported values.
 
 | `spec.severity`
 | Required


### PR DESCRIPTION
- Removes irrelevant fields from the deprecated API doc (though I would alternatively be okay with stripping out the entire file and leaving the intro if that's preferable to the removals)
- Updates the custom message doc to clarify its use

ref: https://issues.redhat.com/browse/ACM-18041