### PR TITLE
Note that BMHs are not backed up by default

### DIFF
--- a/release_notes/known_issues_continuity.adoc
+++ b/release_notes/known_issues_continuity.adoc
@@ -93,6 +93,15 @@ oc delete appliedmanifestwork <the-left-appliedmanifestwork-name>
 
 link:https://github.com/stolostron/backlog/issues/27129[ACM-27129]
 
+[#baremetalhost-not-backed-up]
+=== The BareMetalHost resources are not backed up by default
+
+BareMetalHosts used to add hosts to a host inventory when using Central Infrastructure Management are not included in backups by default.
+
+You can add the `cluster.open-cluster-management.io/backup: cluster-activation` label to the BareMetalHosts to include them in backups. For more information, see the link:../business_continuity/backup_restore/backup_arch.adoc#resources-restored-managed-cluster-activation[Resources restored at managed clusters activation time] topic.
+
+link:https://issues.redhat.com/browse/ACM-26582[ACM-26582]
+
 [#known-issues-volsync]
 == Volsync known issues
 


### PR DESCRIPTION
BMHs used to add hosts in CIM are not backed up by default. Add a note about this in the DR known issues and document a workaround.

https://issues.redhat.com/browse/ACM-26586

cc @swopebe 