### PR TITLE
Update Global Hub requirements for ACM 2.16

### DIFF
--- a/global_hub/global_hub_install_disconnected.adoc
+++ b/global_hub/global_hub_install_disconnected.adoc
@@ -121,7 +121,7 @@ metadata:
     global-hub.open-cluster-management.io/strimzi-catalog-source-name: redhat-operators
     global-hub.open-cluster-management.io/strimzi-catalog-source-namespace: openshift-marketplace
     global-hub.open-cluster-management.io/strimzi-subscription-package-name: amq-streams
-    global-hub.open-cluster-management.io/strimzi-subscription-channel: amq-streams-2.9.x
+    global-hub.open-cluster-management.io/strimzi-subscription-channel: amq-streams-3.1.x
   name: multiclusterglobalhub
 spec:
   ......

--- a/global_hub/global_hub_requirements.adoc
+++ b/global_hub/global_hub_requirements.adoc
@@ -56,9 +56,9 @@ See the following supported components:
 |===
 |Platform | Supported for global hub cluster | Supported for managed hub cluster
 
+|{acm-short} 2.16, and later 2.16.x releases | Yes |	Yes
+|{acm-short} 2.15, and later 2.15.x releases | Yes |	Yes
 |{acm-short} 2.14, and later 2.14.x releases | Yes |	Yes
-|{acm-short} 2.13, and later 2.13.x releases | Yes |	Yes
-|{acm-short} 2.12, and later 2.12.x releases | Yes |	Yes
 |{acm-short} on Arm | Yes | Yes
 |{acm-short} on IBM Z | Yes | Yes
 |{acm-short} on IBM Power Systems | Yes | Yes


### PR DESCRIPTION
- Update AMQ Streams subscription channel to 3.1.x
- Update supported ACM versions: add 2.16/2.15, remove 2.12/2.13
https://issues.redhat.com/browse/ACM-30831
