### PR TITLE
Update Global Hub middleware versions and supported platforms

### DIFF
--- a/global_hub/global_hub_install_disconnected.adoc
+++ b/global_hub/global_hub_install_disconnected.adoc
@@ -121,7 +121,7 @@ metadata:
     global-hub.open-cluster-management.io/strimzi-catalog-source-name: redhat-operators
     global-hub.open-cluster-management.io/strimzi-catalog-source-namespace: openshift-marketplace
     global-hub.open-cluster-management.io/strimzi-subscription-package-name: amq-streams
-    global-hub.open-cluster-management.io/strimzi-subscription-channel: amq-streams-2.9.x
+    global-hub.open-cluster-management.io/strimzi-subscription-channel: amq-streams-3.0.x
   name: multiclusterglobalhub
 spec:
   ......

--- a/global_hub/global_hub_requirements.adoc
+++ b/global_hub/global_hub_requirements.adoc
@@ -56,9 +56,9 @@ See the following supported components:
 |===
 |Platform | Supported for global hub cluster | Supported for managed hub cluster
 
+|{acm-short} 2.15, and later 2.15.x releases | Yes |	Yes
 |{acm-short} 2.14, and later 2.14.x releases | Yes |	Yes
 |{acm-short} 2.13, and later 2.13.x releases | Yes |	Yes
-|{acm-short} 2.12, and later 2.12.x releases | Yes |	Yes
 |{acm-short} on Arm | Yes | Yes
 |{acm-short} on IBM Z | Yes | Yes
 |{acm-short} on IBM Power Systems | Yes | Yes
@@ -71,8 +71,8 @@ See the following supported components:
 |===
 |Middleware | Built-in version 
 
-|amq-streams | 2.9.x
-|Kafka | 3.9.0
+|amq-streams | 3.0.x
+|Kafka | 4.0.0
 |PostgreSQL | 16
 |Grafana | 11.1.0
 |===


### PR DESCRIPTION
- Update amq-streams from 2.9.x to 3.0.x
- Update Kafka from 3.9.0 to 4.0.0
- Add ACM 2.15 support, remove ACM 2.12

https://issues.redhat.com/browse/ACM-30827