### PR TITLE
fix: adjust redirected URLs to use target

### DIFF
--- a/EXTERNAL_CONTRIBUTING.adoc
+++ b/EXTERNAL_CONTRIBUTING.adoc
@@ -1,7 +1,7 @@
 [#red-hat-advanced-cluster-management-for-kubernetes-contributing-external]
 = Contributing to Red Hat Advanced Cluster Management for Kubernetes staged documentation
 
-Find the documentation here: https://docs.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes[Product Documentation for Red Hat Advanced Cluster Management for Kubernetes]
+Find the documentation here: https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes[Product Documentation for Red Hat Advanced Cluster Management for Kubernetes]
 
 IMPORTANT: *This contributing doc is for EXTERNAL USERS.* 
 

--- a/README.adoc
+++ b/README.adoc
@@ -11,7 +11,7 @@ See the doc:
 
 * https://www.redhat.com/en/technologies/management/advanced-cluster-management[Red Hat Advanced Cluster Management for Kubernetes]
 
-* https://docs.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/[Product Documentation for Red Hat Advanced Cluster Management for Kubernetes]
+* https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/[Product Documentation for Red Hat Advanced Cluster Management for Kubernetes]
 
 
 

--- a/about/architecture.adoc
+++ b/about/architecture.adoc
@@ -58,7 +58,7 @@ _Governance_ enables you to define policies that either enforce security complia
 
 For more information, learn about access requirements from the link:../secure_clusters/rbac.adoc#role-based-access-control[Role-based access control] documentation.
 
-After you configure a {acm-short} hub cluster and a managed cluster, you can view and create policies with the {acm-short} policy framework. You can visit the link:https://github.com/stolostron/policy-collection/tree/master/community[`policy-collection` open community] to see what policies community members created and contributed, as well as contribute your own policies for others to use. 
+After you configure a {acm-short} hub cluster and a managed cluster, you can view and create policies with the {acm-short} policy framework. You can visit the link:https://github.com/stolostron/policy-collection/tree/main/community[`policy-collection` open community] to see what policies community members created and contributed, as well as contribute your own policies for others to use. 
 
 [#observability-arch]
 == Observability

--- a/apis/channels.json.adoc
+++ b/apis/channels.json.adoc
@@ -275,7 +275,7 @@ __optional__|API version of the referent.|string
 |*fieldPath* +
 __optional__|If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.|string
 |*kind* +
-__optional__|Kind of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/
+__optional__|Kind of the referent. More information, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/[Objects in Kubernetes].
 |*name* +
 __optional__|Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Names]|string
 |*namespace* +

--- a/apis/channels.json.adoc
+++ b/apis/channels.json.adoc
@@ -275,7 +275,7 @@ __optional__|API version of the referent.|string
 |*fieldPath* +
 __optional__|If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.|string
 |*kind* +
-__optional__|Kind of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/
+__optional__|Kind of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/
 |*name* +
 __optional__|Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names[Names]|string
 |*namespace* +

--- a/business_continuity/backup_restore/backup_arch.adoc
+++ b/business_continuity/backup_restore/backup_arch.adoc
@@ -14,7 +14,7 @@ image:../images/cluster_backup_controller_dataflow25.png[Backup and restore arch
 
 The backup and restore component gives a set of policies for reporting issues. Use the policy templates to create an alert to the hub cluster administrator if the backup solution is not functioning. 
 
-The cluster backup and restore operator depends on the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-release-notes[OADP Operator] to install Velero, and to create a connection from the hub cluster to the backup storage location where the data is stored. Velero is the component that runs the backup and restore operations. The cluster backup and restore operator solution provides backup and restore support for all {acm-short} hub cluster resources, including managed clusters, applications, and policies.
+The cluster backup and restore operator depends on the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-release-notes[OADP Operator] to install Velero, and to create a connection from the hub cluster to the backup storage location where the data is stored. Velero is the component that runs the backup and restore operations. The cluster backup and restore operator solution provides backup and restore support for all {acm-short} hub cluster resources, including managed clusters, applications, and policies.
 
 [#backed-up-resources]
 == Resources that are backed up

--- a/business_continuity/backup_restore/backup_install.adoc
+++ b/business_continuity/backup_restore/backup_install.adoc
@@ -46,7 +46,7 @@ To enable the backup operator for your active and passive hub clusters, complete
 
 To create a storage location secret, complete the following steps: 
 
-. Complete the steps for link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-creating-default-secret_installing-oadp-aws[Creating a default Secret] for the cloud storage where the backups are saved. 
+. Complete the steps for link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-creating-default-secret_installing-oadp-aws[Creating a default Secret] for the cloud storage where the backups are saved. 
 . Create the secret resource in the OADP Operator namespace, which is located in the backup component namespace.
 
 [#installing-the-oadp-operator]
@@ -254,7 +254,7 @@ apiVersion: operator.open-cluster-management.io/v1
 
 - See link:https://velero.io/[Velero].
 
-- See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-s3-compatible-backup-storage-providers_about-installing-oadp[AWS S3 compatible backup storage providers] in the {ocp-short} documentation for a list of supported Velero storage providers.
+- See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-s3-compatible-backup-storage-providers_about-installing-oadp[AWS S3 compatible backup storage providers] in the {ocp-short} documentation for a list of supported Velero storage providers.
 
-- Learn more about the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-installing-dpa_installing-oadp-aws[_DataProtectionApplication_] resource.
+- Learn more about the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#oadp-installing-dpa_installing-oadp-aws[_DataProtectionApplication_] resource.
                                                                                        

--- a/business_continuity/backup_restore/backup_velero.adoc
+++ b/business_continuity/backup_restore/backup_velero.adoc
@@ -32,6 +32,6 @@ spec:
 
 == Additional resources
 
-- Refer to the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#default-velero-cloud-provider-plugins[Default Velero cloud provider plugins] topic in the {ocp} documentation to find out more about the `DataProtectionApplication` parameters.
+- Refer to the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/backup_and_restore/oadp-application-backup-and-restore#default-velero-cloud-provider-plugins[Default Velero cloud provider plugins] topic in the {ocp} documentation to find out more about the `DataProtectionApplication` parameters.
 
-- Refer to the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/backup_and_restore/index#cpu-and-memory-requirement-for-configurations[CPU and memory requirement for configurations] topic in the {ocp-short} documentation for more details about the backup and restore CPU and memory requirements based on cluster usage.
+- Refer to the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/backup_and_restore/index#cpu-and-memory-requirement-for-configurations[CPU and memory requirement for configurations] topic in the {ocp-short} documentation for more details about the backup and restore CPU and memory requirements based on cluster usage.

--- a/clusters/about/cluster_mce_overview.adoc
+++ b/clusters/about/cluster_mce_overview.adoc
@@ -9,7 +9,7 @@ The {mce-short} is the cluster lifecycle operator that provides cluster manageme
 
 - With your {ocp-short} cluster, you can use {mce-short} as a standalone cluster manager for cluster lifecycle function, or you can use it as part of a {acm-short} hub cluster. 
 
-- If you are using {ocp-short} only, the operator is included with subscription. Visit link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/architecture/about-the-multicluster-engine-for-kubernetes-operator[About {mce}] from the {ocp-short} documentation.
+- If you are using {ocp-short} only, the operator is included with subscription. Visit link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/architecture/about-the-multicluster-engine-for-kubernetes-operator[About {mce}] from the {ocp-short} documentation.
 
 - If you subscribe to {acm-short}, you also receive the operator with installation. You can create, manage, and monitor other Kubernetes clusters with the {acm-short} hub cluster. 
 

--- a/clusters/assisted_installer/ai_auto_add_host.adoc
+++ b/clusters/assisted_installer/ai_auto_add_host.adoc
@@ -148,7 +148,7 @@ You can use the `{}bmac.agent-install.openshift.io/cluster-reference` annotation
 
 - To learn about root device hints, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/postinstallation_configuration/post-install-configuration-overview[Postinstallation configuration overview] in the {ocp-short} documentation.
 
-- link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets]
+- link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets]
 
 - xref:../credentials/credential_on_prem.adoc#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment]
 

--- a/clusters/assisted_installer/ai_enable_cim.adoc
+++ b/clusters/assisted_installer/ai_enable_cim.adoc
@@ -351,4 +351,4 @@ oc login
 
 - For additional information about zero touch provisioning, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/edge_computing/ztp-deploying-far-edge-clusters-at-scale#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] in the {ocp-short} documentation.
 
-- link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets]
+- link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets]

--- a/clusters/assisted_installer/ai_overview.adoc
+++ b/clusters/assisted_installer/ai_overview.adoc
@@ -9,7 +9,7 @@ The {infra} is a {mce-short} component that manages and installs the workloads t
 
 You can use the console to create a host inventory, which is a pool of bare-metal or virtual machines that you can use to create on-premises {ocp-short} clusters. These clusters can be standalone, with dedicated machines for the control plane, or link:../../clusters/hosted_control_planes/hosted_intro.adoc#hosted-control-planes-intro[hosted control planes], where the control plane runs as pods on a hub cluster.
 
-You can install standalone clusters by using the console, API, or GitOps by using Zero Touch Provisioning (ZTP). See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/scalability_and_performance/index#installing-disconnected-rhacm_ztp-preparing-the-hub-cluster[Installing GitOps ZTP in a disconnected environment] in the {ocp} documentation for more information on ZTP.
+You can install standalone clusters by using the console, API, or GitOps by using Zero Touch Provisioning (ZTP). See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/scalability_and_performance/index#installing-disconnected-rhacm_ztp-preparing-the-hub-cluster[Installing GitOps ZTP in a disconnected environment] in the {ocp} documentation for more information on ZTP.
 
 A machine joins the host inventory after booting with a Discovery Image. The Discovery Image is a Red Hat CoreOS live image that contains the following:
 

