### PR TITLE
Add link cache and limit concurrency

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,8 +20,15 @@ jobs:
         run: |
           find . -name \*.adoc -exec asciidoctor --failure-level WARN --trace --verbose --warnings {} +
 
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: cache-lychee-${{ github.sha }}
+          restore-keys: cache-lychee-
+
       - name: Link Check
         uses: lycheeverse/lychee-action@1d97d84f0bc547f7b25f4c2170d87d810dc2fb2c
         with:
-          args: --no-progress --timeout 30 --scheme http --scheme https --require-https "./**/main.html"
+          args: --cache --no-progress --threads 4 --timeout 30 --retry-wait-time 15 --max-concurrency 60 --scheme http --scheme https --require-https "./**/main.html"
           fail: true


### PR DESCRIPTION
Avoid the GitHub 429 Too Many Requests error.
