### PR TITLE
Update observability_enable.adoc to correct indentation of secret

### DIFF
--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -365,11 +365,11 @@ metadata:
 type: Opaque
 stringData:
   thanos.yaml: |
- type: s3
- config:
-   bucket: $S3_BUCKET
-   endpoint: s3.$REGION.amazonaws.com
-   signature_version2: false
+    type: s3
+    config:
+      bucket: $S3_BUCKET
+      endpoint: s3.$REGION.amazonaws.com
+      signature_version2: false
 ----
 
 . Specify the service account annotations in the `MultiClusterObservability` custom resource as described in _Creating the MultiClusterObservability custom resource_ section. 


### PR DESCRIPTION
Update `observability_enable.adoc` to correct indentation of secret:
With the secret yaml file mentioned in step 7. Attach the policies to the role of section https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html-single/observability/index#generate-access-keys we were getting:
~~~
error: error parsing thanos.yaml: error converting YAML to JSON: yaml: line 8: did not find expected key
~~~

After correcting the indentation the error has been resolved. Please add these changes in 2.12 , 2.14 and further.

BUG : https://issues.redhat.com/browse/ACM-22629