--- a/clusters/cluster_lifecycle/adv_config_cluster.adoc
+++ b/clusters/cluster_lifecycle/adv_config_cluster.adoc
@@ -470,7 +470,7 @@ spec:
 [#add-resources-adv-cluster]
 == Additional resources
 
-* link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#api-server-certificates[Adding API server certificates]
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#api-server-certificates[Adding API server certificates]
 
 * link:../support_troubleshooting/trouble_cluster_offline_cert_mce.adoc#troubleshooting-imported-clusters-offline-after-certificate-change-mce[Troubleshooting imported clusters offline after certificate change]
 

--- a/clusters/cluster_lifecycle/create_aws_govcloud.adoc
+++ b/clusters/cluster_lifecycle/create_aws_govcloud.adoc
@@ -16,13 +16,13 @@ When you create a cluster, the creation process uses the {ocp-short} installer w
 
 You must have the following prerequisites before creating an AWS GovCloud cluster: 
 
-* You must have AWS login credentials, which include user name, password, access key ID, and secret access key. See link:https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html[Understanding and Getting Your Security Credentials].
+* You must have AWS login credentials, which include user name, password, access key ID, and secret access key. See link:https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html[Understanding and Getting Your Security Credentials].
 
 * You need an AWS credential. See xref:../credentials/credential_aws.adoc#creating-a-credential-for-amazon-web-services[Creating a credential for Amazon Web Services] for more information.
 
 * You need a configured domain in AWS. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_aws/index[Installing on AWS] for instructions on how to configure a domain.
 
-* You must have an {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* You must have an {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 
 * You must have an Amazon Virtual Private Cloud (VPC) with an existing {ocp} cluster for the hub cluster. This VPC must be different from the VPCs that are used for the managed cluster resources or the managed cluster service endpoints.
 

--- a/clusters/cluster_lifecycle/create_azure.adoc
+++ b/clusters/cluster_lifecycle/create_azure.adoc
@@ -18,7 +18,7 @@ See the following prerequisites before creating a cluster on Azure:
 * You need a configured domain in Azure or Azure Government. See link:https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-custom-domain-name-portal[Configuring a custom domain name for an Azure cloud service] for instructions on how to configure a domain.
 * You need Azure login credentials, which include user name and password. See the link:https://azure.microsoft.com/en-ca/features/azure-portal[Microsoft Azure Portal].
 * You need Azure service principals, which include `clientId`, `clientSecret`, and `tenantId`. See link:https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli?view=azure-cli-latest#password-based-authentication[azure.microsoft.com].
-* You need an {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* You need an {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 
 *Note:* If you change your cloud provider access key on the cloud provider, you also need to manually update the corresponding credential for the cloud provider on the console of {mce-short}. This is required when your credentials expire on the cloud provider where the managed cluster is hosted and you try to delete the managed cluster.  
 

--- a/clusters/cluster_lifecycle/create_cluster_on_prem.adoc
+++ b/clusters/cluster_lifecycle/create_cluster_on_prem.adoc
@@ -393,11 +393,11 @@ You can confirm that it was approved when the output of the previous command inc
 [#additional-resources-cluster-on-premises]
 == Additional resources
 
-- For additional steps that are required when creating a cluster on the Nutanix platform with the CLI, see link:https://docs.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/assembly_installing-on-nutanix#adding-hosts-on-nutanix-with-the-api_installing-on-nutanix[Adding hosts on Nutanix with the API] and link:https://docs.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/assembly_installing-on-nutanix#nutanix-post-installation-configuration_installing-on-nutanix[Nutanix post-installation configuration] in the {ocp} documentation.
+- For additional steps that are required when creating a cluster on the Nutanix platform with the CLI, see link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/assembly_installing-on-nutanix#adding-hosts-on-nutanix-with-the-api_installing-on-nutanix[Adding hosts on Nutanix with the API] and link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/assembly_installing-on-nutanix#nutanix-post-installation-configuration_installing-on-nutanix[Nutanix post-installation configuration] in the {ocp} documentation.
 
 - For additional information about zero touch provisioning, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/edge_computing/ztp-deploying-far-edge-clusters-at-scale[Clusters at the network far edge] in the {ocp-short} documentation.
 
-- See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets]
+- See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets]
 
 - See xref:../credentials/credential_on_prem.adoc#creating-a-credential-for-an-on-premises-environment[Creating a credential for an on-premises environment]
 

--- a/clusters/cluster_lifecycle/create_google.adoc
+++ b/clusters/cluster_lifecycle/create_google.adoc
@@ -18,7 +18,7 @@ See the following prerequisites before creating a cluster on GCP:
 * You must have a GCP credential. See xref:../credentials/credential_google.adoc#creating-a-credential-for-google-cloud-platform[Creating a credential for Google Cloud Platform] for more information.
 * You must have a configured domain in GCP. See link:https://cloud.google.com/endpoints/docs/openapi/dev-portal-setup-custom-domain[Setting up a custom domain] for instructions on how to configure a domain.
 * You need your GCP login credentials, which include user name and password.
-* You must have an {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* You must have an {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 
 *Note:* If you change your cloud provider access key on the cloud provider, you also need to manually update the corresponding credential for the cloud provider on the console of {mce-short}. This is required when your credentials expire on the cloud provider where the managed cluster is hosted and you try to delete the managed cluster.
 

--- a/clusters/cluster_lifecycle/create_ocp_aws.adoc
+++ b/clusters/cluster_lifecycle/create_ocp_aws.adoc
@@ -17,8 +17,8 @@ See the following prerequisites before creating a cluster on AWS:
 * You must have a deployed hub cluster.
 * You need an AWS credential. See xref:../credentials/credential_aws.adoc#creating-a-credential-for-amazon-web-services[Creating a credential for Amazon Web Services] for more information.
 * You need a configured domain in AWS. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_aws/index[Installing on AWS] for instructions on how to configure a domain.
-* You must have Amazon Web Services (AWS) login credentials, which include user name, password, access key ID, and secret access key. See link:https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html[Understanding and Getting Your Security Credentials].
-* You must have an {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* You must have Amazon Web Services (AWS) login credentials, which include user name, password, access key ID, and secret access key. See link:https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html[Understanding and Getting Your Security Credentials].
+* You must have an {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 
 +
 *Note:* If you change your cloud provider access key on the cloud provider, you also need to manually update the corresponding credential for the cloud provider on the console. This is required when your credentials expire on the cloud provider where the managed cluster is hosted and you try to delete the managed cluster.

--- a/clusters/cluster_lifecycle/create_openstack.adoc
+++ b/clusters/cluster_lifecycle/create_openstack.adoc
@@ -15,7 +15,7 @@ See the following prerequisites before creating a cluster on Red Hat OpenStack P
 
 * You must have a hub cluster that is deployed on {ocp-short} version 4.6 or later.
 * You must have a Red Hat OpenStack Platform credential. See xref:../credentials/credential_openstack.adoc#creating-a-credential-for-openstack[Creating a credential for Red Hat OpenStack Platform] for more information.
-* You need an {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* You need an {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 * You need the following information for the Red Hat OpenStack Platform instance where you are deploying:
 ** Flavor name for the control plane and worker instances; for example, `m1.xlarge`
 ** Network name for the external network to provide the floating IP addresses
@@ -54,7 +54,7 @@ If you want to add your cluster to an existing cluster set, you must have the co
 
 Every managed cluster must be associated with a managed cluster set. If you do not assign the managed cluster to a `ManagedClusterSet`, it is automatically added to the `default` managed cluster set.
 
-If there is already a base DNS domain that is associated with the selected credential that you configured for your Red Hat OpenStack Platform account, that value is populated in the field. You can change the value by overwriting it. See link:https://docs.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/users_and_identity_management_guide/domains[Managing domains] in the Red Hat OpenStack Platform documentation for more information. This name is used in the hostname of the cluster.
+If there is already a base DNS domain that is associated with the selected credential that you configured for your Red Hat OpenStack Platform account, that value is populated in the field. You can change the value by overwriting it. See link:https://docs.redhat.com/en/documentation/red_hat_openstack_platform/16.1/html/users_and_identity_management_guide/domains[Managing domains] in the Red Hat OpenStack Platform documentation for more information. This name is used in the hostname of the cluster.
  
 The release image identifies the version of the {ocp-short} image that is used to create the cluster. If the version that you want to use is available, you can select the image from the list of images. If the image that you want to use is not a standard image, you can enter the URL to the image that you want to use. See xref:../cluster_lifecycle/release_image_intro.adoc#release-images-intro[Release images] for more information about release images. Only release images for {ocp-short} versions 4.6.x and higher are supported.
 

--- a/clusters/cluster_lifecycle/create_single_node_ocp_clusterpool.adoc
+++ b/clusters/cluster_lifecycle/create_single_node_ocp_clusterpool.adoc
@@ -23,7 +23,7 @@ See xref:../credentials/credential_intro.adoc#credentials[Managing credentials o
 * A configured domain in your provider environment.
 See your provider documentation for instructions about how to configure a domain.
 * Provider login credentials.
-* A {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* A {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 
 * Enable the {sno} feature. Because the {sno} feature is a Technology Preview feature, it is not enabled when you install {acm-short}. You must enable it by completing the following steps:
 

--- a/clusters/cluster_lifecycle/create_vm.adoc
+++ b/clusters/cluster_lifecycle/create_vm.adoc
@@ -15,7 +15,7 @@ See the following prerequisites before creating a cluster on vSphere:
 
 * You must have a hub cluster that is deployed on a supported {ocp-short} version.
 * You need a vSphere credential. See xref:../credentials/credential_vm.adoc#creating-a-credential-for-vmware-vsphere[Creating a credential for VMware vSphere] for more information.
-* You need an {ocp-short} image pull secret. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
+* You need an {ocp-short} image pull secret. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets].
 * You must have the following information for the VMware instance where you are deploying:
 ** Required static IP addresses for API and Ingress instances
 ** DNS records for:

--- a/clusters/cluster_lifecycle/import_cli.adoc
+++ b/clusters/cluster_lifecycle/import_cli.adoc
@@ -18,7 +18,7 @@ After you install {mce}, you are ready to import a cluster and manage it by usin
 
 * A deployed hub cluster. If you are importing bare metal clusters, the hub cluster must be installed on a supported {ocp-short} version. 
 * A separate cluster you want to manage.
-* The {ocp-short} CLI. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] for information about installing and configuring the {ocp-short} CLI.
+* The {ocp-short} CLI. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] for information about installing and configuring the {ocp-short} CLI.
 * A defined `multiclusterhub.spec.imagePullSecret` if you are importing a cluster that was not created by {ocp-short}. This secret might have been created when {mce} was installed. See xref:../install_upgrade/adv_config_install.adoc#custom-image-pull-secret[Custom image pull secret] for more information about how to define this secret.
 * Review the hub cluster `KubeAPIServer` certificate verification strategy and update the strategy if needed. To learn what strategy to use for your setup, see xref:../cluster_lifecycle/adv_config_cluster.adoc#config-hub-kube-api-server[Configuring the hub cluster `KubeAPIServer` verification strategy].
 

--- a/clusters/cluster_lifecycle/import_intro.adoc
+++ b/clusters/cluster_lifecycle/import_intro.adoc
@@ -13,7 +13,7 @@ See the following information about using CNCF providers:
 
 * Learn how CNCF providers are certified at link:https://www.cncf.io/training/certification/software-conformance/[Certified Kubernetes Conformance]. 
 
-* For Red Hat support information about CNCF third-party providers, see link:https://access.redhat.com/third-party-software-support[Red Hat support with third party components], or link:https://access.redhat.com/support/contact/[Contact Red Hat support].
+* For Red Hat support information about CNCF third-party providers, see link:https://access.redhat.com/articles/third-party-software-support[Red Hat support with third party components], or link:https://access.redhat.com/support/contact/[Contact Red Hat support].
 
 * If you bring your own CNCF conformance certified cluster, you need to change the {ocp-short} CLI `oc` command to the Kubernetes CLI command, `kubectl`. 
 

--- a/clusters/cluster_lifecycle/release_image_disconn.adoc
+++ b/clusters/cluster_lifecycle/release_image_disconn.adoc
@@ -9,7 +9,7 @@ In some cases, you need to maintain a custom list of release images when the hub
 
 . Add the mapping between the managed cluster and the disconnected repository with your cluster image sets by completing the following steps that fits your managed cluster:
 +
-  * For an {ocp-short} managed cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/image-configuration#images-configuration-registry-mirror_image-configuration[Configuring image registry repository mirroring] for information about using your `ImageContentSourcePolicy` object to complete the mapping. 
+  * For an {ocp-short} managed cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/image-configuration#images-configuration-registry-mirror_image-configuration[Configuring image registry repository mirroring] for information about using your `ImageContentSourcePolicy` object to complete the mapping. 
  
   * For a managed cluster that is not an {ocp-short} cluster, use the `ManageClusterImageRegistry` custom resource definition to override the location of the image sets. See xref:../cluster_lifecycle/specify_img_registry.adoc#specify-registry-img-on-managed-clusters-for-import[Specifying registry images on managed clusters for import] for information about how to override the cluster for the mapping.  
 
@@ -49,7 +49,7 @@ Pull From: quay.io/openshift-release-dev/ocp-release@sha256:69d1292f64a2b67227c5
 ----
 
 +
-To learn more about the image tag and digest, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#images-referencing-images-imagestreams_tagging-images[Referencing images in imagestreams].
+To learn more about the image tag and digest, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#images-referencing-images-imagestreams_tagging-images[Referencing images in imagestreams].
 
 . Create each of the `clusterImageSets` by entering the following command for each YAML file:
 

--- a/clusters/cluster_lifecycle/scale_node_ctrl_plane.adoc
+++ b/clusters/cluster_lifecycle/scale_node_ctrl_plane.adoc
@@ -195,4 +195,4 @@ oc patch agent <AGENT-NAME> -p '{"spec":{"role": "master"}}' --type=merge
 +
 *Note:* CSRs are not automatically approved.
 
-. Follow the steps in link:https://docs.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster] in the {ai} for {ocp-short} documentation.
+. Follow the steps in link:https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/2025/html/installing_openshift_container_platform_with_the_assisted_installer/expanding-the-cluster#installing-primary-control-plane-node-unhealthy-cluster_expanding-the-cluster[Installing a primary control plane node on an unhealthy cluster] in the {ai} for {ocp-short} documentation.

--- a/clusters/credentials/credential_aws.adoc
+++ b/clusters/credentials/credential_aws.adoc
@@ -100,13 +100,13 @@ oc label secret hypershift-operator-oidc-provider-s3-credentials -n <your-local-
 [#aws-cred-additional-resources]
 == Additional resources
 
-- See link:https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html[Understanding and getting your security credentials].
+- See link:https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html[Understanding and getting your security credentials].
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_aws/index[Installing on AWS].
 
 - link:https://console.aws.amazon.com/iam/home#/security_credentials[Log in to AWS].
 
-- link:https://cloud.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
+- link:https://console.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/installing_on_aws/index#installation-config-parameters-aws[Installation configuration parameters for AWS] for more information about how to generate a key.
 

--- a/clusters/credentials/credential_azure.adoc
+++ b/clusters/credentials/credential_azure.adoc
@@ -107,7 +107,7 @@ data:
 
 - See link:https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli[Create an Azure service principal with the Azure CLI] to find your base domain resource group name.
 
-- link:https://cloud.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
+- link:https://console.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/installing_on_azure/index#ssh-agent-using_installing-azure-preparing-ipi[Generating a key pair for cluster node SSH access] for more information about how to generate a key.
 

--- a/clusters/credentials/credential_google.adoc
+++ b/clusters/credentials/credential_google.adoc
@@ -85,7 +85,7 @@ data:
 
 - See the link:https://cloud.google.com/iam/docs/service-accounts-create[Create service accounts] to create your service account JSON key.
 
-- link:https://cloud.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
+- link:https://console.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/installing_on_azure/index#ssh-agent-using_installing-azure-preparing-ipi[Generating a key pair for cluster node SSH access] for more information about how to generate a key.
 

--- a/clusters/credentials/credential_on_prem.adoc
+++ b/clusters/credentials/credential_on_prem.adoc
@@ -30,7 +30,7 @@ Start at the navigation menu. Click *Credentials* to choose from existing creden
 . You can optionally add a _Base DNS domain_ for your credential. If you add the base DNS domain to the credential, it is automatically populated in the correct field when you create a cluster with this credential. If you do not add the DNS domain, you can add it when you create your cluster.
 
 . Enter your _Red Hat OpenShift pull secret_. This pull secret is automatically entered when you create a cluster and specify this credential.
-You can download your pull secret from link:https://cloud.redhat.com/openshift/install/pull-secret[Pull secret]. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets] for more information about pull secrets.
+You can download your pull secret from link:https://console.redhat.com/openshift/install/pull-secret[Pull secret]. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#using-image-pull-secrets[Using image pull secrets] for more information about pull secrets.
 
 . Enter your `SSH public key`. This `SSH public key` is also automatically entered when you create a cluster and specify this credential. 
 

--- a/clusters/credentials/credential_openstack.adoc
+++ b/clusters/credentials/credential_openstack.adoc
@@ -116,7 +116,7 @@ data:
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_openstack/installing-openstack-installer-custom[Installing a cluster on OpenStack with customizations].
 
-- link:https://cloud.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
+- link:https://console.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_openstack/installing-openstack-installer-custom#ssh-agent-using_installing-openstack-installer-custom[Generating a key pair for cluster node SSH access] for more information.
 

--- a/clusters/credentials/credential_vm.adoc
+++ b/clusters/credentials/credential_vm.adoc
@@ -138,7 +138,7 @@ data:
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_vmware_vsphere/installer-provisioned-infrastructure#installing-vsphere-installer-provisioned-customizations[Installing a cluster on vSphere with customizations].
 
-- link:https://cloud.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
+- link:https://console.redhat.com/openshift/install/pull-secret[Download your Red Hat OpenShift pull secret].
 
 - See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/installing_on_vmware_vsphere/index#ssh-agent-using_ipi-vsphere-preparing-to-install[Generating a key pair for cluster node SSH access] for more information.
 

--- a/clusters/install_upgrade/adv_config_install.adoc
+++ b/clusters/install_upgrade/adv_config_install.adoc
@@ -109,7 +109,7 @@ The secret requirements for {ocp-short} clusters are automatically resolved by {
 
 *Important:* These secrets are namespace-specific, so make sure that you are in the namespace that you use for your engine.
 
- . Download your {ocp-short} pull secret file from link:https://cloud.redhat.com/openshift/install/pull-secret[cloud.redhat.com/openshift/install/pull-secret] by selecting *Download pull secret*. Your {ocp-short} pull secret is associated with your Red Hat Customer Portal ID, and is the same across all Kubernetes providers.
+ . Download your {ocp-short} pull secret file from link:https://console.redhat.com/openshift/install/pull-secret[cloud.redhat.com/openshift/install/pull-secret] by selecting *Download pull secret*. Your {ocp-short} pull secret is associated with your Red Hat Customer Portal ID, and is the same across all Kubernetes providers.
 
  . Run the following command to create your secret:
 +

--- a/clusters/install_upgrade/config_infra_nodes_mce.adoc
+++ b/clusters/install_upgrade/config_infra_nodes_mce.adoc
@@ -8,7 +8,7 @@ After adding infrastructure nodes to your {ocp-short} cluster, follow the xref:.
 [#config-infra-nodes-ocp]
 == Configuring infrastructure nodes to the {ocp-short} cluster
 
-Follow the procedures that are described in link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp-short} documentation. Infrastructure nodes are configured with a Kubernetes `taints` and `labels` to keep non-management workloads from running on them.
+Follow the procedures that are described in link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp-short} documentation. Infrastructure nodes are configured with a Kubernetes `taints` and `labels` to keep non-management workloads from running on them.
 
 For compatibility with the infrastructure node enablement, which is provided by {mce-short}, ensure your infrastructure nodes have the following `taints` and `labels` applied:
 

--- a/clusters/install_upgrade/install_connected.adoc
+++ b/clusters/install_upgrade/install_connected.adoc
@@ -36,7 +36,7 @@ Before you install {mce-short}, see the following prerequisites:
 
   - link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installation_overview/index[{ocp-short} Installing]
 
-* Your {ocp-short} command line interface (CLI) must be configured to run `oc` commands. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the {ocp-short} CLI.
+* Your {ocp-short} command line interface (CLI) must be configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the {ocp-short} CLI.
 
 * Your {ocp-short} permissions must allow you to create a namespace.
 

--- a/clusters/install_upgrade/install_disconnected.adoc
+++ b/clusters/install_upgrade/install_disconnected.adoc
@@ -28,7 +28,7 @@ See the link:https://docs.redhat.com/en/documentation/openshift_container_platfo
 [#confirm-ocp-installation-2]
 == Confirm your {ocp-short} installation
 
-* You must have a supported {ocp-short} version, including the registry and storage services, installed and working in your cluster. For information about {ocp-short}, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/[{ocp-short} documentation].
+* You must have a supported {ocp-short} version, including the registry and storage services, installed and working in your cluster. For information about {ocp-short}, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/[{ocp-short} documentation].
 
 * When and if you are connected, accessing the {ocp-short} web console with the following command to verify:
 
@@ -143,7 +143,7 @@ oc apply -f mce-policy.yaml
 +
 the {mce-short} is included in the Operator Lifecycle Manager Red Hat Operator catalog.
 
-. Configure the disconnected Operator Lifecycle Manager for the Red Hat Operator catalog. Follow the steps in the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] topic of the{ocp} documentation.
+. Configure the disconnected Operator Lifecycle Manager for the Red Hat Operator catalog. Follow the steps in the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] topic of the{ocp} documentation.
 
 . Continue to install the {mce-short} for Kubernetes from the _Operator Lifecycle Manager_ catalog.
 

--- a/clusters/install_upgrade/uninstall.adoc
+++ b/clusters/install_upgrade/uninstall.adoc
@@ -25,7 +25,7 @@ For more information about detaching clusters, see the _Removing a cluster from 
 [#removing-a-multiclusterengine-instance-by-using-commands]
 == Removing resources by using commands
 
-. If you have not already. ensure that your {ocp-short} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands. 
+. If you have not already. ensure that your {ocp-short} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands. 
 
 . Change to your project namespace by entering the following command. Replace _namespace_ with the name of your project namespace:
 +

--- a/clusters/install_upgrade/upgrade_cluster_disconnected_policies.adoc
+++ b/clusters/install_upgrade/upgrade_cluster_disconnected_policies.adoc
@@ -31,7 +31,7 @@ See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4
 You must have the following prerequisites before you can use {update-service} to upgrade your disconnected clusters:
 
 * You need to install {acm-short}. See the {acm-short} link:../install/install_overview.adoc#installing[Installing and upgrading] documentation.
-* You need a hub cluster that is running on a supported {ocp} version with restricted OLM configured. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details about how to configure restricted OLM. Take note of the catalog source image when you configure restricted OLM.
+* You need a hub cluster that is running on a supported {ocp} version with restricted OLM configured. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] for details about how to configure restricted OLM. Take note of the catalog source image when you configure restricted OLM.
 * You need an {ocp-short} cluster that the hub cluster manages.
 * You need access credentials to a local repository where you can mirror the cluster images. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring in disconnected environments] for more information.
 +

--- a/clusters/release_notes/mce_known_issues.adoc
+++ b/clusters/release_notes/mce_known_issues.adoc
@@ -5,7 +5,7 @@ Review the Known issues for _Cluster lifecycle with {mce-short}_ for this releas
 
 Cluster management known issues and limitations are part of the _Cluster lifecycle with {mce-short}_ documentation. Known issues for {mce-short} integrated _with_ {acm-short} are documented in the link:../../release_notes/acm_release_notes.adoc#acm-release-notes[Release notes for {acm-short}]. 
 
-*Important:* {ocp-short} release notes are not documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17[{ocp-short} release notes].
+*Important:* {ocp-short} release notes are not documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17[{ocp-short} release notes].
 
 * <<cluster-issues-install,Installation>>
 * <<cluster-issues-mce,Cluster management>>

--- a/clusters/release_notes/mce_new.adoc
+++ b/clusters/release_notes/mce_new.adoc
@@ -15,7 +15,7 @@ Use {mce-short} features for creating, importing, managing, and destroying Kuber
 
 - Learn how CNCF providers are certified at link:https://www.cncf.io/training/certification/software-conformance/[Certified Kubernetes Conformance].
 
-- For Red Hat support information about CNCF third-party providers, see link:https://access.redhat.com/third-party-software-support[Red Hat support with third party components], or link:https://access.redhat.com/support/contact/[Contact Red Hat support].
+- For Red Hat support information about CNCF third-party providers, see link:https://access.redhat.com/articles/third-party-software-support[Red Hat support with third party components], or link:https://access.redhat.com/support/contact/[Contact Red Hat support].
 
 - If you bring your own CNCF conformance certified cluster, you need to change the {ocp-short} CLI `oc` command to the Kubernetes CLI command, `kubectl`.
 

--- a/clusters/release_notes/mce_release_notes.adoc
+++ b/clusters/release_notes/mce_release_notes.adoc
@@ -8,7 +8,7 @@ Learn about new features and enhancements, support, deprecations, removals, and 
 * xref:../release_notes/mce_known_issues.adoc#known-issues-mce[Known issues for Cluster lifecycle with {mce-short}]
 * xref:../release_notes/mce_deprecate_remove.adoc#deprecations-removals-cluster-mce[Deprecations and removals for Cluster lifecycle with {mce-short}]
 
-*Important:* {ocp-short} release notes are _not_ documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.19[{ocp-short} release notes].
+*Important:* {ocp-short} release notes are _not_ documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19[{ocp-short} release notes].
 
 *Deprecated:* {mce-short} 2.4 and earlier versions are no longer supported. The documentation might remain available, but without any errata releases for fixed issues or other updates.
 

--- a/clusters/support_troubleshooting/must_gather_mce.adoc
+++ b/clusters/support_troubleshooting/must_gather_mce.adoc
@@ -23,7 +23,7 @@ With this scenario, you check the guide to see if your solution is in the docume
 
 See the following procedure to start using the `must-gather` command:
 
-. Learn about the `must-gather` command and install the prerequisites that you need at link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/support/support-overview#support-overview-gather-data-cluster[Gathering data about your cluster] in the {ocp-short} documentation.
+. Learn about the `must-gather` command and install the prerequisites that you need at link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/support/support-overview#support-overview-gather-data-cluster[Gathering data about your cluster] in the {ocp-short} documentation.
 
 . Log in to your cluster. For the usual use-case, you should run the `must-gather` while you are logged into your _engine_ cluster. 
 

--- a/clusters/support_troubleshooting/trouble_console_status_mce.adoc
+++ b/clusters/support_troubleshooting/trouble_console_status_mce.adoc
@@ -43,7 +43,7 @@ oc describe clusterdeployments -n <new_cluster_name>
 ----
 +
 Replace `new_cluster_name` with the name of the cluster that you created.
-For more information about cluster installation logs, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.4/html/installing/installing-gather-logs[Gathering installation logs] in the Red Hat OpenShift documentation. 
+For more information about cluster installation logs, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.4/html/installing/installing-gather-logs[Gathering installation logs] in the Red Hat OpenShift documentation. 
 
  . See if there is additional information about the problem in the _Status.Conditions.Message_ and _Status.Conditions.Reason_ entries of the resource.
  

--- a/clusters/support_troubleshooting/trouble_reinstall_mce.adoc
+++ b/clusters/support_troubleshooting/trouble_reinstall_mce.adoc
@@ -17,7 +17,7 @@ If you have this problem, complete the following steps:
 
 . Run the uninstallation process to remove the current components by following the steps in xref:../install_upgrade/uninstall.adoc#uninstalling-mce[Uninstalling].
 
-. Ensure that your {ocp} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands.
+. Ensure that your {ocp} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands.
 
 . Copy the following script into a file, replacing the `<namespace>` value in the script with the name of the namespace where you previously installed {mce-short}. 
 

--- a/gitops/deploy_gitops.adoc
+++ b/gitops/deploy_gitops.adoc
@@ -229,6 +229,6 @@ Your policies are deployed using GitOps.
 == Additional resources
 
 - See link:https://nvd.nist.gov/800-53/Rev4[NIST Special Publication 800-53] for standards. 
-- See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started#cli-using-cli_cli-developer-commands[Using the OpenShift CLI] for more information.
+- See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started#cli-using-cli_cli-developer-commands[Using the OpenShift CLI] for more information.
 - See link:../applications/subscribe_git_resources.adoc#resource-overwrite-example[Application Lifecycle] for more details about the _Resource overwrite example_.
 

--- a/gitops/gitops_policy_generator.adoc
+++ b/gitops/gitops_policy_generator.adoc
@@ -135,16 +135,16 @@ Enable the `policyDefaults.orderManifests` parameter and disable `policyDefaults
 
 * See link:../governance/generate_pol_operator_install.adoc#policy-gen-install-operator[Generating a policy that installs the Compliance Operator].
 * See link:../gitops/deploy_gitops.adoc#gitops-deploy-policies[Deploying policies by using GitOps] for more details.
-* See link:https://docs.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.11/html/understanding_openshift_gitops/index[Understanding OpenShift GitOps] and the link:https://cloud.redhat.com/learn/topics/operators[Operator] documentation for more details.
-* See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster[Adding Operators to a cluster - Installing from OperatorHub using the CLI] 
-* See the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator[Compliance Operator documentation] for more details. 
-* See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[_all namespaces_ installation mode].
-* See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[_namespaced_ installation mode].
-* See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/nodes/working-with-containers#nodes-containers-init[Using Init Containers to perform tasks before a pod is deployed].
+* See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.11/html/understanding_openshift_gitops/index[Understanding OpenShift GitOps] and the link:https://cloud.redhat.com/learn/topics/operators[Operator] documentation for more details.
+* See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster[Adding Operators to a cluster - Installing from OperatorHub using the CLI] 
+* See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator[Compliance Operator documentation] for more details. 
+* See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[_all namespaces_ installation mode].
+* See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[_namespaced_ installation mode].
+* See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/nodes/working-with-containers#nodes-containers-init[Using Init Containers to perform tasks before a pod is deployed].
 * See link:https://argoproj.github.io/argo-cd/[Argo CD].
 
 * View the following examples of YAML input that {ocp-short} supports:
 
-- link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/audit-log-policy-config[Configuring the audit log policy]
+- link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/audit-log-policy-config[Configuring the audit log policy]
 - link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/logging/index[Logging]
 

--- a/gitops/gitops_push_pull.adoc
+++ b/gitops/gitops_push_pull.adoc
@@ -99,7 +99,7 @@ For both Push and Pull model, the _Argo CD ApplicationSet controller_ on the hub
 
 - Push model implementation only contains the Argo CD application on the hub cluster, which has credentials for managed clusters. The Argo CD application on the hub cluster can deploy the applications to the managed clusters.
 
-- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {gitops-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://docs.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the {gitops} documentation.
+- *Important:* With a large number of managed clusters that require resource application, consider potential strain on the {gitops-short} GitOps controller memory and CPU usage. To optimize resource management, see link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.12/html/managing_resource_use/configuring-resource-quota[Configuring resource quota or requests] in the {gitops} documentation.
 
 - By default, the Push model is used to deploy the application unless you add the `apps.open-cluster-management.io/ocm-managed-cluster` and `apps.open-cluster-management.io/pull-to-ocm-managed-cluster` annotations to the template section of the `ApplicationSet`.
 
@@ -250,7 +250,7 @@ statuses:
 [#pull-push-resources]
 == Additional resources
 
- - See  link:https://docs.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/declarative_cluster_configuration/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the {gitops} documentation.
+ - See  link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.12/html/declarative_cluster_configuration/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations[Configuring an OpenShift cluster by deploying an application with cluster configurations] in the {gitops} documentation.
 
 
-- See link:https://docs.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the {gitops} documentation.
+- See link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.12/html/argo_cd_instance/setting-up-argocd-instance[Setting up an Argo CD instance] in the {gitops} documentation.

--- a/gitops/gitops_registering.adoc
+++ b/gitops/gitops_registering.adoc
@@ -6,7 +6,7 @@ To configure {gitops-short} with the Push model, you can register a set of one o
 [#prerequisites-argo]
 == Prerequisites 
 
-. You need to install the link:https://docs.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/installing_gitops/index[{gitops} operator] on your {acm}.
+. You need to install the link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.12/html/installing_gitops/index[{gitops} operator] on your {acm}.
 
 . Import one or more managed clusters.
 
@@ -148,4 +148,4 @@ For more information, see the following resources and examples:
 
 - link:../clusters/cluster_lifecycle/create_clustersetbinding.adoc#creating-a-managedclustersetbinding[Creating a _ManagedClusterSetBinding_ resource] 
 
-- link:https://docs.redhat.com/documentation/en-us/red_hat_openshift_gitops/1.12/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About {gitops}] 
+- link:https://docs.redhat.com/en/documentation/red_hat_openshift_gitops/1.12/html/understanding_openshift_gitops/about-redhat-openshift-gitops[About {gitops}] 

--- a/global_hub/global_hub_install_connected.adoc
+++ b/global_hub/global_hub_install_connected.adoc
@@ -38,9 +38,9 @@ To install the {global-hub} operator in a connected environment by using the {oc
 [#additional-resource-custom-global-hub-install]
 == Additional resources
 
-- For more information about mirroring an Operator catalog, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
-- For more information about accessing images from private registries, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries].
-- For more information about adding a catalog source, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster].
+- For more information about mirroring an Operator catalog, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
+- For more information about accessing images from private registries, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries].
+- For more information about adding a catalog source, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster].
 - For more information about installing {acm-short} in a disconnected environment, see link:../install/install_disconnected.adoc#install-on-disconnected-networks[Installing in disconnected network environments].
 - For more information about mirroring images, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring images for a disconnected installation].
 - For more information about the Operator SDK Intregration with OLM, see link:https://sdk.operatorframework.io/docs/olm-integration/[Operator SDK Integration with Operator Lifecycle Manager].

--- a/global_hub/global_hub_install_disconnected.adoc
+++ b/global_hub/global_hub_install_disconnected.adoc
@@ -11,11 +11,11 @@ If your cluster is in a restricted network, you can deploy the {global-hub} oper
 You must meet the following requirements before you install {global-hub} in a disconnected environment:
 
 - An image registry and a bastion host must have access to both the internet and to your mirror registry.
-- Install the Operator Lifecycle Manager on your cluster. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#operator-lifecycle-manager-olm[Operator Lifecycle Manager (OLM)].
+- Install the Operator Lifecycle Manager on your cluster. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#operator-lifecycle-manager-olm[Operator Lifecycle Manager (OLM)].
 - Install {acm}.
 - Install the following command line interfaces:
 +
-* The {ocp-short} command line. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the {ocp-short} CLI].
+* The {ocp-short} command line. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the {ocp-short} CLI].
 * The `opm` command line. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/opm-cli#cli-opm-install[Installing the opm CLI].
 * The  `oc-mirror` plugin. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/disconnected_environments/mirroring-in-disconnected-environments#about-installing-oc-mirror-v2[Mirroring images for a disconnected installation by using the oc-mirror plugin v2].
 
@@ -81,7 +81,7 @@ oc patch OperatorHub cluster --type json \
 -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 ----
 
-. Mirror the Operator catalog by completing the procedure, link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring the Operator catalog].
+. Mirror the Operator catalog by completing the procedure, link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring the Operator catalog].
 . Add the `CatalogSource` resource for your mirrored catalog into the `openshift-marketplace` namespace. Your `CatalogSource` YAML file might be similar to the following example, with `4.x` set as the supported version:
 +
 [source,yaml]
@@ -178,7 +178,7 @@ By completing the previous step, a label and an annotation are added to the sele
 [#global-hub-installing-disconnected-pull-secret]
 === Configure the image pull secret
 
-If the Operator or Operand images that are referenced by a subscribed Operator require access to a private registry, you can either link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-creating-catalog-from-index_olm-managing-custom-catalogs[provide access to all namespaces in the cluster, or to individual target tenant namespaces]. 
+If the Operator or Operand images that are referenced by a subscribed Operator require access to a private registry, you can either link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-creating-catalog-from-index_olm-managing-custom-catalogs[provide access to all namespaces in the cluster, or to individual target tenant namespaces]. 
 
 [#global-hub-installing-disconnected-pull-secret-generic]
 ==== Configure the {global-hub} image pull secret in an {ocp-short} cluster
@@ -249,7 +249,7 @@ oc secrets link <operator_sa> -n <tenant_namespace> <secret_name> --for=pull
 [#global-hub-installing-disconnected-operator]
 === Installing the Global Hub Operator
 
-You can install and subscribe an Operator from OperatorHub using the {ocp} web console. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] for the procedure. After adding the Operator, you can check the status of the {global-hub} Operator by running the following command: 
+You can install and subscribe an Operator from OperatorHub using the {ocp} web console. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/administrator-tasks#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] for the procedure. After adding the Operator, you can check the status of the {global-hub} Operator by running the following command: 
 
 [source,bash]
 ----
@@ -265,5 +265,5 @@ multicluster-global-hub-operator-687584cb7c-fnftj   1/1     Running   0         
 
 - For more information about mirroring images, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/disconnected_environments/mirroring-in-disconnected-environments[Mirroring in disconnected environments].
 
-- For more information about mirroring an Operator catalog, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
+- For more information about mirroring an Operator catalog, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
 

--- a/global_hub/global_hub_requirements.adoc
+++ b/global_hub/global_hub_requirements.adoc
@@ -48,7 +48,7 @@ See the following networking requirements:
 
 See the following supported components: 
 
-* The {global-hub} and {ocp-short} console share an integrated console, so they support the same browser. For information about supported browsers and versions, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/web_console/index#web-console[Accessing the web console] in the {ocp} documentation
+* The {global-hub} and {ocp-short} console share an integrated console, so they support the same browser. For information about supported browsers and versions, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/web_console/index#web-console[Accessing the web console] in the {ocp} documentation
 
 * See the following table of supported platforms for the {global-hub} cluster:
 

--- a/governance/compliance_operator_policy.adoc
+++ b/governance/compliance_operator_policy.adoc
@@ -6,7 +6,7 @@ You can use the Compliance Operator to automate the inspection of numerous techn
 Recommendations that are generated from the Compliance Operator are based on generally available information and practices regarding such standards, and might assist you with remediations, but actual compliance is your responsibility. Work with an authorized auditor to achieve compliance with a standard.
 
 
-For the latest updates, see the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#compliance-operator-release-notes[Compliance Operator release notes].
+For the latest updates, see the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#compliance-operator-release-notes[Compliance Operator release notes].
 
 
 [#compliance-operator-policy-overview]
@@ -14,7 +14,7 @@ For the latest updates, see the link:https://docs.redhat.com/documentation/en-us
 
 You can install the Compliance Operator on your managed cluster by using the Compliance Operator policy. The Compliance operator policy is created as a Kubernetes configuration policy in {acm-short}. {ocp-short} supports the compliance operator policy.
 
-*Note:* The link:https://github.com/open-cluster-management/grc-ui/blob/main/src-web/components/common/templates/spec-comp-operator.yaml[Compliance operator policy] relies on the {ocp-short} Compliance Operator, which is not supported on the IBM Power or IBM Z architectures. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator] in the {ocp-short} documentation for more information about the Compliance Operator.
+*Note:* The link:https://github.com/open-cluster-management/grc-ui/blob/main/src-web/components/common/templates/spec-comp-operator.yaml[Compliance operator policy] relies on the {ocp-short} Compliance Operator, which is not supported on the IBM Power or IBM Z architectures. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator] in the {ocp-short} documentation for more information about the Compliance Operator.
 
 [#compliance-operator-resources]
 == Compliance operator resources
@@ -97,7 +97,7 @@ After you install the compliance operator policy, the following pods are created
 [#additional-resources-comp]
 == Additional resources
 
-- For more information, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/security_and_compliance/index#compliance-operator-understanding[Managing the Compliance Operator] in the {ocp-short} documentation for more details.
+- For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/security_and_compliance/index#compliance-operator-understanding[Managing the Compliance Operator] in the {ocp-short} documentation for more details.
 
 - You can also create and apply the E8 scan policy and OpenShift CIS scan policy, after you have installed the compliance operator. For more information, see xref:../governance/e8_scan_policy.adoc#e8-scan-policy[E8 scan policy] and xref:../governance/ocp_cis_policy.adoc#ocp-cis-policy[OpenShift CIS scan policy].
 

--- a/governance/e8_scan_policy.adoc
+++ b/governance/e8_scan_policy.adoc
@@ -3,7 +3,7 @@
 
 An Essential 8 (E8) scan policy deploys a scan that checks the master and worker nodes for compliance with the E8 security profiles. You must install the compliance operator to apply the E8 scan policy.
 
-The E8 scan policy is created as a Kubernetes configuration policy in {acm-short}. {ocp-short} supports the E8 scan policy. For more information, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/security_and_compliance/index#compliance-operator-understanding[Managing the Compliance Operator] in the {ocp-short} documentation for more details.
+The E8 scan policy is created as a Kubernetes configuration policy in {acm-short}. {ocp-short} supports the E8 scan policy. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/security_and_compliance/index#compliance-operator-understanding[Managing the Compliance Operator] in the {ocp-short} documentation for more details.
 
 [#e8-scan-policy-resources]
 == E8 scan policy resources

--- a/governance/manage_operator.adoc
+++ b/governance/manage_operator.adoc
@@ -1,7 +1,7 @@
 [#managing-operator-policies-disconnected]
 = Managing operator policies in disconnected environments
 
-You might need to deploy {acm} policies on {ocp} clusters that are not connected to the internet (disconnected). If the policies you deploy are used to deploy policies that install an {olm} operator, you must follow the procedure for link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
+You might need to deploy {acm} policies on {ocp} clusters that are not connected to the internet (disconnected). If the policies you deploy are used to deploy policies that install an {olm} operator, you must follow the procedure for link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog].
 
 Complete the following steps to validate access to the operator images:
 

--- a/governance/ocp_cis_policy.adoc
+++ b/governance/ocp_cis_policy.adoc
@@ -3,7 +3,7 @@
 
 An OpenShift CIS scan policy deploys a scan that checks the master and worker nodes for compliance with the OpenShift CIS security benchmark. You must install the compliance operator to apply the OpenShift CIS policy.
 
-The OpenShift CIS scan policy is created as a Kubernetes configuration policy in {acm-short}. {ocp-short} supports the OpenShift CIS scan policy. For more information, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator] in the {ocp-short} documentation for more details.
+The OpenShift CIS scan policy is created as a Kubernetes configuration policy in {acm-short}. {ocp-short} supports the OpenShift CIS scan policy. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator] in the {ocp-short} documentation for more details.
 
 [#ocp-cis-policy-resources]
 == OpenShift CIS resources

--- a/governance/operator_pol_ctrl.adoc
+++ b/governance/operator_pol_ctrl.adoc
@@ -98,6 +98,6 @@ a| Use this parameter to define the compliance behavior for specific scenarios t
 * See xref:../governance/template_support_intro.adoc#template-processing[Template processing].
 * See xref:../governance/install_operator.adoc#install-operator-with-policy[Installing an operator by using the `OperatorPolicy` resource] for more details.
 * See xref:../governance/manage_operator.adoc#managing-operator-policies-disconnected[Managing operator policies in disconnected environments]. 
-* See the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/understanding-operators#olm-subscription_olm-understanding-olm[Subscription] topic in the {ocp-short} documentation.
-* See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/understanding-operators#operator-lifecycle-manager-olm[Operator Lifecycle Manager (OLM)] for more details.
-* See the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] documentation for general information on OLM.
+* See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/understanding-operators#olm-subscription_olm-understanding-olm[Subscription] topic in the {ocp-short} documentation.
+* See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/understanding-operators#operator-lifecycle-manager-olm[Operator Lifecycle Manager (OLM)] for more details.
+* See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-adding-operators-to-a-cluster[Adding Operators to a cluster] documentation for general information on OLM.

--- a/governance/supported_policies.adoc
+++ b/governance/supported_policies.adoc
@@ -66,11 +66,11 @@ View the following policy documentation to learn how to apply policies:
 
 * Find more details about Kubernetes role-based access control in the Kubernetes link:https://kubernetes.io/docs/reference/access-authn-authz/rbac/[RBAC documentation].
 
-* Review the {ocp-short} documentation for more details about link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/authentication_and_authorization/managing-pod-security-policies[Managing Security Context Constraints documentation].
+* Review the {ocp-short} documentation for more details about link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/authentication_and_authorization/managing-pod-security-policies[Managing Security Context Constraints documentation].
 
-* Review the {ocp-short} documentation for more information about link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/encrypting-etcd[Encrypting etcd data].
+* Review the {ocp-short} documentation for more information about link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/encrypting-etcd[Encrypting etcd data].
 
-* See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator] in the {ocp-short} documentation.
+* See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator] in the {ocp-short} documentation.
 
 * For more details about the Container Security Operator, see the link:https://github.com/quay/container-security-operator#readme[Quay GitHub repository].
 

--- a/install/adv_config_install.adoc
+++ b/install/adv_config_install.adoc
@@ -66,7 +66,7 @@ The secret requirements for {ocp-short} clusters are automatically resolved by {
 
 **Important:** These secrets are namespace-specific, so make sure that you are in the namespace that you use for your hub cluster.
 
-. Go to link:https://cloud.redhat.com/openshift/install/pull-secret[cloud.redhat.com/openshift/install/pull-secret] to download the {ocp-short} pull secret file.
+. Go to link:https://console.redhat.com/openshift/install/pull-secret[cloud.redhat.com/openshift/install/pull-secret] to download the {ocp-short} pull secret file.
 . Click *Download pull secret*.
 . Run the following command to create your secret:
 

--- a/install/cleanup_reinstall.adoc
+++ b/install/cleanup_reinstall.adoc
@@ -12,7 +12,7 @@ Before you reinstall {acm} on a cluster where a previous version was installed a
 
 Remove all artifacts that remain by running the clean-up script. You need to clean up artifacts if you plan to reinstall {acm-short} with an older version of {acm-short} on the same cluster. 
 
-. Ensure that your {ocp} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands.
+. Ensure that your {ocp} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands.
 
 . Copy the following script into a file, replacing the `<namespace>` value in the script with the name of the namespace where you previously installed {acm-short}. 
 

--- a/install/cluster_size.adoc
+++ b/install/cluster_size.adoc
@@ -94,13 +94,13 @@ Also learn more about link:https://cloud.google.com/compute/docs/machine-resourc
 | 10
 | 16 GB 
 | 100 GB
-| See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_ibm_z_and_ibm_linuxone[Installing a cluster on IBM Z systems] in the {ocp-short} documentation for more information.
+| See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_ibm_z_and_ibm_linuxone/index[Installing a cluster on IBM Z systems] in the {ocp-short} documentation for more information.
 
 IBM Z systems provide the ability to configure simultaneous multithreading (SMT), which extends the number of vCPUs that can run on each core. If you configured SMT, One physical core (IFL) provides two logical cores (threads). The hypervisor can provide two or more vCPUs.
 
 One vCPU is equal to one physical core when simultaneous multithreading (SMT), or hyper-threading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
 
-For more information about SMT, see link:https://www.ibm.com/docs/en/aix/7.2?topic=concepts-simultaneous-multithreading[Simultaneous multithreading].
+For more information about SMT, see link:https://www.ibm.com/docs/en/aix/7.2.0?topic=concepts-simultaneous-multithreading[Simultaneous multithreading].
 
 | {ocp-short} on IBM Power systems
 | 3 
@@ -109,7 +109,7 @@ For more information about SMT, see link:https://www.ibm.com/docs/en/aix/7.2?top
 | 16
 | 16 GB
 | 120 GB
-| See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_ibm_power[Installing a cluster on Power systems] in the {ocp-short} documentation for more information.
+| See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_ibm_power/index[Installing a cluster on Power systems] in the {ocp-short} documentation for more information.
 
 IBM Power systems provide the ability to configure simultaneous multithreading (SMT), which extends the number of vCPUs that can run on each core. If you configured SMT, your SMT level determines how you satisfy the 16 vCPU requirement. The most common configurations are:
 
@@ -117,7 +117,7 @@ Two cores running on SMT-8 (the default configuration for systems that are runni
 
 Four cores running on SMT-4 provides the required 16 vCPUs. 
 
-For more information about SMT, see link:https://www.ibm.com/docs/en/aix/7.2?topic=concepts-simultaneous-multithreading[Simultaneous multithreading].
+For more information about SMT, see link:https://www.ibm.com/docs/en/aix/7.2.0?topic=concepts-simultaneous-multithreading[Simultaneous multithreading].
 
 | {ocp-short} on-premises
 | 3
@@ -134,7 +134,7 @@ A {acm} hub cluster can be installed and supported on {ocp-short} bare metal. Th
 [#single-node]
 == Creating and managing single node {ocp-short} clusters
 
-View link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_a_single_node[Installing on a single node] to learn about the requirements. Since each cluster is unique, the following guidelines provide only sample deployment requirements that are classified by size and purpose. 
+View link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installing_on_a_single_node/index[Installing on a single node] to learn about the requirements. Since each cluster is unique, the following guidelines provide only sample deployment requirements that are classified by size and purpose. 
 
 _Availability zones_ isolate potential fault domains across the cluster. 
 

--- a/install/config_infra_nodes_acm.adoc
+++ b/install/config_infra_nodes_acm.adoc
@@ -8,7 +8,7 @@ After adding infrastructure nodes to your {ocp-short} cluster, follow the xref:.
 [#config-infra-nodes-ocp]
 == Configuring infrastructure nodes to the {ocp-short} cluster
 
-Follow the procedures that are described in link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp-short} documentation. Infrastructure nodes are configured with a Kubernetes `taints` and `labels` to keep non-management workloads from running on them.
+Follow the procedures that are described in link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp-short} documentation. Infrastructure nodes are configured with a Kubernetes `taints` and `labels` to keep non-management workloads from running on them.
 
 . To be compatible with the infrastructure node enablement provided by {acm-short}, ensure your infrastructure nodes have the following `taints` and `labels` applied:
 

--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -39,7 +39,7 @@ Before you install {acm-short}, see the following requirements:
 
 * You need a supported {ocp-short} and the {ocp-short} CLI. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installation_overview/index[{ocp-short} installing].
 
-* Your {ocp-short} command line interface (CLI) must be configured to run `oc` commands. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the {ocp-short} CLI.
+* Your {ocp-short} command line interface (CLI) must be configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the {ocp-short} CLI.
 
 * Your {ocp-short} permissions must allow you to create a namespace. Without a namespace, installation fails.
 

--- a/install/install_disconnected.adoc
+++ b/install/install_disconnected.adoc
@@ -16,7 +16,7 @@ You must meet the following requirements before you install {acm}:
 
 * You must have a workstation that has access to both the Internet and your local mirror registry. 
 
-* You need a supported {ocp-short} version deployed in your environment, and you must be logged in with the command-line interface. See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installation_overview/index[{ocp-short} install documentation] for information on installing {ocp-short}. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the command-line tool.
+* You need a supported {ocp-short} version deployed in your environment, and you must be logged in with the command-line interface. See the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/installation_overview/index[{ocp-short} install documentation] for information on installing {ocp-short}. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the CLI] for information about installing and configuring the command-line tool.
 
 * Review xref:../install/cluster_size.adoc#sizing-your-cluster[Sizing your cluster] to learn about setting up capacity for your hub cluster.
 
@@ -66,7 +66,7 @@ In disconnected environments, {olm} cannot access the standard operator sources 
 
 +
 To prepare your disconnected cluster for installing {acm-short}, follow the procedure that is described in
-link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/operators/index#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] in the {ocp-short} documentation.
+link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/operators/index#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks] in the {ocp-short} documentation.
 
 . Include operator packages in your mirror catalog. 
 

--- a/install/uninstall.adoc
+++ b/install/uninstall.adoc
@@ -63,7 +63,7 @@ When you delete the resource, the pods in the `open-cluster-management-observabi
 
 Delete the `MultiClusterHub` custom resource and remove artifacts. Complete the following steps:
 
-. If you have not already, ensure that your {ocp-short} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands. 
+. If you have not already, ensure that your {ocp-short} CLI is configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands. 
 
 . Change to your project namespace by entering the following command. Replace _namespace_ with the your project namespace:
 

--- a/install/upgrade_hub.adoc
+++ b/install/upgrade_hub.adoc
@@ -79,7 +79,7 @@ While it is upgrading, the `Status` field shows the `Updating` status. After the
 .. Verify that the `csv` version from the previous release, for instance, `2.11` (EUS), is replaced with the upgraded version, for instance, `2.13` (EUS).
 .. Verify that the `MultiClusterHub` instance `status.currentVersion` specification value is set at `2.13` and matches the `desiredVersion` status, which is also set at `2.13`.
 
-For more information about upgrading your operator, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/index[Operators] in the {ocp-short} documentation.
+For more information about upgrading your operator, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/operators/index[Operators] in the {ocp-short} documentation.
 
 [#upgrading-clusterpools]
 == Managing cluster pools with an upgrade

--- a/observability/obs_config.adoc
+++ b/observability/obs_config.adoc
@@ -278,7 +278,7 @@ Observability components require 2701mCPU and 11972Mi memory to install the obse
 - For more information about enabling observability, read xref:../observability/observability_enable.adoc#enabling-observability-service[Enabling the observability service].
 - Read xref:../observability/obs_metrics.adoc#adding-custom-metrics[Adding custom metrics] to learn how to customize metrics.
 - Read xref:../observability/design_grafana.adoc#using-grafana-dashboards[Using Grafana dashboards].
-- Learn from the {ocp-short} documentation what types of metrics are collected and sent using telemetry. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/support/index#about-remote-health-monitoring[Information collected by Telemetry] for information. 
+- Learn from the {ocp-short} documentation what types of metrics are collected and sent using telemetry. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/support/index#about-remote-health-monitoring[Information collected by Telemetry] for information. 
 - Refer to link:../governance/policy_ctrl_adv_config.adoc#gov-metric[Governance metric] for details.
 - Refer to link:https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/[Prometheus recording rules].
 - Also refer to link:https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[Prometheus alerting rules].

--- a/observability/observability_enable.adoc
+++ b/observability/observability_enable.adoc
@@ -81,7 +81,7 @@ oc create secret generic multiclusterhub-operator-pull-secret \
 ----
 
 +
-*Important:* If you modify the global pull secret for your cluster by using the {ocp-short} documentation, be sure to also update the global pull secret in the Observability namespace. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global pull secret] for more details.
+*Important:* If you modify the global pull secret for your cluster by using the {ocp-short} documentation, be sure to also update the global pull secret in the Observability namespace. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/images/managing-images#images-update-global-pull-secret_using-image-pull-secrets[Updating the global pull secret] for more details.
 
 . Create a secret for your object storage for your cloud provider. Your secret must contain the credentials to your storage solution. For example, run the following command:
 
@@ -422,7 +422,7 @@ observability-thanos-store-shard-x  (statefulsets)
 [#creating-mco-cr]
 === Creating the MultiClusterObservability custom resource
 
-Use the `MultiClusterObservability` custom resource to specify the persistent volume storage size for various components. You must set the storage size during the initial creation of the `MultiClusterObservability` custom resource. When you update the storage size values post-deployment, changes take effect only if the storage class supports dynamic volume expansion. For more information, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/storage/expanding-persistent-volumes[Expanding persistent volumes from the {ocp} documentation].
+Use the `MultiClusterObservability` custom resource to specify the persistent volume storage size for various components. You must set the storage size during the initial creation of the `MultiClusterObservability` custom resource. When you update the storage size values post-deployment, changes take effect only if the storage class supports dynamic volume expansion. For more information, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/storage/expanding-persistent-volumes[Expanding persistent volumes from the {ocp} documentation].
 
 Complete the following steps to create the `MultiClusterObservability` custom resource on your hub cluster:
 

--- a/release_notes/acm_known_issues_intro.adoc
+++ b/release_notes/acm_known_issues_intro.adoc
@@ -15,6 +15,6 @@ Review the known issues for application management. The following list contains 
 * xref:../release_notes/known_issues_network.adoc#known-issues_submariner[Networking known issues]
 * xref:../release_notes/known_issues_global.adoc#known-issues-global-hub[Global Hub known issues]
 
-*Important:* {ocp-short} release notes are not documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.19[{ocp-short} release notes].
+*Important:* {ocp-short} release notes are not documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19[{ocp-short} release notes].
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].

--- a/release_notes/acm_new.adoc
+++ b/release_notes/acm_new.adoc
@@ -13,7 +13,7 @@ Access the link:https://access.redhat.com/articles/7120842[{acm-short} Support M
 
 - Learn how CNCF providers are certified at link:https://www.cncf.io/training/certification/software-conformance/[Certified Kubernetes Conformance]. 
 
-- For Red Hat support information about CNCF third-party providers, see link:https://access.redhat.com/third-party-software-support[Red Hat support with third party components], or link:https://access.redhat.com/support/contact/[Contact Red Hat support].
+- For Red Hat support information about CNCF third-party providers, see link:https://access.redhat.com/articles/third-party-software-support[Red Hat support with third party components], or link:https://access.redhat.com/support/contact/[Contact Red Hat support].
 
 - If you bring your own CNCF conformance certified cluster, you need to change the {ocp-short} CLI `oc` command to the Kubernetes CLI command, `kubectl`. 
 

--- a/release_notes/acm_release_notes.adoc
+++ b/release_notes/acm_release_notes.adoc
@@ -15,7 +15,7 @@ Access the link:https://access.redhat.com/articles/7120842[{acm-short} Support M
 * xref:../release_notes/fips_readiness.adoc#fips-readiness[FIPS readiness]
 * xref:../release_notes/observability_support.adoc#observability-support[Observability support]
 
-*Important:* {ocp-short} release notes are not documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.19[{ocp-short} release notes].
+*Important:* {ocp-short} release notes are not documented in this product documentation. For your {ocp-short} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19[{ocp-short} release notes].
 
 *Deprecated:* {acm-short} 2.9 and earlier versions are no longer supported. The documentation might remain available, but without any errata releases for fixed issues or other updates.
 

--- a/release_notes/fips_readiness.adoc
+++ b/release_notes/fips_readiness.adoc
@@ -18,7 +18,7 @@ For more information, see link:https://docs.redhat.com/en/documentation/openshif
 
 Read the following limitations with {acm-short} components and features for FIPS readiness.
 
-* Persistent Volume Claim (PVC) and S3 storage that is used by the search and observability components must be encrypted when you configure the provided storage. {acm-short} does not provide storage encryption, see the {ocp-short} documentation, link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/storage/index#configuring-persistent-storage[Configuring persistent storage].
+* Persistent Volume Claim (PVC) and S3 storage that is used by the search and observability components must be encrypted when you configure the provided storage. {acm-short} does not provide storage encryption, see the {ocp-short} documentation, link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/storage/index#configuring-persistent-storage[Configuring persistent storage].
 
 * When you provision managed clusters using the {acm-short} console, select the following checkbox in the _Cluster details_ section of the managed cluster creation to enable the FIPS standards:
 

--- a/release_notes/known_issues_application.adoc
+++ b/release_notes/known_issues_application.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for application management. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].
 

--- a/release_notes/known_issues_console.adoc
+++ b/release_notes/known_issues_console.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for the console. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes#ocp-4-15-known-issues[{ocp-short} known issues]. 
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes#ocp-4-15-known-issues[{ocp-short} known issues]. 
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].
 

--- a/release_notes/known_issues_continuity.adoc
+++ b/release_notes/known_issues_continuity.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for {acm}. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].
 

--- a/release_notes/known_issues_global.adoc
+++ b/release_notes/known_issues_global.adoc
@@ -1,7 +1,7 @@
 [#known-issues-global-hub]
 = Multicluster global hub Operator known issues
 
-Review the known issues for the {global-hub} Operator. The following list contains known issues for this release, or known issues that continued from the previous release. For your {ocp-short} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues].
+Review the known issues for the {global-hub} Operator. The following list contains known issues for this release, or known issues that continued from the previous release. For your {ocp-short} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues].
 
 [#hub-cluster-recreates-addon]
 == Detached hosted managed hub cluster recreates the _addon_ 
@@ -24,7 +24,7 @@ link:https://issues.redhat.com/browse/ACM-21506[ACM-15014]
 [#kafka-operator-keeps-restarting]
 == Kafka operator keeps restarting 
 
-In the Federal Information Processing Standard (FIPS) environment, the Kafka operator keeps restarting because of the out-of-memory (OOM) state. To fix this issue, set the resource limit to at least `512M`. For detailed steps on how to set this limit, see link:https://docs.redhat.com/documentation/en-us/red_hat_amq_streams/2.6/html/deploying_and_managing_amq_streams_on_openshift/deploy-intro_str#assembly-fips-support-str[amq stream doc].
+In the Federal Information Processing Standard (FIPS) environment, the Kafka operator keeps restarting because of the out-of-memory (OOM) state. To fix this issue, set the resource limit to at least `512M`. For detailed steps on how to set this limit, see link:https://docs.redhat.com/en/documentation/red_hat_amq_streams/2.6/html/deploying_and_managing_amq_streams_on_openshift/deploy-intro_str#assembly-fips-support-str[amq stream doc].
 
 link:https://issues.redhat.com/browse/ACM-12592[ACM-12592]
 

--- a/release_notes/known_issues_governance.adoc
+++ b/release_notes/known_issues_governance.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for Governance. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues].
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues].
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].
 

--- a/release_notes/known_issues_install.adoc
+++ b/release_notes/known_issues_install.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for installing and upgrading. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].
 

--- a/release_notes/known_issues_network.adoc
+++ b/release_notes/known_issues_network.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for Submariner. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes/#ocp-4-15-known-issues[{ocp-short} known issues]. 
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}].
 

