### PR TITLE
ACM-18043: Policy templating doc tweaks (GRC)

### DIFF
--- a/governance/adv_template_process.adoc
+++ b/governance/adv_template_process.adoc
@@ -1,5 +1,5 @@
 [#adv-template-processing]
-= Advanced template processing in configuration policies
+= Using advanced template processing in policies
 
 Use both managed cluster and hub cluster templates to reduce the need to create separate policies for each target cluster or hardcode configuration values in the policy definitions. For security, both resource-specific and the generic lookup functions in hub cluster templates are restricted to the namespace of the policy on the hub cluster.
 
@@ -8,8 +8,8 @@ Use both managed cluster and hub cluster templates to reduce the need to create 
 Continue reading for advanced template use-cases:
 
 * <<special-annotation-processing,Special annotation for reprocessing>>
-* <<raw-object-template-processing,Object template processing>>
 * <<bypass-template-processing,Bypass template processing>>
+* <<raw-object-template-processing,Raw object template processing>>
 
 [#special-annotation-processing]
 == Special annotation for reprocessing
@@ -18,10 +18,19 @@ Hub cluster templates are resolved to the data in the referenced resources durin
 
 If you need to manually initiate an update, use the special annotation, `policy.open-cluster-management.io/trigger-update`, to indicate changes for the data referenced by the templates. Any change to the special annotation value automatically initiates template processing. Additionally, the latest contents of the referenced resource are read and updated in the policy definition that is propagated for processing on managed clusters. A way to use this annotation is to increment the value by one each time.
 
-[#raw-object-template-processing]
-== Object template processing
+[#bypass-template-processing]
+== Bypassing template processing
 
-Set object templates with a YAML string representation. The `object-template-raw` parameter is an optional parameter that supports advanced templating use-cases, such as if-else and the `range` function. The following example is defined to add the `species-category: mammal` label  to any ConfigMap in the `default` namespace that has a `name` key equal to `Sea Otter`:
+By default, {acm-short} processes all Go templates. You might create a policy that contains a policy in `policy-templates` that is not intended to be processed by {acm-short}. To bypass template processing for a particular template, change `{{ template content }}` to `+{{ `{{ template content }}` }}+` to have the template return a raw string to be processed by a subsequent templating engine.
+
+If you want to completely bypass the template resolution for a configuration policy, add the following annotation in the relevant `ConfigurationPolicy` contained in your `Policy`: `policy.open-cluster-management.io/disable-templates: "true"`.
+
+[#raw-object-template-processing]
+== Processing raw templates in configuration policies
+
+The `object-template-raw` parameter is an optional parameter that supports advanced templating use-cases, such as the `if` conditional function and the `range` loop function. The `object-templates-raw` parameter accepts a string containing Go templates, and when you use these templates, they must result in an `object-templates` array.
+
+For example, see the following YAML sample that adds the `species-category: mammal` label to any ConfigMap in the `default` namespace that has a `name` key equal to `Sea Otter`:
 
 [source,yaml]
 ----
@@ -42,7 +51,7 @@ object-templates-raw: |
 ----
 
 *Note:* While `spec.object-templates` and `spec.object-templates-raw` are optional, exactly one of the two parameter fields must be set.
- 
+
 View the following policy example that uses advanced templates to create and configure infrastructure `MachineSet` objects for your managed clusters.
 
 [source,yaml]
@@ -133,19 +142,11 @@ spec:
     {{- end }}
 ----
 
-[#bypass-template-processing]
-== Bypass template processing
-
-You might create a policy that contains a template that is not intended to be processed by {acm-short}. By default, {acm-short} processes all templates. 
-
-To bypass template processing for your hub cluster, you must change `{{ template content }}` to `{{ `{{ template content }}`` `}}`.
-
-Alternatively, you can add the following annotation in the `ConfigurationPolicy` section of your `Policy`: `policy.open-cluster-management.io/disable-templates: "true"`. When this annotation is included, the previous workaround is not necessary. Template processing is bypassed for the `ConfigurationPolicy`.
-
 [#additional-resources-hub-temp]
 == Additional resources
 
 * See xref:../governance/template_functions.adoc#template-functions[Template functions] for more details.
 * Return to xref:../governance/template_support_intro.adoc#template-processing[Template processing].
+* See xref:../governance/manage_policies.adoc#policy-cli-commands[Policy CLI] for tools to resolve Go templates locally.
 * See xref:../governance/config_policy_ctrl.adoc#kubernetes-config-policy-controller[Kubernetes configuration policy controller] for more details.
 * Also refer to the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/backup_and_restore/control-plane-backup-and-restore#backing-up-etcd-data_backup-etcd[Backing up etcd data].

--- a/governance/adv_template_process.adoc
+++ b/governance/adv_template_process.adoc
@@ -9,7 +9,7 @@ Continue reading for advanced template use-cases:
 
 * <<special-annotation-processing,Special annotation for reprocessing>>
 * <<bypass-template-processing,Bypass template processing>>
-* <<raw-object-template-processing,Raw object template processing>>
+* <<raw-object-template-processing,Processing raw templates in configuration policies>>
 
 [#special-annotation-processing]
 == Special annotation for reprocessing

--- a/governance/adv_template_process.adoc
+++ b/governance/adv_template_process.adoc
@@ -23,7 +23,7 @@ If you need to manually initiate an update, use the special annotation, `policy.
 
 By default, {acm-short} processes all Go templates. You might create a policy that contains a policy in `policy-templates` that is not intended to be processed by {acm-short}. To bypass template processing for a particular template, change `{{ template content }}` to `+{{ `{{ template content }}` }}+`. Then, the template returns a raw string to be processed by a subsequent templating engine.
 
-If you want to completely bypass the template resolution for a configuration policy, add the following annotation in the relevant `ConfigurationPolicy` contained in your `Policy`: `policy.open-cluster-management.io/disable-templates: "true"`.
+If you want to completely bypass the template resolution for a configuration policy, add the `policy.open-cluster-management.io/disable-templates: "true"` annotation in the relevant `ConfigurationPolicy` that is contained in your `Policy` resource.
 
 [#raw-object-template-processing]
 == Processing raw templates in configuration policies

--- a/governance/adv_template_process.adoc
+++ b/governance/adv_template_process.adoc
@@ -30,7 +30,7 @@ If you want to completely bypass the template resolution for a configuration pol
 
 The `object-template-raw` parameter is an optional parameter that supports advanced templating use-cases, such as the `if` conditional function and the `range` loop function. The `object-templates-raw` parameter accepts a string containing Go templates, and when you use these templates, they must result in an `object-templates` array.
 
-For example, see the following YAML sample that adds the `species-category: mammal` label to any ConfigMap in the `default` namespace that has a `name` key equal to `Sea Otter`:
+For example, see the following YAML sample that adds the `species-category: mammal` label to any `ConfigMap` in the `default` namespace that has a `name` key equal to `Sea Otter`:
 
 [source,yaml]
 ----

--- a/governance/adv_template_process.adoc
+++ b/governance/adv_template_process.adoc
@@ -21,7 +21,7 @@ If you need to manually initiate an update, use the special annotation, `policy.
 [#bypass-template-processing]
 == Bypassing template processing
 
-By default, {acm-short} processes all Go templates. You might create a policy that contains a policy in `policy-templates` that is not intended to be processed by {acm-short}. To bypass template processing for a particular template, change `{{ template content }}` to `+{{ `{{ template content }}` }}+` to have the template return a raw string to be processed by a subsequent templating engine.
+By default, {acm-short} processes all Go templates. You might create a policy that contains a policy in `policy-templates` that is not intended to be processed by {acm-short}. To bypass template processing for a particular template, change `{{ template content }}` to `+{{ `{{ template content }}` }}+`. Then, the template returns a raw string to be processed by a subsequent templating engine.
 
 If you want to completely bypass the template resolution for a configuration policy, add the following annotation in the relevant `ConfigurationPolicy` contained in your `Policy`: `policy.open-cluster-management.io/disable-templates: "true"`.
 

--- a/governance/adv_template_process.adoc
+++ b/governance/adv_template_process.adoc
@@ -8,7 +8,7 @@ Use both managed cluster and hub cluster templates to reduce the need to create 
 Continue reading for advanced template use-cases:
 
 * <<special-annotation-processing,Special annotation for reprocessing>>
-* <<bypass-template-processing,Bypass template processing>>
+* <<bypass-template-processing,Bypassing template processing>>
 * <<raw-object-template-processing,Processing raw templates in configuration policies>>
 
 [#special-annotation-processing]

--- a/governance/template_functions.adoc
+++ b/governance/template_functions.adoc
@@ -171,7 +171,7 @@ spec:
           http://{{ (lookup "v1" "Service" "default" "metrics").spec.clusterIP }}:8080
 ----
 <1> Configuration values can be set as key-value properties.
-<2> The value for the `metrics-url` data key is a template that retrieves the `v1/Service` Kubernetes resource `metrics` from the `default` namespace, and is set to the value of the `Spec.ClusterIP` in the queried resource.
+<2> The value for the `metrics-url` data key is a template that retrieves the `v1/Service` Kubernetes resource `metrics` from the `default` namespace, and is set to the value of the `spec.clusterIP` in the queried resource.
 
 [#base64enc-func]
 === _base64enc_

--- a/governance/template_functions.adoc
+++ b/governance/template_functions.adoc
@@ -48,31 +48,22 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-fromsecret
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
+  - objectDefinition:
       apiVersion: v1
-      data: <1>
-        USER_NAME: YWRtaW4=
-        PASSWORD: '{{ fromSecret "default" "localsecret" "PASSWORD" }}' <2>
-      kind: Secret <3>
+      kind: Secret <1>
       metadata:
         name: demosecret
         namespace: test
       type: Opaque
-  remediationAction: enforce
-  severity: low
+      data: <2>
+        USER_NAME: YWRtaW4=
+        PASSWORD: '{{ fromSecret "default" "localsecret" "PASSWORD" }}' <3>
 ----
-<1> When you use this function with hub cluster templates, the output is automatically encrypted using the <<protect-function,protect>> function.
-<2> The value for the `PASSWORD` data key is a template that references the secret on the target cluster.
-<3> You receive a policy violation if the Kubernetes `Secret` resource does not exist on the target cluster. If the data key does not exist on the target cluster, the value becomes an empty string.
+<1> You receive a policy violation if the Kubernetes `Secret` resource does not exist on the target cluster. If the data key does not exist on the target cluster, the value becomes an empty string.
+<2> When you use the `fromSecret` function with hub cluster templates, the output is automatically encrypted using the <<protect-function,protect>> function to protect the value in flight to the managed cluster.
+<3> The value for the `PASSWORD` data key is a template that references the secret on the target cluster.
 
 *Important:* When you add multiline string values such as, certificates, always add `| toRawJson | toLiteral` syntax at the end of the template pipeline to handle line breaks. For example, if you are copying a certificate from a `Secret` resource and including it in a `ConfigMap` resource, your template pipeline might be similar to the following syntax:
 
@@ -102,33 +93,19 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-fromcm-lookup
-  namespace: test-templates
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-      kind: ConfigMap <1>
-      apiVersion: v1
-      metadata:
-        name: demo-app-config
-        namespace: test
-      data: <2>
+  - objectDefinition:
+      ...
+      data: <1>
         app-name: sampleApp
         app-description: "this is a sample app"
-        log-file: '{{ fromConfigMap "default" "logs-config" "log-file" }}' <3>
-        log-level: '{{ fromConfigMap "default" "logs-config" "log-level" }}' <4>
-  remediationAction: enforce
-  severity: low
+        log-file: '{{ fromConfigMap "default" "logs-config" "log-file" }}' <2>
+        log-level: '{{ fromConfigMap "default" "logs-config" "log-level" }}' <3>
 ----
-<1> You receive a policy violation if the Kubernetes `ConfigMap` resource does not exist on the target cluster.
-<2> If the `data` key does not exist on the target cluster, the value becomes an empty string.
-<3> The value for the `log-file` data key is a template that retrieves the value of the `log-file` from the `logs-config` config map in the `default` namespace.
-<4> The `log-level` is a tempalte that retrieves the value of the `log-level` data key in the `default` namespace.
+<1> If the `data` key does not exist on the target cluster, the value becomes an empty string.
+<2> The `log-file` template value retrieves the value of the `log-file` data key from the `logs-config` `ConfigMap` in the `default` namespace.
+<3> The `log-level` template value retrieves the value of the `log-level` data key from the `logs-config` `ConfigMap` in the `default` namespace.
 
 [#fromclusterclaim-func]
 === _fromClusterClaim_
@@ -147,27 +124,14 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-clusterclaims <1>
-  namespace: default
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-      kind: ConfigMap
-      apiVersion: v1
-      metadata:
-        name: sample-app-config
-        namespace: default
+  - objectDefinition:
+      ...
       data: <2>
         platform: '{{ fromClusterClaim "platform.open-cluster-management.io" }}' <3>
         product: '{{ fromClusterClaim "product.open-cluster-management.io" }}'
         version: '{{ fromClusterClaim "version.openshift.io" }}'
-  remediationAction: enforce
-  severity: low
 ----
 <1> When you use this function, enter the name of a Kubernetes `ClusterClaim` resource. You receive a policy violation if the `ClusterClaim` resource does not exist.
 <2> Configuration values can be set as key-value properties.
@@ -196,28 +160,15 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-lookup
-  namespace: test-templates
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-      kind: ConfigMap
-      apiVersion: v1
-      metadata:
-        name: demo-app-config
-        namespace: test
+  - objectDefinition:
+      ...
       data: <1>
         app-name: sampleApp
         app-description: "this is a sample app"
-        metrics-url: | <2>
+        metrics-url: >- <2>
           http://{{ (lookup "v1" "Service" "default" "metrics").spec.clusterIP }}:8080
-  remediationAction: enforce
-  severity: low
 ----
 <1> Configuration values can be set as key-value properties.
 <2> The value for the `metrics-url` data key is a template that retrieves the `v1/Service` Kubernetes resource `metrics` from the `default` namespace, and is set to the value of the `Spec.ClusterIP` in the queried resource.
@@ -239,19 +190,13 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-fromsecret
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-    ...
-    data:
-      USER_NAME: '{{ fromConfigMap "default" "myconfigmap" "admin-user" | base64enc }}'
+  - objectDefinition:
+      ...
+      data:
+        USER_NAME: >-
+          {{ fromConfigMap "default" "myconfigmap" "admin-user" | base64enc }}
 ----
 
 [#base64dec-func]
@@ -271,20 +216,13 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-fromsecret
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-    ...
-    data:
-      app-name: |
-         "{{ ( lookup "v1"  "Secret" "testns" "mytestsecret") .data.appname ) | base64dec }}"
+  - objectDefinition:
+      ...
+      data:
+        app-name: >-
+          {{ ( lookup "v1"  "Secret" "testns" "mytestsecret") .data.appname ) | base64dec }}
 ----
 
 [#indent-function]
@@ -302,22 +240,13 @@ View the following example of the configuration policy that uses the `indent` fu
 ----
 apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
-metadata:
-  name: demo-fromsecret
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-    ...
-    data:
-      Ca-cert:  |
-        {{ ( index ( lookup "v1" "Secret" "default" "mycert-tls"  ).data  "ca.pem"  ) |  base64dec | indent 4  }}
+  - objectDefinition:
+      ...
+      data:
+        Ca-cert: >-
+          {{ ( index ( lookup "v1" "Secret" "default" "mycert-tls"  ).data  "ca.pem"  ) |  base64dec | indent 4  }}
 ----
 
 [#autoindent-function]
@@ -333,20 +262,13 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-fromsecret
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-    ...
-    data:
-      Ca-cert:  |
-        {{ ( index ( lookup "v1" "Secret" "default" "mycert-tls"  ).data  "ca.pem"  ) |  base64dec | autoindent }}
+  - objectDefinition:
+      ...
+      data:
+        Ca-cert: >-
+          {{ ( index ( lookup "v1" "Secret" "default" "mycert-tls"  ).data  "ca.pem"  ) |  base64dec | autoindent }}
 ----
 
 [#toInt-function]
@@ -366,20 +288,13 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-template-function
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-    ...
-    spec:
-      vlanid:  |
-        {{ (fromConfigMap "site-config" "site1" "vlan")  | toInt }}
+  - objectDefinition:
+      ...
+      spec:
+        vlanid: >-
+          {{ (fromConfigMap "site-config" "site1" "vlan")  | toInt }}
 ----
 
 [#toBool-function]
@@ -399,20 +314,13 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-template-function
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
-    ...
-    spec:
-      enabled:  |
-        {{ (fromConfigMap "site-config" "site1" "enabled")  | toBool }}
+  - objectDefinition:
+      ...
+      spec:
+        enabled: >-
+          {{ (fromConfigMap "site-config" "site1" "enabled")  | toBool }}
 ----
 
 [#protect-function]
@@ -426,19 +334,12 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   name: demo-template-function
-  namespace: test
 spec:
-  namespaceSelector:
-    exclude:
-    - kube-*
-    include:
-    - default
   object-templates:
-  - complianceType: musthave
-    objectDefinition:
+  - objectDefinition:
     ...
     spec:
-      enabled:  |
+      enabled: >-
         {{hub (lookup "v1" "Secret" "default" "my-hub-secret").data.message | protect hub}}
 ----
 
@@ -472,13 +373,13 @@ The `copySecretData` function copies all of the `data` contents of the specified
 
 [source,yaml]
 ----
-complianceType: musthave
-      objectDefinition:
-        apiVersion: v1
-        kind: Secret
-        metadata:
-          name: my-secret-copy
-        data: '{{ copySecretData "default" "my-secret" }}' <1>
+...
+objectDefinition:
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: my-secret-copy
+  data: '{{ copySecretData "default" "my-secret" }}' <1>
 ----
 <1> When you use this function with hub cluster templates, the output is automatically encrypted using the <<protect-function,protect>> function.
 
@@ -489,13 +390,13 @@ The `copyConfigMapData` function copies all of the `data` content of the specifi
 
 [source,yaml]
 ----
-complianceType: musthave
-      objectDefinition:
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: my-secret-copy
-        data: '{{ copyConfigMapData "default" "my-configmap" }}'
+...
+objectDefinition:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-secret-copy
+  data: '{{ copyConfigMapData "default" "my-configmap" }}'
 ----
 
 [#getNodes]
@@ -505,18 +406,18 @@ The `getNodesWithExactRoles` function returns a list of nodes with only the role
 
 [source,yaml]
 ----
-      complianceType: musthave
-      objectDefinition:
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: my-configmap
-          data:
-            infraNode: |
-              {{- range $i,$nd := (getNodesWithExactRoles "infra").items }}
-              node{{ $i }}: {{ $nd.metadata.name }}
-              {{- end }}
-            replicas: {{ len ((getNodesWithExactRoles "infra").items) | toInt }}
+...
+objectDefinition:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-configmap
+    data:
+      infraNode: |
+        {{- range $i,$nd := (getNodesWithExactRoles "infra").items }}
+        node{{ $i }}: {{ $nd.metadata.name }}
+        {{- end }}
+      replicas: {{ len ((getNodesWithExactRoles "infra").items) | toInt }}
 ----
 
 [#hasNodes]
@@ -526,14 +427,14 @@ The `hasNodesWithExactRoles` function returns the `true` value if the cluster co
 
 [source,yaml]
 ----
-      complianceType: musthave
-      objectDefinition:
-        apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: my-configmap
-        data:
-          key: '{{ hasNodesWithExactRoles "infra" }}'
+...
+objectDefinition:
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: my-configmap
+  data:
+    key: '{{ hasNodesWithExactRoles "infra" }}'
 ----
 
 [#open-source-community-functions]
@@ -577,7 +478,8 @@ The `hasNodesWithExactRoles` function returns the `true` value if the cluster co
 == Additional resources
 
 * See xref:../governance/template_support_intro.adoc#template-processing[Template processing] for more details.
-* See xref:../governance/adv_template_process.adoc#adv-template-processing[Advanced template processing in configuration policies] for use-cases.
+* See xref:../governance/adv_template_process.adoc#adv-template-processing[Advanced template processing in policies] for use-cases.
+* See xref:../governance/manage_policies.adoc#policy-cli-commands[Policy CLI] for tools to resolve Go templates locally.
 * For label selector examples, see the link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Kubernetes labels and selectors] documentation.
 * Refer to the link:https://golang.org/pkg/text/template[Golang documentation - Package templates].
 * See the link:https://masterminds.github.io/sprig/[Sprig Function Documentation] for more details.

--- a/governance/template_support_intro.adoc
+++ b/governance/template_support_intro.adoc
@@ -38,11 +38,11 @@ See the following table for a comparison of hub cluster and managed cluster temp
 | {{ … }}
 
 | Context
-| A `.ManagedClusterName` variable is available, which at runtime, resolves to the name of the target cluster where the policy is propagated. The `.ManagedClusterLabels` variable is also available, which resolves to a map of keys and values of the labels on the managed cluster where the policy is propagated.
+| Context variables `.ManagedClusterName`, `.ManagedClusterLabels`, and `.PolicyMetadata` are available. `.ManagedClusterName` resolves to the name of the target cluster where the policy is propagated. `.ManagedClusterLabels` resolves to a map of keys and values of the labels on the managed cluster where the policy is propagated. `.PolicyMetadata` resolves to a map with the `name`, `namespace`, `labels`, and `annotations` keys with values from the root policy.
 | For `ConfigurationPolicy` resources, an `.ObjectNamespace` variable that resolves to the name of the selected namespace from the `spec.namespaceSelector` at runtime.
 
 | Access control
-| By default, you can only reference namespaced Kubernetes resources that are in the same namespace as the `Policy` object and the `ManagedCluster` object of the cluster that the policy propogates to.
+| By default, you can only reference namespaced Kubernetes resources that are in the same namespace as the `Policy` object and the `ManagedCluster` object of the cluster that the policy propagates to.
 
 Alternatively, you can specify the `spec.hubTemplateOptions.serviceAccountName` field in the `Policy` object to a service account in the same namespace as the `Policy` resource. When you specify the field, the service account is used for all hub cluster template lookups.
 
@@ -61,10 +61,6 @@ The equivalent call might use the following syntax: `{{hub "(lookup "v1" "Secret
 | The output of template functions are stored in `Policy` resource objects in each applicable managed cluster namespace on the hub cluster, before it is synced to the managed cluster. This means that any sensitive results from template functions are readable by anyone with read access to the `Policy` resource objects on the hub cluster, and anyone with read access to the `ConfigurationPolicy` or `OperatorPolicy` resource objects on the managed clusters. Additionally, if etcd encryption is enabled, the policy resource objects are not encrypted. It is best to carefully consider this when using template functions that return sensitive output (e.g. from a secret).
 | The output of template functions are not stored in policy related resource objects.
 
-| Policy metadata
-| The `.PolicyMetadata` variable resolves to a map with the `name`, `namespace`, `labels`, and `annotations` keys with values from the root policy.
-| No context variables
-
 | Processing
 | Processing occurs at runtime on the hub cluster during propagation of replicated policies to clusters. Policies and the hub cluster templates within the policies are processed on the hub cluster only when templates are created or updated.
 | Processing occurs on the managed cluster. Configuration policies are processed periodically, which automatically updates the resolved object definition with data in the referenced resources. Operator policies automatically update whenever a referenced resource changes.
@@ -77,5 +73,5 @@ The equivalent call might use the following syntax: `{{hub "(lookup "v1" "Secret
 Continue reading the following topics:
 
 * xref:../governance/template_functions.adoc#template-functions[Template functions]
-* xref:../governance/adv_template_process.adoc#adv-template-processing[Advanced template processing in configuration policies]
+* xref:../governance/adv_template_process.adoc#adv-template-processing[Advanced template processing in policies]
 


### PR DESCRIPTION
- Clean out extra portions of YAML
- Reorganize/rename advanced template doc
- Reorganize template comparison table

ref: https://issues.redhat.com/browse/ACM-18043

Split from:
- #7521