### PR TITLE
ACM-18042: Adopt policy best practices (GRC)

### DIFF
--- a/clusters/install_upgrade/upgrade_cluster_disconnected_policies.adoc
+++ b/clusters/install_upgrade/upgrade_cluster_disconnected_policies.adoc
@@ -267,9 +267,6 @@ metadata:
   name: placement-policy-mirror
   namespace: default
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       []  <3>
@@ -358,9 +355,6 @@ metadata:
   name: placement-policy-catalog
   namespace: default
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       []  <2>
@@ -461,9 +455,6 @@ metadata:
   name: placement-policy-cluster-version
   namespace: default
 spec:
-  clusterConditions:
-  - status: "True"
-    type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       [] <2> 

--- a/gitops/gitops_policy_generator.adoc
+++ b/gitops/gitops_policy_generator.adoc
@@ -62,9 +62,6 @@ metadata:
   name: placement-install-openshift-gitops
   namespace: policies
 spec:
-  clusterConditions:
-    - status: "True"
-      type: ManagedClusterConditionAvailable
   clusterSelector:
     matchExpressions:
       - key: vendor

--- a/governance/generate_pol_operator_install.adoc
+++ b/governance/generate_pol_operator_install.adoc
@@ -84,6 +84,11 @@ spec:
           operator: In
           values:
           - OpenShift
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/governance/generate_pol_operator_install.adoc
+++ b/governance/generate_pol_operator_install.adoc
@@ -6,6 +6,7 @@ Generate a policy that installs the Compliance Operator onto your clusters. For 
 Complete the following steps:
 
 . Create a YAML file with a `Namespace`, a `Subscription`, and an `OperatorGroup` manifest called `compliance-operator.yaml`. The following example installs these manifests in the `compliance-operator` namespace. Replace `<release-0.x>` with the correct channel:
+
 +
 [source,yaml]
 ----
@@ -36,6 +37,7 @@ spec:
 ----
 
 . Create a `PolicyGenerator` configuration file. View the following `PolicyGenerator` policy example that installs the Compliance Operator on all {ocp-short} managed clusters:
+
 +
 [source,yaml]
 ----
@@ -59,6 +61,7 @@ policies:
 ----
 
 . Add the policy generator to your `kustomization.yaml` file. The `generators` section might resemble the following configuration:
+
 +
 [source,yaml]
 ----
@@ -67,6 +70,7 @@ generators:
 ----
 +
 As a result, the generated policy resembles the following file:
+
 +
 [source,yaml]
 ----

--- a/governance/hub_policy_framework.adoc
+++ b/governance/hub_policy_framework.adoc
@@ -26,6 +26,11 @@ spec:
     labelSelector:
     matchExpressions:
       - {key: environment, operator: In, values: ["dev"]}
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ----
 
 +