--- a/release_notes/known_issues_observability.adoc
+++ b/release_notes/known_issues_observability.adoc
@@ -3,7 +3,7 @@
 
 Review the known issues for {acm}. The following list contains known issues for this release, or known issues that continued from the previous release. 
 
-For your {ocp} cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/release_notes#ocp-4-15-known-issues [{ocp-short} known issues].
+For your {ocp} cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/release_notes#ocp-4-15-known-issues [{ocp-short} known issues].
 
 For more about deprecations and removals, see xref:../release_notes/acm_deprecate_remove.adoc#deprecations-removals-acm[Deprecations and removals for {acm-short}]. 
 

--- a/secure_clusters/certificates.adoc
+++ b/secure_clusters/certificates.adoc
@@ -98,8 +98,8 @@ If you customize the hub cluster API server certificate, the managed cluster aut
 
 - For more details about securely connecting to a privately-hosted Git server with SSL/TLS certificates, see link:../applications/configuring_git_channel.adoc#using-custom-CA-certificates-for-secure-HTTPS-connection[Using custom CA certificates for a secure HTTPS connection].
 
-- See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#add-service-serving[OpenShift Service Serving Certificates] for more details.
+- See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#add-service-serving[OpenShift Service Serving Certificates] for more details.
 
-- The {ocp-short} default ingress is a hub cluster certificate. See link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress[Replacing the default ingress certificate] for more details.
+- The {ocp-short} default ingress is a hub cluster certificate. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/security_and_compliance/configuring-certificates#replacing-default-ingress[Replacing the default ingress certificate] for more details.
 
 

