### PR TITLE
Fix table parsing

### DIFF
--- a/applications/app_sample.adoc
+++ b/applications/app_sample.adoc
@@ -73,7 +73,7 @@ spec:
 | Required
 
 | spec.selector.matchLabels
-| key:value` pair that are a Kubernetes label and value found on the subscription or subscriptions this application is associated with. The label is used for the application resource to find the related subscriptions by performing a label name and value match.
+| A `key:value` pair that are a Kubernetes label and value found on the subscription or subscriptions this application is associated with. The label is used for the application resource to find the related subscriptions by performing a label name and value match.
 | Required
 
 |===

--- a/applications/app_sample.adoc
+++ b/applications/app_sample.adoc
@@ -64,25 +64,16 @@ spec:
 | Required
 
 
-| metadata
-|
-|
-
-|
-| `name`: The name for identifying the application resource.
+| metadata.name
+| The name for identifying the application resource.
 | Required
 
+| metadata.namespace
+| The namespace resource to use for the application.
+| Required
 
-| 
-| `namespace`: The namespace resource to use for the application.
-|
-
-| spec
-|
-|
-
-|
-| selector.matchLabels: `key:value` pair that are a Kubernetes label and value found on the subscription or subscriptions this application will be associated with. The label allows the application resource to find the related subscriptions by performing a label name and value match.
+| spec.selector.matchLabels
+| key:value` pair that are a Kubernetes label and value found on the subscription or subscriptions this application is associated with. The label is used for the application resource to find the related subscriptions by performing a label name and value match.
 | Required
 
 |===

--- a/applications/app_sample.adoc
+++ b/applications/app_sample.adoc
@@ -81,12 +81,9 @@ spec:
 |
 |
 
-| selector.matchLabels
-| 
-`key:value` pair that are a Kubernetes label and value found on the subscription or subscriptions this application will be associated with. The label allows the application resource to find the related subscriptions by performing a label name and value match.
-
-| Required
 |
+| selector.matchLabels: `key:value` pair that are a Kubernetes label and value found on the subscription or subscriptions this application will be associated with. The label allows the application resource to find the related subscriptions by performing a label name and value match.
+| Required
 
 |===
 

--- a/governance/policy_generator.adoc
+++ b/governance/policy_generator.adoc
@@ -464,6 +464,7 @@ The following manifests are supported:
 | Serves as the `ConfigurationPolicy` resource name when `ConsolidateManifests` is set to `false`. If multiple manifests are present in the path, an index number is appended. If multiple manifests are present and their names are provided, with `consolidateManifests` set to `true`, the name of the first manifest is used for all manifest paths.
 
 | `policies[].manifests[].patches`
+| Optional
 | A list of Kustomize patches to apply to the manifest at the path. If there are multiple manifests, the patch requires the following fields: `apiVersion`, `kind`, `metadata.name`, and `metadata.namespace`. To ensure a Kustomize patch is applied to the correct manifest, set values for the fields specified earlier. If there is a single manifest, you can patch the `metadata.name` and `metadata.namespace` parameters. For more details, see the link:https://kubectl.docs.kubernetes.io/guides/example/inline_patch/#patchesstrategicmerge[Kustomize documentation on strategic merge patches].
 
 | `policies[].manifests[].openapi.path`

--- a/secure_clusters/certificates.adoc
+++ b/secure_clusters/certificates.adoc
@@ -46,7 +46,7 @@ View the following {acm-short} hub cluster certificates table:
 
 .{acm-short} hub cluster certificates
 |===
-| Namespace | Secret name | Pod label |  
+| Namespace | Secret name | Pod label
 
 | open-cluster-management
 | channels-apps-open-cluster-management-webhook-svc-ca


### PR DESCRIPTION
These were flagged as warning in the build.

Link checking is fixed in:
- #8323 

Misalignment is visible in production:
- https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/governance/policy-deployment#policy-generator-yaml-table
  <img width="845" height="499" alt="image" src="https://github.com/user-attachments/assets/edd022bf-97e0-4541-aab1-9a6fbae36462" />
- https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.14/html/secure_clusters/securing-cluster-intro#acm-hub-cluster-certs
  <img width="772" height="344" alt="image" src="https://github.com/user-attachments/assets/d620c6eb-a443-4d63-8d91-1d1a9400d0a7" />