@@ -270,6 +275,11 @@ spec:
       labelSelector:
         matchExpressions:
         - {key: environment, operator: In, values: ["dev"]}
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ----
 
 [#add-resources-policy-overview]

--- a/governance/manage_policies.adoc
+++ b/governance/manage_policies.adoc
@@ -73,6 +73,7 @@ spec:
 ----
 
 . Define a `PlacementBinding` resource to bind your policy to your `Placement` resource. Your `PlacementBinding` resource might resemble the following YAML sample:
+
 +
 [source,yaml]
 ----
@@ -169,6 +170,7 @@ subjects:
 ----
 +
 See the following `Placement` example:
+
 +
 [source,yaml]
 ----
@@ -281,6 +283,7 @@ Delete a security policy from the CLI or the console.
 
 * Delete a security policy from the CLI:
 .. Delete a security policy by running the following command:
+
 +
 ----
 oc delete policies.policy.open-cluster-management.io <policy-name> -n <policy-namespace>

--- a/governance/manage_policies.adoc
+++ b/governance/manage_policies.adoc
@@ -281,21 +281,26 @@ Click *Disable policy*. Your policy is disabled.
 
 Delete a security policy from the CLI or the console.
 
-* Delete a security policy from the CLI:
-.. Delete a security policy by running the following command:
+Use the following procedure to delete from the CLI:
+
+. Delete a security policy by running the following command:
 
 +
 ----
 oc delete policies.policy.open-cluster-management.io <policy-name> -n <policy-namespace>
 ----
-+
-After your policy is deleted, it is removed from your target cluster or clusters. Verify that your policy is removed by running the following command: `oc get policies.policy.open-cluster-management.io <policy-name> -n <policy-namespace>`
 
-* Delete a security policy from the console:
-+
-From the navigation menu, click *Governance* to view a table list of your policies. Click the *Actions* icon for the policy you want to delete in the policy violation table.
-+
-Click *Remove*. From the _Remove policy_ dialog box, click *Remove policy*.
+. Verify that your policy is removed by running the following command: `oc get policies.policy.open-cluster-management.io <policy-name> -n <policy-namespace>`
+
+Use the following procedure to delete a security policy from the console. 
+
+. From the navigation menu, click *Governance* to view a table list of your policies. 
+
+. Click the *Actions* icon for the policy you want to delete in the policy violation table.
+
+. Click *Remove*. 
+
+. From the _Remove policy_ dialog box, click *Remove policy*.
 
 [#deleting-policy-sets]
 === Deleting policy sets from the console

--- a/governance/manage_policies.adoc
+++ b/governance/manage_policies.adoc
@@ -182,6 +182,11 @@ spec:
       labelSelector:
         matchLabels:
           cloud: "IBM"
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ----
 
 . *Optional:* Add a description for your policy. 

--- a/governance/opp_policyset_install.adoc
+++ b/governance/opp_policyset_install.adoc
@@ -101,6 +101,11 @@ spec:
       labelSelector:
         matchExpressions:
         - {key: name, operator: In, values: ["local-cluster"]}
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ----
 +
 . To apply the previous YAML from the command line interface, run the following command:

--- a/governance/opp_policyset_install.adoc
+++ b/governance/opp_policyset_install.adoc
@@ -9,6 +9,7 @@ Continue reading for guidance to apply the Red Hat Openshift Platform Plus polic
 Complete the following steps before you apply the policy set:
 
 . To allow for subscriptions to be applied to your cluster, you must apply the `policy-configure-subscription-admin-hub.yaml` policy and set the remediation action to `enforce`. Copy and paste the following YAML into the YAML editor of the console:
+
 +
 [source,yaml]
 ----
@@ -109,12 +110,14 @@ spec:
 ----
 +
 . To apply the previous YAML from the command line interface, run the following command:
+
 +
 ----
 oc apply -f policy-configure-subscription-admin-hub.yaml
 ----
 . Install the Policy Generator kustomize plugin. Use Kustomize v4.5 or newer. See link:../gitops/gitops_policy__operator.adoc#gitops-policy-operator[Generating a policy to install an Operator].
 . Policies are installed to the `policies` namespace. You must bind that namespace to a `ClusterSet`. For example, copy and apply the following example YAML to bind the namespace to the default `ClusterSet`:
+
 +
 [source,yaml]
 ----
@@ -128,6 +131,7 @@ spec:
 ----
 +
 . Run the following command to apply the `ManagedClusterSetBinding` resource from the command line interface:
+
 +
 ----
 oc apply -f managed-cluster.yaml 

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -120,6 +120,11 @@ spec:
   - requiredClusterSelector:
       labelSelector:
         matchExpressions: []
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding

--- a/governance/policy_set_ctrl.adoc
+++ b/governance/policy_set_ctrl.adoc
@@ -58,6 +58,11 @@ spec:
             operator: In
             values: 
               - local-cluster
+    tolerations:
+        - key: cluster.open-cluster-management.io/unavailable
+          operator: Exists
+        - key: cluster.open-cluster-management.io/unreachable
+          operator: Exists
 ----
 
 

--- a/mce_acm_integration/discover_hosted/acm_integrate_import_hcp.adoc
+++ b/mce_acm_integration/discover_hosted/acm_integrate_import_hcp.adoc
@@ -206,7 +206,7 @@ subjects:
 +
 [source,bash]
 ----
-oc get policy policy-mce-hcp-autoimport -n <namespace>
+oc get policies.policy.open-cluster-management.io policy-mce-hcp-autoimport -n <namespace>
 ---- 
 
 *Important:* You can _detach_ a hosted cluster from {acm-short} by using the *Detach* option in the {acm-short} console, or by removing the corresponding `ManagedCluster` custom resource from the command line. 

--- a/mce_acm_integration/discover_hosted/acm_integrate_import_rosa.adoc
+++ b/mce_acm_integration/discover_hosted/acm_integrate_import_rosa.adoc
@@ -193,5 +193,5 @@ subjects:
 
 +
 ----
-oc get policy policy-rosa-autoimport -n <namespace>
+oc get policies.policy.open-cluster-management.io policy-rosa-autoimport -n <namespace>
 ---- 


### PR DESCRIPTION
- Use fully qualified name for policy
- Remove `ManagedClusterConditionAvailable`
  - When dealing with policies, this setting is not recommended since it could introduce churn.
- Add `tolerations` to `Placement`
  - Not having these tolerations could introduce churn if the managed cluster becomes unavailable.

ref: https://issues.redhat.com/browse/ACM-18042

Split from:
- #7521 