### PR TITLE
Update Global Hub middleware versions for 1.7.0

### DIFF
--- a/global_hub/global_hub_requirements.adoc
+++ b/global_hub/global_hub_requirements.adoc
@@ -69,12 +69,12 @@ See the following supported components:
 
 +
 |===
-|Middleware | Built-in version 
+|Middleware | Built-in version
 
-|amq-streams | 2.9.x
-|Kafka | 3.9.0
+|Streams for Apache Kafka | 3.1.x
+|Kafka | 4.1.0
 |PostgreSQL | 16
-|Grafana | 11.1.0
+|Grafana | 12.2.0
 |===
 
 


### PR DESCRIPTION
## Summary
- Update middleware version table in `global_hub/global_hub_requirements.adoc`
- Streams for Apache Kafka: 2.9.x → 3.1.x (renamed from amq-streams)
- Kafka: 3.9.0 → 4.1.0
- Grafana: 11.1.0 → 12.2.0

## Source References
- Grafana 12.2.0: [glo-grafana release-1.7 VERSION file](https://github.com/stolostron/glo-grafana/tree/release-1.7)
- Kafka 4.1.0: hub-of-hubs `operator/pkg/controllers/transporter/protocol/strimzi_transporter.go` (DefaultAMQKafkaVersion = "4.1.0")
- Streams for Apache Kafka 3.1.x: hub-of-hubs `operator/pkg/controllers/transporter/protocol/strimzi_transporter.go` (DefaultAMQChannel = "amq-streams-3.1.x")

## Jira
Fixes: https://issues.redhat.com/browse/ACM-29114

🤖 Generated with [Claude Code](https://claude.ai/code)