### PR TITLE
https://issues.redhat.com/browse/ACM-25617 for 2.16

### DIFF
--- a/business_continuity/backup_restore/backup_restore.adoc
+++ b/business_continuity/backup_restore/backup_restore.adoc
@@ -91,7 +91,7 @@ Run the restore operation on the hub cluster that uses the same {acm-short} oper
 
 . On the restore hub cluster, install the {acm-short} operator at the same version as the hub cluster where you created the backup. 
 . Restore the backup data on the restore hub cluster. 
-. On the restore hub cluster, use the upgrade operation to upgrade to the {acm-short}operator version that you want to use. 
+. On the restore hub cluster, use the upgrade operation to upgrade to the {acm-short} operator version that you want to use. 
 
 [#clean-hub-restore]
 == Cleaning the hub cluster after restore


### PR DESCRIPTION
@birsanv Here is more info from the issue description: "On the restore hub cluster, install the operator at the same version as the hub cluster where the backup was created". Which Operator do you refer to? Is it the OADP operator?"

From my perspective, the ACM operator is what we were referring to. Should we refer to a different operator? 