### PR TITLE
https://issues.redhat.com/browse/ACM-19816--Fix MCH namespace in Enabling SiteConfig operator docs

### DIFF
--- a/mce_acm_integration/siteconfig/siteconfig_enable.adoc
+++ b/mce_acm_integration/siteconfig/siteconfig_enable.adoc
@@ -20,7 +20,7 @@ Patch the `MultiClusterHub` resource, then verify that {sco} is enabled. Complet
 +
 [source,terminal]
 ----
-oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n rhacm --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"siteconfig","enabled": true}}]'
+oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n <namespace> --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"siteconfig","enabled": true}}]'
 ----
 
 . Verify that the {sco} is enabled by running the following command on the hub cluster:
@@ -28,7 +28,7 @@ oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n
 +
 [source,terminal]
 ----
-oc -n rhacm get po | grep siteconfig
+oc -n <namespace> get po | grep siteconfig
 ----
 
 +
@@ -45,7 +45,7 @@ siteconfig-controller-manager-6fdd86cc64-sdg87                    2/2     Runnin
 +
 [source,terminal]
 ----
-oc -n rhacm get cm
+oc -n <namespace> get cm
 ----
 
 +


### PR DESCRIPTION
Cherry-picked from https://github.com/stolostron/rhacm-docs/pull/7708
Approvals are in the original PR.