### PR TITLE
ACM-18034: Doc `resourceRequirements` add-on configuration

### DIFF
--- a/add-ons/addon_overview.adoc
+++ b/add-ons/addon_overview.adoc
@@ -4,5 +4,5 @@
 With {acm} klusterlet add-ons, you can further configure your managed clusters to improve performance and add functionality to your applications. See the following enablement options:
 
 * xref:../add-ons/klusterlet_managed.adoc#add-ons-klusterlet[Enabling klusterlet add-ons on clusters for cluster management]
-* xref:../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons]
+* xref:../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet_addons[Configuring klusterlet add-ons]
 * xref:../add-ons/cluster_wide_proxy.adoc#enable-cluster-wide-proxy-addon[Enabling cluster-wide proxy on existing cluster add-ons]

--- a/add-ons/addon_overview.adoc
+++ b/add-ons/addon_overview.adoc
@@ -4,5 +4,5 @@
 With {acm} klusterlet add-ons, you can further configure your managed clusters to improve performance and add functionality to your applications. See the following enablement options:
 
 * xref:../add-ons/klusterlet_managed.adoc#add-ons-klusterlet[Enabling klusterlet add-ons on clusters for cluster management]
-* xref:../add-ons/configure_nodeselector_tolerations_addons.adoc#configure-nodeselector-tolerations-addons[Configuring nodeSelectors and tolerations for klusterlet add-ons]
+* xref:../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons]
 * xref:../add-ons/cluster_wide_proxy.adoc#enable-cluster-wide-proxy-addon[Enabling cluster-wide proxy on existing cluster add-ons]

--- a/add-ons/addon_overview.adoc
+++ b/add-ons/addon_overview.adoc
@@ -4,5 +4,5 @@
 With {acm} klusterlet add-ons, you can further configure your managed clusters to improve performance and add functionality to your applications. See the following enablement options:
 
 * xref:../add-ons/klusterlet_managed.adoc#add-ons-klusterlet[Enabling klusterlet add-ons on clusters for cluster management]
-* xref:../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet_addons[Configuring klusterlet add-ons]
+* xref:../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet-addons[Configuring klusterlet add-ons]
 * xref:../add-ons/cluster_wide_proxy.adoc#enable-cluster-wide-proxy-addon[Enabling cluster-wide proxy on existing cluster add-ons]

--- a/add-ons/configure_addons.adoc
+++ b/add-ons/configure_addons.adoc
@@ -86,12 +86,12 @@ oc apply -f addondeploymentconfig
 . Use the configuration that you created as the global default configuration for your add-on by running the following command:
 +
 ----
-oc patch clustermanagementaddons <addon-name> --type='json' -p='[{"op":"add", "path":"/spec/supportedConfigs", "value":[{"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs", "defaultConfig":{"name":"deploy-config","namespace":"open-cluster-management-hub"}}]}]'
+oc patch clustermanagementaddons <addon-name> --type='json' -p='[{"op":"add", "path":"/spec/supportedConfigs", "value":[{"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs", "defaultConfig":{"name":"<config-name>","namespace":"<config-namespace>"}}]}]'
 ----
 +
-* Replace `addon-name` with your add-on name.
-* Replace `config-name` with the name of the `AddonDeploymentConfig` that you just created.
-* Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you just created.
+* Replace `<addon-name>` with your add-on name.
+* Replace `<config-name>` with the name of the `AddonDeploymentConfig` that you just created.
+* Replace `<config-namespace>` with the namespace of the `AddonDeploymentConfig` that you just created.
 
 The `nodeSelector` and `tolerations` that you specified are applied to all of your add-on on each of the managed clusters.
 

