### PR TITLE
Resolve conversion-blocking AsciiDocDITA warnings and errors 2.17--use for info only

### DIFF
--- a/clusters/install_upgrade/config_infra_nodes_mce.adoc
+++ b/clusters/install_upgrade/config_infra_nodes_mce.adoc
@@ -8,6 +8,8 @@ Configure your {ocp-short} cluster to contain infrastructure nodes to run approv
 
 After adding infrastructure nodes to your {ocp-short} cluster, follow the _Installing from the {ocp-short} command-line interface_ xref:./install_connected.adoc#installing-while-connected-online-mce[Installing from the {ocp-short} command-line interface] instructions and add the following configurations to the {olm} Subscription and `MultiClusterEngine` custom resource.
 
+.Procedure
+
 . Configure infrastructure nodes to the {ocp-short} cluster.
 
 .. Follow the procedures that are described in link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/machine_management/creating-infrastructure-machinesets[Creating infrastructure machine sets] in the {ocp-short} documentation. Infrastructure nodes are configured with a Kubernetes `taints` and `labels` to keep non-management workloads from running on them.

--- a/clusters/install_upgrade/install_connected.adoc
+++ b/clusters/install_upgrade/install_connected.adoc
@@ -8,18 +8,17 @@ The {mce-short} is installed with {olm}, which manages the installation, upgrade
 
 *Required access:* Cluster administrator
 
+After you prepare, you can install from the {ocp-catalog} console, or from the {ocp-short} command-line interface.
+
 .Prerequisites
 
 Before you start the installation procedure, you must complete the preparation process. See xref:./prepare_install_mce_connected.adoc#preparing-to-install-mce[Preparing to install {mce-short}].
 
 .Procedure
 
-After you prepare, you can install from the {ocp-catalog} console, or from the {ocp-short} command-line interface.
+* *Installing from the {ocp-catalog} console:*
 
-== Installing from the {ocp-catalog} console
-
-From the _Administrator_ view in your {ocp-short} navigation, install the {ocp-catalog} console that is provided with {ocp-short}. See the following steps:
-
+. From the _Administrator_ view in your {ocp-short} navigation, install the {ocp-catalog} console that is provided with {ocp-short}. See the following steps:
 . Go to *Ecosystem* > *Software Catalog*.
 . Choose the Operator that you want to install.
 . On the _Operator Installation_ page, select the options for your installation:
@@ -68,9 +67,7 @@ spec: {}
 +
 After the `MultiClusterEngine` resource is created, the status for the resource is `Available` on the `MultiCluster Engine` tab.
 
-== Installing from the {ocp-short} command-line interface
-
-See the following steps to install from the {ocp-short} command-line interface:
+* *Installing from the {ocp-short} command-line interface:*
 
 . Create a {mce-short} namespace where the operator requirements are contained. Run the following command, where `<namespace>` is the name for your {mce-short} namespace. The value for `<namespace>` might be referred to as _Project_ in the {ocp-short} environment:
 
@@ -190,7 +187,7 @@ oc delete validatingwebhookconfiguration multiclusterengines.multicluster.opensh
 oc delete mce --all 
 ----
 
-*Notes:*
+.Results
 
 - A `ServiceAccount` with a `ClusterRoleBinding` automatically gives cluster administrator privileges to 
 {mce-short} and to any user credentials with access to the namespace where you install 

--- a/clusters/install_upgrade/install_disconnected.adoc
+++ b/clusters/install_upgrade/install_disconnected.adoc
@@ -22,8 +22,8 @@ You must meet the following requirements before you install the {mce-short}:
 
 .Procedure
 
-Confirm your {ocp-short} installation and then install in a disconnected environment.
-
+. Confirm your {ocp-short} installation and then install in a disconnected environment.
++
 You must have a supported {ocp-short} version, including the registry and storage services, installed and working in your cluster. For information about {ocp-short}, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/[{ocp-short} documentation].
 
 . When and if you are connected, access the {ocp-short} web console with the following command to verify:

--- a/clusters/install_upgrade/prepare_install_mce_connected.adoc
+++ b/clusters/install_upgrade/prepare_install_mce_connected.adoc
@@ -50,8 +50,6 @@ Before you install {mce-short}, see the following prerequisites:
 
 .Procedure
 
-You must have a supported {ocp-short} version, including the registry and storage services, installed and working. For more information about installing {ocp-short}, see the {ocp-short} documentation. Confirm your {ocp-short} installation.
-
 . Verify that {mce-short} is not already installed on your {ocp-short} cluster. The {mce-short} allows only one single installation on each {ocp-short} cluster. 
 
 . To ensure that the {ocp-short} cluster is set up correctly, access the {ocp-short} web console with the following command:

--- a/clusters/install_upgrade/uninstall.adoc
+++ b/clusters/install_upgrade/uninstall.adoc
@@ -10,6 +10,8 @@ When you uninstall {mce}, you see two different levels of the process: A _custom
 
 - The second level is a more complete uninstall that removes most operator components, excluding components such as custom resource definitions. When you continue with this step, it removes all of the components and subscriptions that were not removed with the custom resource removal. After this uninstall, you must reinstall the operator before reinstalling the custom resource.
 
+You can use the terminal or the console to remove {mce-short}.
+
 .Prerequisites
 
 Before you uninstall the {mce-short}, you must detach all of the clusters that are managed by that engine. To avoid errors, detach all clusters, then try to uninstall again.
