### PR TITLE
[2.14_stage] Omit `403` errors for link checker

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -43,6 +43,6 @@ jobs:
             --scheme http
             --scheme https
             --require-https
-            --accept 200..=299,429
+            --accept 200..=299,403,429
             "./**/main.html"
           fail: true


### PR DESCRIPTION
Currently the `https://developers.redhat.com/` site is throwing a `403 Unauthorized` error even though the site exists. Adding an exception (since we could run into this more if additional bot web scraping protections are put in place).