--- a/secure_clusters/rbac.adoc
+++ b/secure_clusters/rbac.adoc
@@ -1,7 +1,7 @@
 [#rbac-rhacm]
 = Role-based access control
 
-{acm} supports role-based access control (RBAC). Your role determines the actions that you can perform. RBAC is based on the authorization mechanisms in Kubernetes, similar to {ocp}. For more information about RBAC, see the OpenShift _RBAC_ overview in the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/authentication_and_authorization/using-rbac[{ocp-short} documentation].
+{acm} supports role-based access control (RBAC). Your role determines the actions that you can perform. RBAC is based on the authorization mechanisms in Kubernetes, similar to {ocp}. For more information about RBAC, see the OpenShift _RBAC_ overview in the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/authentication_and_authorization/using-rbac[{ocp-short} documentation].
 
 *Note:* Action buttons are disabled from the console if the user-role access is impermissible.
 

--- a/troubleshooting/must_gather_global_hub.adoc
+++ b/troubleshooting/must_gather_global_hub.adoc
@@ -16,9 +16,9 @@ You must meet the following prerequisites to run the `must-gather` command:
 
 * Access to the global hub and managed hub clusters as a user with the `cluster-admin` role.
 
-* Install the {ocp-short} command-line interface on your local machine. For more information, see the link:https://docs.openshift.com/container-platform/4.17/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the OpenShift CLI] in the {ocp-short} documentation.
+* Install the {ocp-short} command-line interface on your local machine. For more information, see the link:https://docs.openshift.com/en/container-platform/4.17/cli_reference/openshift_cli/getting-started-cli.html[Getting started with the OpenShift CLI] in the {ocp-short} documentation.
 
-* Learn about the `must-gather` command and install the prerequisites that you need by reading the link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/support/gathering-cluster-data[Gathering data about your cluster] in the {ocp-short} documentation.
+* Learn about the `must-gather` command and install the prerequisites that you need by reading the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/support/gathering-cluster-data[Gathering data about your cluster] in the {ocp-short} documentation.
 
 [#global-hub-must-gather-procedure]
 == Running the must-gather command

--- a/troubleshooting/trouble_console_status.adoc
+++ b/troubleshooting/trouble_console_status.adoc
@@ -43,7 +43,7 @@ oc describe clusterdeployments -n <new_cluster_name>
 ----
 +
 Replace `new_cluster_name` with the name of the cluster that you created.
-For more information about cluster installation logs, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.4/html/installing/installing-gather-logs[Gathering installation logs] in the Red Hat OpenShift documentation. 
+For more information about cluster installation logs, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.4/html/installing/installing-gather-logs[Gathering installation logs] in the Red Hat OpenShift documentation. 
 
  . See if there is additional information about the problem in the _Status.Conditions.Message_ and _Status.Conditions.Reason_ entries of the resource.
  

--- a/troubleshooting/trouble_observability.adoc
+++ b/troubleshooting/trouble_observability.adoc
@@ -33,7 +33,7 @@ observabilityaddons.observability.open-cluster-management.io
 observatoria.core.observatorium.io
 ----
 
-. If you create your own storageClass for a Bare Metal cluster, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html-single/storage/index#persistent-storage-using-nfs[Persistent storage using NFS].
+. If you create your own storageClass for a Bare Metal cluster, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html-single/storage/index#persistent-storage-using-nfs[Persistent storage using NFS].
 . To ensure that the observability component can find the default storageClass, update the `storageClass` parameter in the `multicluster-observability-operator` custom resource definition. Your parameter might resemble the following value:
 
 ----

--- a/troubleshooting/troubleshooting_intro.adoc
+++ b/troubleshooting/troubleshooting_intro.adoc
@@ -9,7 +9,7 @@ For `must-gather` information, see the following sections:
 * xref:../troubleshooting/must_gather_global_hub.adoc#global-hub-must-gather[Running the must-gather command to troubleshoot issues with {global-hub}]
 * xref:../troubleshooting/must_gather_rhem.adoc#must-gather-rhem[Running the must-gather command to troubleshoot the {rhem}]
 
-For more information about the `must-gather` command, see the link:https://docs.openshift.com/container-platform/4.17/support/gathering-cluster-data.html[Gathering data about your cluster] in the {ocp-short} documentation.
+For more information about the `must-gather` command, see the link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/support/gathering-cluster-data[Gathering data about your cluster] in the {ocp-short} documentation.
 
 Additionally, check your role-based access. See link:../secure_clusters/rbac.adoc#role-based-access-control[Role-based access control] for details.
 


### PR DESCRIPTION
This PR isn't essential, but I think it's probably a good practice since we don't know how long the redirect behavior will last.

I noticed a bunch of redirects in the summary of the CI, so I ran:
```
find . -name \*.adoc -exec asciidoctor --failure-level WARN --trace --verbose --warnings {} +
lychee $(yq '.jobs.asciidoc.steps[] | select(.name == "Link Check").with.args' .github/workflows/linting.yml) --output lychee.json --format json ./**/**/main.html ./**/**/**/main.html
```
And then deleted the HTML files and told Cursor:
>Do a broad find/replace over the *.adoc files using the results under the "redirect_map" key in the lychee.json file. Replace the value in "url" with the final location in the redirects array. Ignore any "issues.redhat.com" links.

Assisted-by: Cursor IDE using claude-4.5-sonnet