### PR TITLE
[2.14_stage] Add `openapi` policy generator content

### DIFF
--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -461,7 +461,7 @@ The following manifests are supported:
 
 | `policies[].manifests[].patches`
 | Optional
-| A list of Kustomize patches to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so Kustomize can identify the manifest that the patch applies to. If there is a single manifest, the `metadata.name` and `metadata.namespace` fields can be patched. See the link:https://kubectl.docs.kubernetes.io/guides/example/inline_patch/#patchesstrategicmerge[Kustomize documentation on strategic merge patches] for more details.
+| A list of Kustomize patches to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so that Kustomize can identify the manifest where the patch is to be applied. If there is a single manifest, the `metadata.name` and `metadata.namespace` fields can be patched. See the link:https://kubectl.docs.kubernetes.io/guides/example/inline_patch/#patchesstrategicmerge[Kustomize documentation on strategic merge patches] for more details.
 
 | `policies[].manifests[].openapi.path`
 | Optional

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -461,7 +461,11 @@ The following manifests are supported:
 
 | `policies[].manifests[].patches`
 | Optional
-| A list of Kustomize patches to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so Kustomize can identify the manifest that the patch applies to. If there is a single manifest, the `metadata.name` and `metadata.namespace` fields can be patched.
+| A list of Kustomize patches to apply to the manifest at the path. If there are multiple manifests, the patch requires the `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace` (if applicable) fields to be set so Kustomize can identify the manifest that the patch applies to. If there is a single manifest, the `metadata.name` and `metadata.namespace` fields can be patched. See the link:https://kubectl.docs.kubernetes.io/guides/example/inline_patch/#patchesstrategicmerge[Kustomize documentation on strategic merge patches] for more details.
+
+| `policies[].manifests[].openapi.path`
+| Optional
+| Use the `openapi.path` field to specify the path to an OpenAPI schema file to be used when patching the manifest. This is useful when patching the arrays of a custom resource. See the link:https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/openapi/[Kustomize documentation on `openapi`] for details.
 
 | `policies.policyLabels`
 | Optional


### PR DESCRIPTION
Add `policies[].manifests[].openapi.path` and additional details on patching with the policy generator.

ref: https://issues.redhat.com/browse/ACM-20692