### PR TITLE
https://issues.redhat.com/browse/ACM-30307

### DIFF
--- a/observability/use_observability.adoc
+++ b/observability/use_observability.adoc
@@ -55,7 +55,7 @@ oc get secret $SECRET_NAME -n openshift-ingress -o jsonpath=" {.data.tls\.crt}" 
 +
 [source,bash]
 ----
-curl --cacert ./ca.crt -H "Authorization: Bearer {TOKEN}" https://{PROXY_ROUTE_URL}/api/v1/query?query={QUERY_EXPRESSION}
+curl --cacert ./ca.crt -H "Authorization: Bearer {MY_TOKEN}" https://{PROXY_ROUTE_URL}/api/v1/query?query={QUERY_EXPRESSION}
 ----
 +
 *Note:* The `QUERY_EXPRESSION` is the standard Prometheus query expression. For example, query the metrics `cluster_infrastructure_provider` by replacing the URL in the previous command with the following URL: `https://{PROXY_ROUTE_URL}/api/v1/query?query=cluster_infrastructure_provider`. For more details, see link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus].

--- a/observability/use_observability.adoc
+++ b/observability/use_observability.adoc
@@ -55,7 +55,7 @@ oc get secret $SECRET_NAME -n openshift-ingress -o jsonpath=" {.data.tls\.crt}" 
 +
 [source,bash]
 ----
-curl --cacert ./ca.crt -H "Authorization: Bearer ${MY_TOKEN}" https://{PROXY_ROUTE_URL}/api/v1/query?query={QUERY_EXPRESSION}
+curl --cacert ./ca.crt -H "Authorization: Bearer ${MY_TOKEN}" https://${PROXY_ROUTE_URL}/api/v1/query?query=${QUERY_EXPRESSION}
 ----
 +
 *Note:* The `QUERY_EXPRESSION` is the standard Prometheus query expression. For example, query the metrics `cluster_infrastructure_provider` by replacing the URL in the previous command with the following URL: `https://{PROXY_ROUTE_URL}/api/v1/query?query=cluster_infrastructure_provider`. For more details, see link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus].

--- a/observability/use_observability.adoc
+++ b/observability/use_observability.adoc
@@ -55,7 +55,7 @@ oc get secret $SECRET_NAME -n openshift-ingress -o jsonpath=" {.data.tls\.crt}" 
 +
 [source,bash]
 ----
-curl --cacert ./ca.crt -H "Authorization: Bearer {MY_TOKEN}" https://{PROXY_ROUTE_URL}/api/v1/query?query={QUERY_EXPRESSION}
+curl --cacert ./ca.crt -H "Authorization: Bearer ${MY_TOKEN}" https://{PROXY_ROUTE_URL}/api/v1/query?query={QUERY_EXPRESSION}
 ----
 +
 *Note:* The `QUERY_EXPRESSION` is the standard Prometheus query expression. For example, query the metrics `cluster_infrastructure_provider` by replacing the URL in the previous command with the following URL: `https://{PROXY_ROUTE_URL}/api/v1/query?query=cluster_infrastructure_provider`. For more details, see link:https://prometheus.io/docs/prometheus/latest/querying/basics/[Querying Prometheus].

--- a/observability/use_observability.adoc
+++ b/observability/use_observability.adoc
@@ -17,6 +17,7 @@ To access your endpoint by using the mutual TLS, which verifies the identities o
 ----
 oc get route rbac-query-proxy -n open-cluster-management-observability
 ----
+//should the previous command be updated to "export PROXY_ROUTE_URL=$(oc get route rbac-query-proxy -n open-cluster-management-observability -o jsonpath='{.spec.host}')"? Would this command help with defining the PROXY_ROUTE_URL variable for the next steps?
 
 . To access the `rbac-query-proxy` route with your {ocp-short} OAuth access token, run the following command to get the token. The token must be associated with a user or service account, which has permission to get namespaces:
 

--- a/observability/use_observability.adoc
+++ b/observability/use_observability.adoc
@@ -15,9 +15,8 @@ To access your endpoint by using the mutual TLS, which verifies the identities o
 +
 [source,bash]
 ----
-oc get route rbac-query-proxy -n open-cluster-management-observability
+export PROXY_ROUTE_URL=$(oc get route rbac-query-proxy -n open-cluster-management-observability -o jsonpath='{.spec.host}')
 ----
-//should the previous command be updated to "export PROXY_ROUTE_URL=$(oc get route rbac-query-proxy -n open-cluster-management-observability -o jsonpath='{.spec.host}')"? Would this command help with defining the PROXY_ROUTE_URL variable for the next steps?
 
 . To access the `rbac-query-proxy` route with your {ocp-short} OAuth access token, run the following command to get the token. The token must be associated with a user or service account, which has permission to get namespaces:
 


### PR DESCRIPTION
From issue description: 

The usage of the environment variable MY_TOKEN is inconsistent in this chapter. Step 2 (retrieve the token) used MY_TOKEN. Executing the curl, which is described in step 4, however used then TOKEN. Also note that PROXY_ROUTE_URL has not been defined in a previous step. 

