### PR TITLE
[ACM-29081] - Update known issues regarding alert forwarding failures

### DIFF
--- a/release_notes/known_issues_observability.adoc
+++ b/release_notes/known_issues_observability.adoc
@@ -37,7 +37,7 @@ link:https://issues.redhat.com/browse/ACM-26604[ACM-26604]
 [#alert-forward-fails]
 == Manually configured alert forwarding fails
 
-When you upgrade to {acm-short} {product-version} alert forwarding fails if you disabled automatic configuration by setting `mco-disable-alerting: true` in the `MultiClusterObservability` custom resource, and if you manually configured alert forwarding. The failure happens after you upgrade because the name of the `observability-alertmanager-accessor` and `hub-alertmanager-router-ca` secrets were changed to include a postfix of the hub cluster ID. The hub ID is obtained from the `uuid` field in the metadata of the `ClusterVersion` CR on the hub. The id, with dashes removed and trimmed to the first 19 characters is appended to the alertmanager secrets. 
+When you upgrade to {acm-short} {product-version} alert forwarding fails if you disabled automatic configuration by setting `mco-disable-alerting: true` in the `MultiClusterObservability` custom resource, and if you manually configured alert forwarding. The failure happens after you upgrade because the name of the `observability-alertmanager-accessor` and `hub-alertmanager-router-ca` secrets were changed to include a postfix of the hub cluster ID. The hub cluster ID is obtained from the `uuid` field in the metadata of the `ClusterVersion` custom resource on the hub cluster. The ID, with dashes removed and trimmed to the first 19 characters, is appended to the `alertmanager` secrets. 
 
 To fix this issue, update your alert forwarding configuration that you manually configured to use the new names of the secrets.
 

--- a/release_notes/known_issues_observability.adoc
+++ b/release_notes/known_issues_observability.adoc
@@ -37,7 +37,7 @@ link:https://issues.redhat.com/browse/ACM-26604[ACM-26604]
 [#alert-forward-fails]
 == Manually configured alert forwarding fails
 
-When you upgrade to {acm-short} {product-version} alert forwarding fails if you disabled automatic configuration by setting `mco-disable-alerting: true` in the `MultiClusterObservability` custom resource, and if you manually configured alert forwarding. The failure happens after you upgrade because the name of the `observability-alertmanager-accessor` and `hub-alertmanager-router-ca` secrets were changed to include a postfix of the hub cluster name.
+When you upgrade to {acm-short} {product-version} alert forwarding fails if you disabled automatic configuration by setting `mco-disable-alerting: true` in the `MultiClusterObservability` custom resource, and if you manually configured alert forwarding. The failure happens after you upgrade because the name of the `observability-alertmanager-accessor` and `hub-alertmanager-router-ca` secrets were changed to include a postfix of the hub cluster ID. The hub ID is obtained from the `uuid` field in the metadata of the `ClusterVersion` CR on the hub. The id, with dashes removed and trimmed to the first 19 characters is appended to the alertmanager secrets. 
 
 To fix this issue, update your alert forwarding configuration that you manually configured to use the new names of the secrets.
 


### PR DESCRIPTION
Clarified the alert forwarding failure issue during upgrades by specifying that the hub cluster ID is used in the secret names. Provided instructions for updating alert forwarding configurations to use the new secret names.

https://issues.redhat.com/browse/ACM-29081