### PR TITLE
fix ACM-28521

### DIFF
--- a/mce_acm_integration/acm_hosted_cluster/acm_discover_hosted.adoc
+++ b/mce_acm_integration/acm_hosted_cluster/acm_discover_hosted.adoc
@@ -15,7 +15,7 @@ Those hosted clusters can be automatically discovered and imported as managed cl
 
 .Prerequisites
 
-* You need one or more {mce-short} clusters.
+* You need one or more {mce-short} clusters that are not yet managed by any {acm-short} cluster. You cannot install {mce-short} in a managed spoke cluster.
 
 * You need a {acm-short} cluster that is set as your hub cluster.
 

--- a/mce_acm_integration/acm_hosted_cluster/acm_discover_hosted.adoc
+++ b/mce_acm_integration/acm_hosted_cluster/acm_discover_hosted.adoc
@@ -15,7 +15,7 @@ Those hosted clusters can be automatically discovered and imported as managed cl
 
 .Prerequisites
 
-* You need one or more {mce-short} clusters that are not yet managed by any {acm-short} cluster. You cannot install {mce-short} in a managed spoke cluster.
+* You need one or more {mce-short} clusters that are not currently managed by any {acm-short} cluster. You cannot install {mce-short} in a managed cluster.
 
 * You need a {acm-short} cluster that is set as your hub cluster.
 


### PR DESCRIPTION
Documentation improvement needed: Clarify MCE must be pre-installed on hosting cluster for HCP setup. Several customers tried installing MCE in an already managed spoke cluster and ran into issues. https://redhat.atlassian.net/browse/ACM-28521