### PR TITLE
Update image_vuln_policy.adoc

### DIFF
--- a/governance/image_vuln_policy.adoc
+++ b/governance/image_vuln_policy.adoc
@@ -10,7 +10,7 @@ For more information about the Security Operator, see the _Container Security Op
 
 * Image vulnerability policy is not functional during a disconnected installation.
 
-* The Image vulnerability policy is not supported on the IBM Power and IBM Z architectures. It relies on the link:https://operatorhub.io/operator/project-quay-container-security-operator[Quay Container Security Operator]. There are no `ppc64le` or `s390x` images in the link:https://quay.io/repository/quay/container-security-operator[container-security-operator registry].
+* The Image vulnerability policy is not supported on the ARM architecture.
 
 View the following sections to learn more:
 
@@ -22,55 +22,24 @@ View the following sections to learn more:
 
 When you create the container security operator policy, it involves the following policies:
 
-- A policy that creates the subscription (`container-security-operator`) to reference the name and channel. This configuration policy must have `spec.remediationAction` set to `enforce` to create the resources. The subscription pulls the profile, as a container, that the subscription supports. View the following example:
+- A policy that creates the subscription (`container-security-operator`) to reference the name and channel. This operator policy must have `spec.remediationAction` set to `enforce` to create the resources. View the following example:
 +
 [source,yaml]
 ----
-apiVersion: policy.open-cluster-management.io/v1
-kind: ConfigurationPolicy
+apiVersion: policy.open-cluster-management.io/v1beta1
+kind: OperatorPolicy
 metadata:
-  name: policy-imagemanifestvuln-example-sub
+  name: operatorpolicy-imagemanifestvuln
 spec:
-  remediationAction: enforce  # will be overridden by remediationAction in parent policy
+  remediationAction: enforce
   severity: high
-  object-templates:
-    - complianceType: musthave
-      objectDefinition:
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: Subscription
-        metadata:
-          name: container-security-operator
-          namespace: openshift-operators
-        spec:
-          channel: quay-v3.3 # specify a specific channel if desired
-          installPlanApproval: Automatic
-          name: container-security-operator
-          source: redhat-operators
-          sourceNamespace: openshift-marketplace
-----
-
-- An `inform` configuration policy to audit the `ClusterServiceVersion` to ensure that the container security operator installation succeeded. View the following example:
-+
-[source,yaml]
-----
-apiVersion: policy.open-cluster-management.io/v1
-kind: ConfigurationPolicy
-metadata:
-  name: policy-imagemanifestvuln-status
-spec:
-  remediationAction: inform  # will be overridden by remediationAction in parent policy
-  severity: high
-  object-templates:
-    - complianceType: musthave
-      objectDefinition:
-        apiVersion: operators.coreos.com/v1alpha1
-        kind: ClusterServiceVersion
-        metadata:
-          namespace: openshift-operators
-        spec:
-          displayName: Red Hat Quay Container Security Operator
-        status:
-          phase: Succeeded   # check the CSV status to determine if operator is running or not
+  complianceType: musthave
+  upgradeApproval: Automatic
+  subscription:
+    name: container-security-operator
+    namespace: openshift-operators
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
 ----
 
 - An `inform` configuration policy to audit whether any `ImageManifestVuln` objects were created by the image vulnerability scans. View the following example:


### PR DESCRIPTION
Z and Power are supported architectures, but it is worth noting that ARM is not.

The policy in the collection and in the UI were also updated to use OperatorPolicy, and this doc was slightly behind.

Jira: https://issues.redhat.com/browse/ACM-25204 