### PR TITLE
Revert https://issues.redhat.com/browse/ACM-22763

### DIFF
--- a/release_notes/known_issues_network.adoc
+++ b/release_notes/known_issues_network.adoc
@@ -32,12 +32,6 @@ For more about deprecations and removals, see xref:../release_notes/acm_deprecat
 
 See the following known issues and limitations that might occur while using networking features.
 
-[#submariner-not-released]
-=== Submariner users cannot use {acm-short} version 2.14 until Submariner version 0.21.0 is released
-//2.14:ACM-22763
-
-Submariner version 0.21.0 is not released at the same time as {acm-short} 2.14. If you use Submariner with {acm-short}, do not update to {acm-short} version 2.14 until the latest Submariner version is released and announced.
-
 [#source-ip-ocp-ovnk]
 === Source IP not retained for applications on {ocp-short} 4.18 with OVN-Kubernetes
 //2.13:ACM-18680


### PR DESCRIPTION
Submariner 0.21 is now shipped.

This reverts commit df5de7f9052f4b662cd61fb91e9732979fc5180d.