### PR TITLE
Fix duplicate 'operator' word and add $ prompt to oc commands in install_connected.adoc

### DIFF
--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -66,7 +66,7 @@ metadata:
 +
 [source,bash]
 ----
-$ oc create namespace <namespace>
+oc create namespace <namespace>
 ----
 
 .. Switch your project namespace to the one that you created. Replace `namespace` with the name of the {acm-short} hub cluster namespace that you created in step 1.
@@ -74,7 +74,7 @@ $ oc create namespace <namespace>
 +
 [source,bash]
 ----
-$ oc project <namespace>
+oc project <namespace>
 ----
 
 .. Create a YAML file to configure an `OperatorGroup` resource. Each namespace can have only one operator group:
@@ -99,7 +99,7 @@ spec:
 +
 [source,bash]
 ----
-$ oc apply -f <path-to-file>/<operator-group>.yaml
+oc apply -f <path-to-file>/<operator-group>.yaml
 ----
 +
 
@@ -125,7 +125,7 @@ spec:
 +
 [source,bash]
 ----
-$ oc apply -f <path-to-file>/<subscription>.yaml
+oc apply -f <path-to-file>/<subscription>.yaml
 ----
 
 .. Create a YAML file to configure the `MultiClusterHub` custom resource. Your default template should look similar to the following example. Replace `namespace` with your project namespace:
@@ -146,7 +146,7 @@ spec: {}
 +
 [source,bash]
 ----
-$ oc apply -f <path-to-file>/<custom-resource>.yaml
+oc apply -f <path-to-file>/<custom-resource>.yaml
 ----
 
 +
@@ -163,7 +163,7 @@ error: unable to recognize "./mch.yaml": no matches for kind "MultiClusterHub" i
 +
 [source,bash]
 ----
-$ oc get mch -o yaml
+oc get mch -o yaml
 ----
 
 +

--- a/install/install_connected.adoc
+++ b/install/install_connected.adoc
@@ -4,7 +4,7 @@
 = Installing while connected online
 
 [role="_abstract"]
-Install {acm} through {olm}, which manages the installation, upgrade, and removal of the components that encompass the {acm-short} hub cluster. Because {acm-short} depends on and uses the {mce-short}, after you create the `MultiClusterHub` resource during installation, the {acm-short} operator automatically installs the {mce-short} operator and creates the `MultiClusterEngine` resource. 
+Install {acm} through {olm}, which manages the installation, upgrade, and removal of the components that encompass the {acm-short} hub cluster. Because {acm-short} depends on and uses the {mce-short}, after you create the `MultiClusterHub` resource during installation, the {acm-short} operator automatically installs the {mce-short} and creates the `MultiClusterEngine` resource. 
 
 .Prerequisites
 
@@ -66,7 +66,7 @@ metadata:
 +
 [source,bash]
 ----
-oc create namespace <namespace>
+$ oc create namespace <namespace>
 ----
 
 .. Switch your project namespace to the one that you created. Replace `namespace` with the name of the {acm-short} hub cluster namespace that you created in step 1.
@@ -74,7 +74,7 @@ oc create namespace <namespace>
 +
 [source,bash]
 ----
-oc project <namespace>
+$ oc project <namespace>
 ----
 
 .. Create a YAML file to configure an `OperatorGroup` resource. Each namespace can have only one operator group:
@@ -99,7 +99,7 @@ spec:
 +
 [source,bash]
 ----
-oc apply -f <path-to-file>/<operator-group>.yaml
+$ oc apply -f <path-to-file>/<operator-group>.yaml
 ----
 +
 
@@ -125,7 +125,7 @@ spec:
 +
 [source,bash]
 ----
-oc apply -f <path-to-file>/<subscription>.yaml
+$ oc apply -f <path-to-file>/<subscription>.yaml
 ----
 
 .. Create a YAML file to configure the `MultiClusterHub` custom resource. Your default template should look similar to the following example. Replace `namespace` with your project namespace:
@@ -146,7 +146,7 @@ spec: {}
 +
 [source,bash]
 ----
-oc apply -f <path-to-file>/<custom-resource>.yaml
+$ oc apply -f <path-to-file>/<custom-resource>.yaml
 ----
 
 +
@@ -163,7 +163,7 @@ error: unable to recognize "./mch.yaml": no matches for kind "MultiClusterHub" i
 +
 [source,bash]
 ----
-oc get mch -o yaml
+$ oc get mch -o yaml
 ----
 
 +


### PR DESCRIPTION
## Summary

- **Fix duplicate "operator" word:** The `{mce-short}` variable already expands to "multicluster engine operator", so `{mce-short} operator` was rendering as "multicluster engine operator operator". Removed the redundant word.
- **Add `$` shell prompt prefix:** Added the missing `$` prompt to all 6 `oc` commands in bash code blocks for consistency and clarity.

## Affected Page
- https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes/2.13/html/install/installing#installing-while-connected-online 

## Files changed

- `install/install_connected.adoc`

## Issue:
- https://redhat.atlassian.net/browse/ACM-34257



## Test plan

- [ ] Verify rendered output no longer shows "multicluster engine operator operator"
- [ ] Verify all oc command code blocks display with `$` prompt prefix