### PR TITLE
https://redhat.atlassian.net/browse/ACM-34578 Switch subctl install docs from CDN to container

### DIFF
--- a/networking/submariner/install_subctl.adoc
+++ b/networking/submariner/install_subctl.adoc
@@ -1,30 +1,31 @@
 [#installing-subctl-command-utility]
 = Installing the subctl command utility
 
-The `subctl` utility is published on the link:https://developers.redhat.com/[Red Hat Developers] page. To install the `subctl` utility locally, complete the following steps:
+The `subctl` utility is distributed as a container image. See the link:https://catalog.redhat.com/software/containers/rhacm2/subctl-rhel9/65bd43fc6a96e2c53f3159b5[Red Hat Ecosystem Catalog `subctl` page] for available image versions.
 
-. Go to the link:https://developers.redhat.com/content-gateway/rest/browse/pub/rhacm/clients/subctl/[`subctl` publication directory].
+*Note:* `registry.redhat.io` requires authentication. If not already configured, run `podman login registry.redhat.io` first.
 
-. Click the folder that matches the version of Submariner that you are using.
+Replace `<version>` in the following examples with the version tag that matches your Submariner deployment, for example `v0.22`.
 
-. Click the `tar.xz` archive for the platform that you are using to download a compressed version of the `subctl` binary.
+[#run-subctl-in-container]
+== Running subctl in a container
 
-.. If your platform is not listed, go to the link:https://catalog.redhat.com/software/containers/rhacm2/subctl-rhel9/65bd43fc6a96e2c53f3159b5[Red Hat Ecosystem Catalog `subctl` page] and extract `subctl` from the relevant image. For example, you can extract the _macos-arm64_ binary from the _arm64_ `subctl` image.
+You can run `subctl` directly from the container image.
 
-. Decompress the `subctl` utility by entering the following command. Replace `<name>` with the name of the archive that you downloaded:
-
-+
-[source,bash]
 ----
-tar -C /tmp/ -xf <name>.tar.xz
+podman run --rm -v ~/.kube:/.kube:z -e KUBECONFIG=/.kube/config \
+  registry.redhat.io/rhacm2/subctl-rhel9:<version> <subcommand>
 ----
 
-. Install the `subctl` utility by entering the following command. Replace `<name>` with the name of the archive that you downloaded. Replace `<version>` with the `subctl` version that you downloaded:
+Replace `<subcommand>` with any `subctl` command, for example `show all` or `diagnose all`.
 
-+
-[source,bash]
+[#extract-subctl-binary]
+== Extracting the subctl binary
+
+If you prefer a local binary, you can extract `subctl` from the container image. The extracted binary requires Red Hat Enterprise Linux 9 or later.
+
 ----
-install -m744 /tmp/<version>/<name> /$HOME/.local/bin/subctl
+podman cp "$(podman create registry.redhat.io/rhacm2/subctl-rhel9:<version>):/usr/local/bin/subctl" subctl
 ----
 
 *Notes:*


### PR DESCRIPTION
The subctl docs originally recommended downloading the binary from
the Red Hat Developers CDN. When Submariner moved to Konflux, CDN
binary publishing was not carried over, and the CDN only has builds
up to 0.20.1. Submariner 0.21+ (ACM 2.14+) has no CDN builds.

Switch to the container image as the install source, with two options:

1. Run subctl directly in its container via `podman run` (works on
   any host with a container runtime, including RHEL 8).
2. Extract the binary from the image (requires RHEL 9+ due to the
   dynamically linked glibc 2.34 dependency).

### Testing

Deployed Submariner on a kind cluster and verified:

- **`podman run` with subctl-rhel9 image**: successfully queries the
  Submariner broker (`show brokers`, `show versions`, `diagnose all`)
- **Extracted binary on RHEL 8 (UBI8)**: fails with
  `GLIBC_2.32 not found` / `GLIBC_2.34 not found`

Cherry-pick to: 2.14_stage, 2.16_stage, 2.17_stage