@@ -27,9 +29,7 @@ For more information about detaching clusters, see the _Removing a cluster from 
 
 .Procedure
 
-You can use the terminal or the console to remove {mce-short}.
-
-. Uninstall {mce-short} from the terminal.
+* Uninstall {mce-short} from the terminal.
 
 .. If you have not already. ensure that your {ocp-short} command-line interface is configured to run `oc` commands. See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/cli_tools/openshift-cli-oc#cli-getting-started[Getting started with the OpenShift CLI] in the {ocp-short} documentation for more information about how to configure the `oc` commands. 
 
@@ -73,7 +73,7 @@ oc delete sub multicluster-engine
 +
 The CSV version might be different.
 
-. Uninstall {mce-short} from the console. When you use the console to uninstall, you remove the operator. 
+* Uninstall {mce-short} from the console. When you use the console to uninstall, you remove the operator.
 
 .. In the {ocp-short} console navigation, select *Operators* > *Installed Operators* > *multicluster engine for Kubernetes*.
 
@@ -104,4 +104,4 @@ oc delete mce --all
 
 .Additional resources
 
-See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/mirroring-in-disconnected-environments[Mirroring in disconnected environments] for more information.
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html-single/disconnected_environments/mirroring-in-disconnected-environments[Mirroring in disconnected environments]

--- a/clusters/install_upgrade/upgrade_cluster_disconnected_policies.adoc
+++ b/clusters/install_upgrade/upgrade_cluster_disconnected_policies.adoc
@@ -1,6 +1,9 @@
+:_mod-docs-content-type: CONCEPT
+
 [#upgrade-disconnect-cluster-policy]
 = Upgrading disconnected clusters by using policies
 
+[role="_abstract"]
 If you have the {acm} hub cluster, which uses the `MultiClusterHub` operator to manage, upgrade, and install hub cluster components, you can use {update-service} with {acm-short} policies to upgrade multiple clusters in a disconnected environment.
 
 {update-service} is a separate operator and operand that monitors the available versions of your managed clusters and makes them available for upgrading in a disconnected environment. {update-service} can perform the following actions:
@@ -543,6 +546,6 @@ Complete the following steps to upgrade:
 If your cluster upgrade fails, the Operator generally retries the upgrade a few times, stops, and reports the status of the failing component. In some cases, the upgrade process continues to cycle through attempts to complete the process. Rolling your cluster back to a previous version after a failed upgrade is not supported. Contact Red Hat support for assistance if your cluster upgrade fails.
 
 [#add-resources-upgrade-service]
-=== Additional resources
+== Additional resources
 
-See link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/registry/configuring-registry-operator#images-configuration-cas_configuring-registry-operator[Configuring additional trust stores for image registry access] in the {ocp-short} documentation to learn more about the external registry CA certificate.
+* link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/registry/configuring-registry-operator#images-configuration-cas_configuring-registry-operator[Configuring additional trust stores for image registry access]

--- a/clusters/install_upgrade/upgrade_mce.adoc
+++ b/clusters/install_upgrade/upgrade_mce.adoc
@@ -3,6 +3,7 @@
 [#upgrading-mce]
 = Upgrading {mce} 
 
+[role="_abstract"]
 Learn how to upgrade your {mce-short}. Control your {mce-short} upgrades by using the operator subscription settings in the {ocp-short} console.
 
 *Required access:* {ocp-short} administrator
@@ -24,8 +25,6 @@ You also use these settings when you upgrade to the latest version of {mce-short
 *Important:* Downgrading a version is not supported. You cannot revert back to an earlier version after upgrading to a later version in the channel selection. You must uninstall the operator and reinstall it with the earlier version to use a previous version.
 
 .Procedure
-
-See the following procedure to upgrade your cluster:
 
 . Log in to your {ocp-short} _Software Catalog_.
 . In the {ocp-short} navigation, select *Operators* > *Installed operators*.
@@ -67,4 +66,4 @@ The {olm} `operatorcondition` resource checks for previous upgrades during the c
 
 .Additional resources
 
-For more information about upgrading your operator, see link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/index[Operators] in the {ocp-short} documentation.
+* link:https://docs.redhat.com/documentation/en-us/openshift_container_platform/4.17/html/operators/index[Operators]


### PR DESCRIPTION
This pull request resolves all conversion blocking [AsciiDocDITA](https://github.com/jhradilek/asciidoctor-dita-vale) warnings in the `clusters/install_upgrade/` directory:

- [ ] AsciiDocDITA.CalloutList
- [ ] AsciiDocDITA.ConceptLink
- [x] AsciiDocDITA.ContentType
- [x] AsciiDocDITA.NestedSection
- [x] AsciiDocDITA.RelatedLinks
- [x] AsciiDocDITA.ShortDescription
- [x] AsciiDocDITA.TaskContents
- [x] AsciiDocDITA.TaskSection
- [x] AsciiDocDITA.TaskStep

Note that I chose the less invasive approach to unblock test conversion. The correct approach would be to:

- split `uninstall.adoc` in two distinct procedures rather than combining two approaches in one.
- split `upgrade_cluster_disconnected_policies.adoc` into multiple concept and procedure modules and use correct templates for each.

I am going to address `AsciiDocDITA.CalloutList` in a separate pull request.