### PR TITLE
Update acm_deprecate_remove.adoc

### DIFF
--- a/release_notes/acm_deprecate_remove.adoc
+++ b/release_notes/acm_deprecate_remove.adoc
@@ -68,12 +68,6 @@ A _deprecated_ component, feature, or service is supported, but no longer recomm
 | Use {acm-short} with {gitops-short} instead.
 | The deprecation is extended for five releases before removal. See link:../gitops/gitops_overview.adoc#gitops-overview[GitOps overview] for updated function.
 
-| Installer
-| `ingress.sslCiphers` field in `operator.open-cluster-management.io_multiclusterhubs_crd.yaml`
-| 2.9
-| None
-| See link:../install/adv_config_install.adoc[Advanced Configuration] for configuring install. If you uppgrade your {acm} version and originally had a `MultiClusterHub` custom resource with the `spec.ingress.sslCiphers` field defined, the field is still recognized, but is deprecated and has no effect.
-
 | Applications and Governance
 | `PlacementRule`
 | 2.8

--- a/release_notes/acm_deprecate_remove.adoc
+++ b/release_notes/acm_deprecate_remove.adoc
@@ -92,7 +92,7 @@ A _removed_ item is typically function that was deprecated in previous releases 
 | `ingress.sslCiphers` field in `operator.open-cluster-management.io_multiclusterhubs_crd.yaml`
 | 2.9
 | None
-| See link:../install/adv_config_install.adoc[Advanced Configuration] for configuring install. If you uppgrade your {acm} version and originally had a `MultiClusterHub` custom resource with the `spec.ingress.sslCiphers` field defined, the field is still recognized, but is deprecated and has no effect.
+| See link:../install/adv_config_install.adoc[Advanced Configuration] for configuring install. If you uppgrade your {acm} version and originally had a `MultiClusterHub` custom resource with the `spec.ingress.sslCiphers` field defined, the field is still recognized, but is removed.
 
 | Policy compliance history API
 | Governance 

--- a/release_notes/acm_deprecate_remove.adoc
+++ b/release_notes/acm_deprecate_remove.adoc
@@ -88,6 +88,12 @@ A _removed_ item is typically function that was deprecated in previous releases 
 | Enable the _Fleet view_ switch to view the new default _Overview_ page.
 | The previous layout of the {acm-short} _Overview_ page is redesigned.
 
+| Installer
+| `ingress.sslCiphers` field in `operator.open-cluster-management.io_multiclusterhubs_crd.yaml`
+| 2.9
+| None
+| See link:../install/adv_config_install.adoc[Advanced Configuration] for configuring install. If you uppgrade your {acm} version and originally had a `MultiClusterHub` custom resource with the `spec.ingress.sslCiphers` field defined, the field is still recognized, but is deprecated and has no effect.
+
 | Policy compliance history API
 | Governance 
 | 2.13


### PR DESCRIPTION
SSLCiphers no longer does anything in the ACM operator. This can be removed.