### PR TITLE
Exclude stolostron/backlog links from checks

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,4 +1,3 @@
----
 name: Linting
 
 on:
@@ -44,5 +43,6 @@ jobs:
             --scheme https
             --require-https
             --accept 200..=299,403,429
-            "./**/main.html"
+            --exclude https://github.com/stolostron/backlog/.*
+            ./**/main.html
           fail: true


### PR DESCRIPTION
These links are inaccessible to the public.