### PR TITLE
Remove Compliance API known issues

### DIFF
--- a/release_notes/known_issues_governance.adoc
+++ b/release_notes/known_issues_governance.adoc
@@ -83,25 +83,6 @@ To resolve the issue, disable the policy and compare the differences between `ob
 
 When you create a policy with identical policy template names, you receive inconsistent results that are not detected, but you might not know the cause. For example, defining a policy with multiple configuration policies named `create-pod` causes inconsistent results. *Best practice:* Avoid using duplicate names for policy templates.
 
-[#database-compliance-history-outage]
-== Database and policy compliance history API outage
-
-There is built-in resilience for database and policy compliance history API outages, however, any compliance events that cannot be recorded by a managed cluster are queued in memory until they are successfully recorded. This means that if there is an outage and the `governance-policy-framework` pod on the managed cluster restarts, all queued compliance events are lost.
-
-If you create or update a new policy during a database outage, any compliance events sent for this new policy cannot be recorded since the mapping of policies to database IDs cannot be updated. When the database is back online, the mapping is automatically updated and future compliance events from those policies are recorded.
-
-[#postgresql-data-loss]
-== PostgreSQL data loss
-
-If there is data loss to the PostgreSQL server such as restoring to a backup without the latest data, you must restart the governance policy propagator on the {acm-short} hub cluster so that it can update the mapping of policies to database IDs. Until you restart the governance policy propagator, new compliance events associated with policies that once existed in the database are no longer recorded. 
-
-To restart the governance policy propagator, run the following command on the {acm-short} hub cluster:
-
-[source,bash]
-----
-oc -n open-cluster-management rollout restart deployment/grc-policy-propagator
-----
-
 [#kyverno-no-status]
 == Kyverno policies no longer report a status for the latest version 
 


### PR DESCRIPTION
The compliance API is fully removed in ACM 2.13.

For https://issues.redhat.com/browse/ACM-16282