### PR TITLE
Update observability_enable.adoc updating required  "," in TrustPolicy JSON file

### DIFF
--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -319,9 +319,9 @@ echo $S3_POLICY
          "${OIDC_PROVIDER}:sub": [
            "system:serviceaccount:${NAMESPACE}:observability-thanos-query",
            "system:serviceaccount:${NAMESPACE}:observability-thanos-store-shard",
-           "system:serviceaccount:${NAMESPACE}:observability-thanos-compact"
+           "system:serviceaccount:${NAMESPACE}:observability-thanos-compact",
            "system:serviceaccount:${NAMESPACE}:observability-thanos-rule",
-           "system:serviceaccount:${NAMESPACE}:observability-thanos-receive",
+           "system:serviceaccount:${NAMESPACE}:observability-thanos-receive"
          ]
        }
      }


### PR DESCRIPTION
DOCBUG: (https://issues.redhat.com/browse/ACM-22630)

Update observability_enable.adoc updating required  "," in TrustPolicy JSON file

With below configuration we  were getting `An error occurred (MalformedPolicyDocument) when calling the CreateRole operation: This policy contains invalid Json` error while creating role for AWS Prometheus and CloudWatch : 

{
[...]
           "system:serviceaccount:${NAMESPACE}:observability-thanos-query",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-store-shard",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-compact"
           "system:serviceaccount:${NAMESPACE}:observability-thanos-rule",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-receive",
   [....]
}

After making below changes, we were able to create role.

{
[...]
           "system:serviceaccount:${NAMESPACE}:observability-thanos-query",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-store-shard",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-compact",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-rule",
           "system:serviceaccount:${NAMESPACE}:observability-thanos-receive"
   [....]
}