### PR TITLE
Fix the namespace in the command for enabling Red Hat Device Manager [closing, cannot submit to prod, doc team will work this in an issue]

### DIFF
--- a/edge_manager/edge_mgr_enable.adoc
+++ b/edge_manager/edge_mgr_enable.adoc
@@ -20,7 +20,7 @@ Patch the `MultiClusterHub` resource, then verify that {rhem} is enabled. Comple
 +
 [source,bash]
 ----
-oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n rhacm --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"edge-manager-preview","enabled": true}}]'
+oc patch multiclusterhubs.operator.open-cluster-management.io multiclusterhub -n open-cluster-management --type json --patch '[{"op": "add", "path":"/spec/overrides/components/-", "value": {"name":"edge-manager-preview","enabled": true}}]'
 ----
 
 . Verify that the {rhem} is enabled by running the following command on the hub cluster:


### PR DESCRIPTION
https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html-single/edge_manager/index#enable-rhem-mch

The first command to enable Red Hat Edge Manager mentions "rhacm" namespace however it should be "open-cluster-management".