--- a/add-ons/configure_addons.adoc
+++ b/add-ons/configure_addons.adoc
@@ -1,7 +1,7 @@
 [#configure-addons]
 = Configuring klusterlet add-ons
 
-In {acm-short}, you can configure the following klusterlet add-ons:
+In {acm-short}, you can configure the following klusterlet add-ons to improve the performance and functionality of your managed clusters:
 
 * application-manager
 * cert-policy-controller
@@ -17,17 +17,21 @@ In {acm-short}, you can configure the following klusterlet add-ons:
 * work-manager
 
 // This note only applies to ACM 2.13 and should be removed in ACM 2.14.
-*NOTE:* Configuring `resourceRequirements` is only available for the following add-ons:
+*Note:* Configuring `resourceRequirements` is only available for the following add-ons:
 
 * cert-policy-controller
 * config-policy-controller
 * governance-policy-framework
 
-Complete the following steps:
+[#applying-specifications-addons]
+== Applying specifications to klusterlet add-ons
+
+When you configure the klusterlet add-ons, you can apply specifications to all the add-ons on each of your managed clusters, such as the `nodeSelector` and `tolerations`. To configure the klusterlet add-on, complete the following steps:
 
 .  Use the `AddonDeploymentConfig` API to create an add-on configuration in any namespace on the hub cluster.
 
-. Create a file named `addondeploymentconfig.yaml` that is based on the following template:
+. Create a file named `addondeploymentconfig.yaml` with the following template:
+
 +
 [source,yaml]
 ----
@@ -49,15 +53,16 @@ spec:
         memory: 150Mi
 ----
 +
-<1> Replace `config-name` with the name of the `AddonDeploymentConfig` that you just created.
-<2> Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you just created.
+<1> Replace `config-name` with the name of the `AddonDeploymentConfig` that you created.
+<2> Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you created.
 <3> Replace `node-selector` with your node selector.
 <4> Replace `tolerations` with your tolerations.
 // The note here only applies to ACM 2.13 and should be removed in ACM 2.14.
-<5> (*NOTE:* Configuring `resourceRequirements` is only available for policy add-ons.) List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
-<6> Replace `<workload-kind>` with the kind of workload, like "deployment". Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. For any of these values, a `*` wildcard can be used to apply the configuration to all objects managed by the add-on. For example, `*:*:*` would apply to every container of every workload kind in any add-on to which this configuration is attached.
+<5> *Note:* Configuring `resourceRequirements` is only available for policy add-ons. List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
+<6> Replace `<workload-kind>` with the kind of workload, for example: `deployment`. Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. 
+.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the  `\*:*:*` attribute , it would apply the configuration  to every container of every workload kind in any add-on the configuration is attached to.
 +
-A completed `AddOnDeployment` file might resemble the following example: 
+A completed `AddOnDeployment` resembles the following example: 
 +
 [source,yaml]
 ----
@@ -77,30 +82,34 @@ spec:
         operator: Equal
 ----
 
-. Run the following command to apply the file that you created:
+. Apply the file you created by running the following command:
 +
+[source,bash]
 ----
 oc apply -f addondeploymentconfig
 ----
 
 . Use the configuration that you created as the global default configuration for your add-on by running the following command:
 +
+[source,bash]
 ----
 oc patch clustermanagementaddons <addon-name> --type='json' -p='[{"op":"add", "path":"/spec/supportedConfigs", "value":[{"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs", "defaultConfig":{"name":"<config-name>","namespace":"<config-namespace>"}}]}]'
 ----
 +
 * Replace `<addon-name>` with your add-on name.
-* Replace `<config-name>` with the name of the `AddonDeploymentConfig` that you just created.
-* Replace `<config-namespace>` with the namespace of the `AddonDeploymentConfig` that you just created.
+* Replace `<config-name>` with the name of the `AddonDeploymentConfig` that you created.
+* Replace `<config-namespace>` with the namespace of the `AddonDeploymentConfig` that you created.
 
-The `nodeSelector` and `tolerations` that you specified are applied to all of your add-on on each of the managed clusters.
+[#overriding-configurations-addons]
+== Overriding configurations on klusterlet add-ons
 
-You can also override the global default `AddonDeploymentConfig` configuration for your add-on on a certain managed cluster by using following steps:
+You can also override the global default `AddonDeploymentConfig` configuration for your add-on on a certain managed cluster. To override configurations, complete the following steps:
 
 . Use the `AddonDeploymentConfig` API to create another configuration to specify the `nodeSelector` and `tolerations` on the hub cluster. 
 
-. Link the new configuration that you created to your add-on `ManagedClusterAddon` on a managed cluster.
+. Connect the new configuration that you created to your `ManagedClusterAddon` add-on on the managed cluster by running the following command:
 +
+[source,bash]
 ----
 oc -n <managed-cluster> patch managedclusteraddons <addon-name> --type='json' -p='[{"op":"add", "path":"/spec/configs", "value":[ 
 
@@ -110,9 +119,10 @@ oc -n <managed-cluster> patch managedclusteraddons <addon-name> --type='json' -p
 +
 * Replace `managed-cluster` with your managed cluster name
 * Replace `addon-name` with your add-on name
-* Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you just created
-* Replace `config-name` with the name of the `AddonDeploymentConfig` that you just created
+* Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you created
+* Replace `config-name` with the name of the `AddonDeploymentConfig` that you created
 +
-The new configuration that you referenced in the add-on `ManagedClusterAddon` overrides the global default configuration that you previously defined in the `ClusterManagementAddon` add-on.
 
-. To make sure your content is deployed to the correct nodes, complete the steps in link:../clusters/cluster_lifecycle/adv_config_cluster.adoc#config-klusterlet-nodes[Optional: Configuring the klusterlet to run on specific nodes].
+The new configuration that you referenced in the `ManagedClusterAddon` add-on  overrides the global default configuration that you defined earlier in the `ClusterManagementAddon` add-on.
+
+To make sure that you can deploy your content to the correct nodes, see link:../clusters/cluster_lifecycle/adv_config_cluster.adoc#config-klusterlet-nodes[Optional: Configuring the klusterlet to run on specific nodes].

--- a/add-ons/configure_addons.adoc
+++ b/add-ons/configure_addons.adoc
@@ -1,7 +1,7 @@
-[#configure-nodeselector-tolerations-addons]
-= Configuring nodeSelectors and tolerations for klusterlet add-ons
+[#configure-addons]
+= Configuring klusterlet add-ons
 
-In {acm-short}, you can configure nodeSelector and tolerations for the following klusterlet add-ons:
+In {acm-short}, you can configure the following klusterlet add-ons:
 
 * application-manager
 * cert-policy-controller
@@ -9,7 +9,6 @@ In {acm-short}, you can configure nodeSelector and tolerations for the following
 * config-policy-controller
 * governance-policy-framework
 * hypershift-addon
-* iam-policy-controller
 * managed-serviceaccount 
 * observability-controller
 * search-collector
@@ -17,9 +16,16 @@ In {acm-short}, you can configure nodeSelector and tolerations for the following
 * volsync
 * work-manager
 
+// This note only applies to ACM 2.13 and should be removed in ACM 2.14.
+*NOTE:* Configuring `resourceRequirements` is only available for the following add-ons:
+
+* cert-policy-controller
+* config-policy-controller
+* governance-policy-framework
+
 Complete the following steps:
 
-.  Use the `AddonDeploymentConfig` API to create a configuration to specify the `nodeSelector` and `tolerations` on a certain namespace on the hub cluster.
+.  Use the `AddonDeploymentConfig` API to create an add-on configuration in any namespace on the hub cluster.
 
 . Create a file named `addondeploymentconfig.yaml` that is based on the following template:
 +
@@ -34,12 +40,22 @@ spec:
   nodePlacement:
     nodeSelector: node-selector <3>
     tolerations: tolerations <4>
+  resourceRequirements: <5>
+  - containerID: "<workload-kind>:<workload-name>:<container-name>" <6>
+    resources:
+      requests:
+        memory: 75Mi
+      limits:
+        memory: 150Mi
 ----
 +
 <1> Replace `config-name` with the name of the `AddonDeploymentConfig` that you just created.
 <2> Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you just created.
 <3> Replace `node-selector` with your node selector.
 <4> Replace `tolerations` with your tolerations.
+// The note here only applies to ACM 2.13 and should be removed in ACM 2.14.
+<5> (*NOTE:* Configuring `resourceRequirements` is only available for policy add-ons.) List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
+<6> Replace `<workload-kind>` with the kind of workload, like "deployment". Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. For any of these values, a `*` wildcard can be used to apply the configuration to all objects managed by the add-on. For example, `*:*:*` would apply to every container of every workload kind in any add-on to which this configuration is attached.
 +
 A completed `AddOnDeployment` file might resemble the following example: 
 +

--- a/add-ons/configure_klusterlet_addons.adoc
+++ b/add-ons/configure_klusterlet_addons.adoc
@@ -1,4 +1,4 @@
-[#configure-klusterlet_addons]
+[#configure-klusterlet-addons]
 = Configuring klusterlet add-ons
 
 In {acm-short}, you can configure the following klusterlet add-ons to improve the performance and functionality of your managed clusters:

--- a/add-ons/configure_klusterlet_addons.adoc
+++ b/add-ons/configure_klusterlet_addons.adoc
@@ -26,7 +26,7 @@ In {acm-short}, you can configure the following klusterlet add-ons to improve th
 [#setting-addondeploymentconfig-klusterlet-addons]
 == Setting up the _AddOnDeploymentConfig_ to configure klusterlet add-ons
 
-When you configure the klusterlet add-ons, you can apply specifications to all the add-ons on each of your managed clusters, such as the `nodeSelector` and `tolerations`. To configure the klusterlet add-on, complete the following steps:
+When you configure the klusterlet add-ons, you can apply specifications to any of the add-ons on each of your managed clusters, such as the `nodeSelector` and `tolerations`. To configure the klusterlet add-on, complete the following steps:
 
 .  Use the `AddonDeploymentConfig` API to create an add-on configuration in any namespace on the hub cluster.
 
@@ -39,11 +39,11 @@ apiVersion: addon.open-cluster-management.io/v1alpha1
 kind: AddOnDeploymentConfig
 metadata:
   name: config-name <1>
-  namespace: config-name-space <2>
+  namespace: config-namespace <2>
 spec:
   nodePlacement:
-    nodeSelector: node-selector <3>
-    tolerations: tolerations <4>
+    nodeSelector: {<node-selector>} <3>
+    tolerations: {<tolerations>} <4>
   resourceRequirements: <5>
   - containerID: "<workload-kind>:<workload-name>:<container-name>" <6>
     resources:
@@ -55,12 +55,12 @@ spec:
 +
 <1> Replace `config-name` with the name of the `AddonDeploymentConfig` that you created.
 <2> Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you created.
-<3> Replace `node-selector` with your node selector.
-<4> Replace `tolerations` with your tolerations.
+<3> Replace `<node-selector>` with your node selector.
+<4> Replace `<tolerations>` with your tolerations.
 // The note here only applies to ACM 2.13 and should be removed in ACM 2.14.
 <5> *Note:* Configuring `resourceRequirements` is only available for policy add-ons. List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
 <6> Replace `<workload-kind>` with the kind of workload, for example: `deployment`. Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. 
-.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the  `\*:\*:\*` attribute , it would apply the configuration  to every container of every workload kind in any add-on the configuration is attached to.
+.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the `*:*:*` attribute , it would apply the configuration to every container of every workload kind in any add-on the configuration is attached to.
 +
 A completed `AddOnDeployment` resembles the following example: 
 +
@@ -86,20 +86,28 @@ spec:
 [#configuring-klusterlet-addons-all-managedclusters]
 == Configuring a klusterlet add-on for all managed clusters
 
-After you set up the `AddOnDeploymentConfig`, you can configure it with the `ClusterManagementAddOn` which then applies this add-on to all your managed clusters attached to the hub cluster. To configure a klusterlet add-on for all managed clusters, complete the following steps:
+After you set up the `AddOnDeploymentConfig`, you can configure it with the `ClusterManagementAddOn` which then applies this add-on configuration to all your managed clusters attached to the hub cluster. To configure a klusterlet add-on for all managed clusters, complete the following steps:
 
 . Apply the `AddOnDeploymentConfig` file to your klusterlet add-on by running the following command:
 +
 [source,bash]
 ----
-oc apply -f addondeploymentconfig
+oc apply -f addondeploymentconfig.yaml
 ----
 
 . Use the configuration that you created as the global default configuration for your add-on by running the following command:
 +
 [source,bash]
 ----
-oc patch clustermanagementaddons <addon-name> --type='json' -p='[{"op":"add", "path":"/spec/supportedConfigs", "value":[{"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs", "defaultConfig":{"name":"<config-name>","namespace":"<config-namespace>"}}]}]'
+oc patch clustermanagementaddons <addon-name> --type='json' -p='[{
+  "op":"add",
+  "path":"/spec/supportedConfigs",
+  "value":[{
+    "group":"addon.open-cluster-management.io",
+    "resource":"addondeploymentconfigs",
+    "defaultConfig":{"name":"<config-name>","namespace":"<config-namespace>"}
+  }]
+}]'
 ----
 +
 * Replace `<addon-name>` with your add-on name.
@@ -109,18 +117,24 @@ oc patch clustermanagementaddons <addon-name> --type='json' -p='[{"op":"add", "p
 [#configuring-klusterlet-addons-single-managedclusters]
 == Configuring a klusterlet add-on for a single managed cluster
 
-You can also override the global default `AddonDeploymentConfig` configuration for your add-on on a certain managed cluster. By overriding, you can configure a klusterlet add-on for a single managed cluster because the add-on only applies to a the particular managed cluster attached to that namespace of that hub cluster.  To override configurations, complete the following steps:
+You can also override the global default `AddonDeploymentConfig` configuration for your add-on on a certain managed cluster. By overriding, you can configure a klusterlet add-on for a single managed cluster because the add-on configuration only applies to a the particular managed cluster attached to that namespace of the hub cluster. To override configurations, complete the following steps:
 
-. Use the `AddonDeploymentConfig` API to create another configuration to specify the `nodeSelector` and `tolerations` on the hub cluster. 
+. Use the `AddonDeploymentConfig` API to create another configuration to specify the `nodeSelector` and `tolerations` on the hub cluster.
 
 . Connect the new configuration that you created to your `ManagedClusterAddon` add-on on the managed cluster by running the following command:
 +
 [source,bash]
 ----
-oc -n <managed-cluster> patch managedclusteraddons <addon-name> --type='json' -p='[{"op":"add", "path":"/spec/configs", "value":[ 
-
-{"group":"addon.open-cluster-management.io","resource":"addondeploymentconfigs","namespace":"<config-namespace>","name":"<config-name>"}
-]}]'
+oc -n <managed-cluster> patch managedclusteraddons <addon-name> --type='json' -p='[{
+  "op":"add",
+  "path":"/spec/configs",
+  "value":[{
+    "group":"addon.open-cluster-management.io",
+    "resource":"addondeploymentconfigs",
+    "namespace":"<config-namespace>",
+    "name":"<config-name>"
+  }]
+}]'
 ----
 +
 * Replace `managed-cluster` with your managed cluster name
@@ -129,6 +143,6 @@ oc -n <managed-cluster> patch managedclusteraddons <addon-name> --type='json' -p
 * Replace `config-name` with the name of the `AddonDeploymentConfig` that you created
 +
 
-The new configuration that you referenced in the `ManagedClusterAddon` add-on  overrides the global default configuration that you defined earlier in the `ClusterManagementAddon` add-on.
+The new configuration that you referenced in the `ManagedClusterAddon` add-on overrides the global default configuration that you defined earlier in the `ClusterManagementAddon` add-on.
 
 To make sure that you can deploy your content to the correct nodes, see link:../clusters/cluster_lifecycle/adv_config_cluster.adoc#config-klusterlet-nodes[Optional: Configuring the klusterlet to run on specific nodes].

--- a/add-ons/configure_klusterlet_addons.adoc
+++ b/add-ons/configure_klusterlet_addons.adoc
@@ -1,4 +1,4 @@
-[#configure-addons]
+[#configure-klusterlet_addons]
 = Configuring klusterlet add-ons
 
 In {acm-short}, you can configure the following klusterlet add-ons to improve the performance and functionality of your managed clusters:
@@ -23,8 +23,8 @@ In {acm-short}, you can configure the following klusterlet add-ons to improve th
 * config-policy-controller
 * governance-policy-framework
 
-[#applying-specifications-addons]
-== Applying specifications to klusterlet add-ons
+[#setting-addondeploymentconfig-klusterlet-addons]
+== Setting up the _AddOnDeploymentConfig_ to configure klusterlet add-ons
 
 When you configure the klusterlet add-ons, you can apply specifications to all the add-ons on each of your managed clusters, such as the `nodeSelector` and `tolerations`. To configure the klusterlet add-on, complete the following steps:
 
@@ -60,7 +60,7 @@ spec:
 // The note here only applies to ACM 2.13 and should be removed in ACM 2.14.
 <5> *Note:* Configuring `resourceRequirements` is only available for policy add-ons. List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
 <6> Replace `<workload-kind>` with the kind of workload, for example: `deployment`. Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. 
-.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the  `\*:*:*` attribute , it would apply the configuration  to every container of every workload kind in any add-on the configuration is attached to.
+.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the  `\*:\*:\*` attribute , it would apply the configuration  to every container of every workload kind in any add-on the configuration is attached to.
 +
 A completed `AddOnDeployment` resembles the following example: 
 +
@@ -82,7 +82,13 @@ spec:
         operator: Equal
 ----
 
-. Apply the file you created by running the following command:
+
+[#configuring-klusterlet-addons-all-managedclusters]
+== Configuring a klusterlet add-on for all managed clusters
+
+After you set up the `AddOnDeploymentConfig`, you can configure it with the `ClusterManagementAddOn` which then applies this add-on to all your managed clusters attached to the hub cluster. To configure a klusterlet add-on for all managed clusters, complete the following steps:
+
+. Apply the `AddOnDeploymentConfig` file to your klusterlet add-on by running the following command:
 +
 [source,bash]
 ----
@@ -100,10 +106,10 @@ oc patch clustermanagementaddons <addon-name> --type='json' -p='[{"op":"add", "p
 * Replace `<config-name>` with the name of the `AddonDeploymentConfig` that you created.
 * Replace `<config-namespace>` with the namespace of the `AddonDeploymentConfig` that you created.
 
-[#overriding-configurations-addons]
-== Overriding configurations on klusterlet add-ons
+[#configuring-klusterlet-addons-single-managedclusters]
+== Configuring a klusterlet add-on for a single managed cluster
 
-You can also override the global default `AddonDeploymentConfig` configuration for your add-on on a certain managed cluster. To override configurations, complete the following steps:
+You can also override the global default `AddonDeploymentConfig` configuration for your add-on on a certain managed cluster. By overriding, you can configure a klusterlet add-on for a single managed cluster because the add-on only applies to a the particular managed cluster attached to that namespace of that hub cluster.  To override configurations, complete the following steps:
 
 . Use the `AddonDeploymentConfig` API to create another configuration to specify the `nodeSelector` and `tolerations` on the hub cluster. 
 

--- a/add-ons/configure_klusterlet_addons.adoc
+++ b/add-ons/configure_klusterlet_addons.adoc
@@ -58,9 +58,9 @@ spec:
 // The note here only applies to ACM 2.13 and should be removed in ACM 2.14.
 <5> *Note:* For {acm-short} version 2.13, you can only configure `resourceRequirements`  for policy add-ons. List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
 <6> Replace `<workload-kind>` with the kind of workload, for example: `deployment`. Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. 
-.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the `\*:\*:\*` attribute , it would apply the configuration to every container of every workload kind in any add-on the configuration is attached to.
+.. For any of these values, you can use `+*+` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the `+*:*:*+` attribute , it would apply the configuration to every container of every workload kind in any add-on the configuration is attached to.
 +
-A completed `AddOnDeployment` resembles the following example: 
+A completed `AddOnDeploymentConfig` resembles the following example:
 
 +
 [source,yaml]
@@ -94,8 +94,7 @@ After you set up the `AddOnDeploymentConfig`, you can configure it with the `Clu
 oc apply -f addondeploymentconfig.yaml
 ----
 
-. Use the configuration that you created as the global default configuration for your add-on by running the following command:
-
+. Connect the new configuration that you created to an add-on for all of your managed clusters by patching the `ClusterManagementAddOn` resource. Run the following command to patch the `spec.supportedConfigs` parameter in the `ClusterManagementAddOn` to point to the new configuration:
 +
 [source,bash]
 ----
@@ -121,8 +120,7 @@ You can also override the global default `AddonDeploymentConfig` configuration f
 
 . Use the `AddonDeploymentConfig` API to create another configuration to specify the `nodeSelector` and `tolerations` on the hub cluster.
 
-. Connect the new configuration that you created to your `ManagedClusterAddon` add-on on the managed cluster by running the following command:
-
+. Connect the new configuration that you created to your `ManagedClusterAddOn` add-on on the hub cluster in the managed cluster namespace. Run the following command to patch the `spec.configs` parameter in the `ManagedClusterAddOn` to point to the new configuration:
 +
 [source,bash]
 ----
@@ -142,8 +140,7 @@ oc -n <managed-cluster> patch managedclusteraddons <addon-name> --type='json' -p
 * Replace `addon-name` with your add-on name
 * Replace `config-namespace` with the namespace of the `AddonDeploymentConfig` that you created
 * Replace `config-name` with the name of the `AddonDeploymentConfig` that you created
-+
 
-The new configuration that you referenced in the `ManagedClusterAddon` add-on overrides the global default configuration that you defined earlier in the `ClusterManagementAddon` add-on.
+The new configuration that you referenced in the `ManagedClusterAddOn` add-on overrides the global default configuration that you defined earlier in the `ClusterManagementAddOn` add-on.
 
 To make sure that you can deploy your content to the correct nodes, see link:../clusters/cluster_lifecycle/adv_config_cluster.adoc#config-klusterlet-nodes[Optional: Configuring the klusterlet to run on specific nodes].

--- a/add-ons/configure_klusterlet_addons.adoc
+++ b/add-ons/configure_klusterlet_addons.adoc
@@ -16,8 +16,7 @@ In {acm-short}, you can configure the following klusterlet add-ons to improve th
 * volsync
 * work-manager
 
-// This note only applies to ACM 2.13 and should be removed in ACM 2.14.
-*Note:* Configuring `resourceRequirements` is only available for the following add-ons:
+*Important:* For {acm-short} version 2.13, you can only configure `resourceRequirements` for the following add-ons:
 
 * cert-policy-controller
 * config-policy-controller
@@ -29,7 +28,6 @@ In {acm-short}, you can configure the following klusterlet add-ons to improve th
 When you configure the klusterlet add-ons, you can apply specifications to any of the add-ons on each of your managed clusters, such as the `nodeSelector` and `tolerations`. To configure the klusterlet add-on, complete the following steps:
 
 .  Use the `AddonDeploymentConfig` API to create an add-on configuration in any namespace on the hub cluster.
-
 . Create a file named `addondeploymentconfig.yaml` with the following template:
 
 +
@@ -58,11 +56,12 @@ spec:
 <3> Replace `<node-selector>` with your node selector.
 <4> Replace `<tolerations>` with your tolerations.
 // The note here only applies to ACM 2.13 and should be removed in ACM 2.14.
-<5> *Note:* Configuring `resourceRequirements` is only available for policy add-ons. List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
+<5> *Note:* For {acm-short} version 2.13, you can only configure `resourceRequirements`  for policy add-ons. List resource requirements here to override the `resources` of the add-on workload containers. If an add-on container matches more than one of the items in the list, the last matching configuration is applied.
 <6> Replace `<workload-kind>` with the kind of workload, for example: `deployment`. Replace `<workload-name>` with the name of the workload. Replace `<container-name>` with the name of the container. 
-.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the `*:*:*` attribute , it would apply the configuration to every container of every workload kind in any add-on the configuration is attached to.
+.. For any of these values, you can use `\*` attribute to apply the configuration to all objects managed by the add-on. For example, if you used the `\*:\*:\*` attribute , it would apply the configuration to every container of every workload kind in any add-on the configuration is attached to.
 +
 A completed `AddOnDeployment` resembles the following example: 
+
 +
 [source,yaml]
 ----
@@ -82,13 +81,13 @@ spec:
         operator: Equal
 ----
 
-
 [#configuring-klusterlet-addons-all-managedclusters]
 == Configuring a klusterlet add-on for all managed clusters
 
-After you set up the `AddOnDeploymentConfig`, you can configure it with the `ClusterManagementAddOn` which then applies this add-on configuration to all your managed clusters attached to the hub cluster. To configure a klusterlet add-on for all managed clusters, complete the following steps:
+After you set up the `AddOnDeploymentConfig`, you can configure it with the `ClusterManagementAddOn` which then applies this add-on configuration to all your managed clusters that are attached to the hub cluster. To configure a klusterlet add-on for all managed clusters, complete the following steps:
 
 . Apply the `AddOnDeploymentConfig` file to your klusterlet add-on by running the following command:
+
 +
 [source,bash]
 ----
@@ -96,6 +95,7 @@ oc apply -f addondeploymentconfig.yaml
 ----
 
 . Use the configuration that you created as the global default configuration for your add-on by running the following command:
+
 +
 [source,bash]
 ----
@@ -122,6 +122,7 @@ You can also override the global default `AddonDeploymentConfig` configuration f
 . Use the `AddonDeploymentConfig` API to create another configuration to specify the `nodeSelector` and `tolerations` on the hub cluster.
 
 . Connect the new configuration that you created to your `ManagedClusterAddon` add-on on the managed cluster by running the following command:
+
 +
 [source,bash]
 ----

--- a/add-ons/main.adoc
+++ b/add-ons/main.adoc
@@ -4,5 +4,5 @@ include::modules/common-attributes.adoc[]
 
 include::addon_overview.adoc[leveloffset=+1]
 include::klusterlet_managed.adoc[leveloffset=+2]
-include::configure_nodeselector_tolerations_addons.adoc[leveloffset=+2]
+include::configure_addons.adoc[leveloffset=+2]
 include::cluster_wide_proxy.adoc[leveloffset=+2]

--- a/add-ons/main.adoc
+++ b/add-ons/main.adoc
@@ -4,5 +4,5 @@ include::modules/common-attributes.adoc[]
 
 include::addon_overview.adoc[leveloffset=+1]
 include::klusterlet_managed.adoc[leveloffset=+2]
-include::configure_addons.adoc[leveloffset=+2]
+include::configure_klusterlet_addons.adoc[leveloffset=+2]
 include::cluster_wide_proxy.adoc[leveloffset=+2]

--- a/clusters/cluster_lifecycle/adv_config_cluster.adoc
+++ b/clusters/cluster_lifecycle/adv_config_cluster.adoc
@@ -219,7 +219,7 @@ metadata:
     open-cluster-management/tolerations: '[{"key":"dedicated","operator":"Equal","value":"acm","effect":"NoSchedule"}]' 
 ----
 
-. To make sure that you can deploy your content to the correct nodes, see link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons].
+. To make sure that you can deploy your content to the correct nodes, see link:../../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet_addons[Configuring klusterlet add-ons].
 
 [#custom-server-url-ca]
 == Customizing the server URL and CA bundle of the hub cluster API server when importing a managed cluster (Technology Preview)

--- a/clusters/cluster_lifecycle/adv_config_cluster.adoc
+++ b/clusters/cluster_lifecycle/adv_config_cluster.adoc
@@ -219,7 +219,7 @@ metadata:
     open-cluster-management/tolerations: '[{"key":"dedicated","operator":"Equal","value":"acm","effect":"NoSchedule"}]' 
 ----
 
-. To make sure your content is deployed to the correct nodes, complete the steps in link:../../add-ons/configure_nodeselector_tolerations_addons.adoc#configure-nodeselector-tolerations-addons[Configuring nodeSelectors and tolerations for klusterlet add-ons].
+. To make sure your content is deployed to the correct nodes, complete the steps in link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons].
 
 [#custom-server-url-ca]
 == Customizing the server URL and CA bundle of the hub cluster API server when importing a managed cluster (Technology Preview)

--- a/clusters/cluster_lifecycle/adv_config_cluster.adoc
+++ b/clusters/cluster_lifecycle/adv_config_cluster.adoc
@@ -219,7 +219,7 @@ metadata:
     open-cluster-management/tolerations: '[{"key":"dedicated","operator":"Equal","value":"acm","effect":"NoSchedule"}]' 
 ----
 
-. To make sure that you can deploy your content to the correct nodes, see link:../../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet_addons[Configuring klusterlet add-ons].
+. To make sure that you can deploy your content to the correct nodes, see link:../../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet-addons[Configuring klusterlet add-ons].
 
 [#custom-server-url-ca]
 == Customizing the server URL and CA bundle of the hub cluster API server when importing a managed cluster (Technology Preview)

--- a/clusters/cluster_lifecycle/adv_config_cluster.adoc
+++ b/clusters/cluster_lifecycle/adv_config_cluster.adoc
@@ -219,7 +219,7 @@ metadata:
     open-cluster-management/tolerations: '[{"key":"dedicated","operator":"Equal","value":"acm","effect":"NoSchedule"}]' 
 ----
 
-. To make sure your content is deployed to the correct nodes, complete the steps in link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons].
+. To make sure that you can deploy your content to the correct nodes, see link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons].
 
 [#custom-server-url-ca]
 == Customizing the server URL and CA bundle of the hub cluster API server when importing a managed cluster (Technology Preview)

--- a/clusters/release_notes/mce_known_issues.adoc
+++ b/clusters/release_notes/mce_known_issues.adoc
@@ -423,7 +423,7 @@ If the `managed-serviceaccount` add-on is required, you can work around the issu
 
 . Update the `managed-serviceaccount` `ManagedClusterAddon` in the local cluster namespace to use the `addonDeploymentConfig` custom resource you created.
 
-To learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-on, see link:../../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet_addons[Configuring klusterlet add-ons].
+To learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-on, see link:../../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet-addons[Configuring klusterlet add-ons].
 
 [#nodes-shut-down-bmh]
 === Nodes shut down after removing `BareMetalHost` resource

--- a/clusters/release_notes/mce_known_issues.adoc
+++ b/clusters/release_notes/mce_known_issues.adoc
@@ -423,7 +423,7 @@ If the `managed-serviceaccount` add-on is required, you can work around the issu
 
 . Update the `managed-serviceaccount` `ManagedClusterAddon` in the local cluster namespace to use the `addonDeploymentConfig` custom resource you created.
 
-See link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons] to learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-ons.
+To learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-on, see link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons] 
 
 [#nodes-shut-down-bmh]
 === Nodes shut down after removing `BareMetalHost` resource

--- a/clusters/release_notes/mce_known_issues.adoc
+++ b/clusters/release_notes/mce_known_issues.adoc
@@ -423,7 +423,7 @@ If the `managed-serviceaccount` add-on is required, you can work around the issu
 
 . Update the `managed-serviceaccount` `ManagedClusterAddon` in the local cluster namespace to use the `addonDeploymentConfig` custom resource you created.
 
-To learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-on, see link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons] 
+To learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-on, see link:../../add-ons/configure_klusterlet_addons.adoc#configure-klusterlet_addons[Configuring klusterlet add-ons].
 
 [#nodes-shut-down-bmh]
 === Nodes shut down after removing `BareMetalHost` resource

--- a/clusters/release_notes/mce_known_issues.adoc
+++ b/clusters/release_notes/mce_known_issues.adoc
@@ -423,7 +423,7 @@ If the `managed-serviceaccount` add-on is required, you can work around the issu
 
 . Update the `managed-serviceaccount` `ManagedClusterAddon` in the local cluster namespace to use the `addonDeploymentConfig` custom resource you created.
 
-See link:../../add-ons/configure_nodeselector_tolerations_addons.adoc#configure-nodeselector-tolerations-addons[Configuring nodeSelectors and tolerations for klusterlet add-ons] to learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-ons.
+See link:../../add-ons/configure_addons.adoc#configure-addons[Configuring klusterlet add-ons] to learn more about how to use the `addonDeploymentConfig` custom resource to configure `tolerations` and `nodeSelector` for add-ons.
 
 [#nodes-shut-down-bmh]
 === Nodes shut down after removing `BareMetalHost` resource


### PR DESCRIPTION
This is an add-on configuration that goes into the add-on doc. However, for 2.13 it only applies to GRC. In 2.14, the remainder of the add-ons will implement it in [ACM-17874](https://issues.redhat.com/browse/ACM-17874).

ref: https://issues.redhat.com/browse/ACM-18034