### PR TITLE
formatting was off in adv_config_install

### DIFF
--- a/install/adv_config_install.adoc
+++ b/install/adv_config_install.adoc
@@ -41,11 +41,11 @@ apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub
 metadata:
   name: multiclusterhub
-  namespace: <namespace> <1>
+  namespace: <namespace>
 spec:
   overrides:
     components:
-    - name: <name> <2>
+    - name: <name>
       enabled: true
 ----
 * Replace `namespace` with the name of your project.
@@ -69,15 +69,13 @@ The secret requirements for {ocp-short} clusters are automatically resolved by {
 
 See link:https://console.redhat.com/openshift/install/pull-secret[cloud.redhat.com/openshift/install/pull-secret] to download the {ocp-short} pull secret file. Click *Download pull secret*. Run the following command to create your secret:
 
-+
 [source,bash]
 ----
 oc create secret generic <secret> -n <namespace> --from-file=.dockerconfigjson=<path-to-pull-secret> --type=kubernetes.io/dockerconfigjson
 ----
-+
- - Replace `secret` with the name of the secret that you want to create.
- - Replace `namespace` with your project namespace, as the secrets are namespace-specific.
- - Replace `path-to-pull-secret` with the path to your {ocp-short} pull secret that you downloaded.
+- Replace `secret` with the name of the secret that you want to create.
+- Replace `namespace` with your project namespace, as the secrets are namespace-specific.
+- Replace `path-to-pull-secret` with the path to your {ocp-short} pull secret that you downloaded.
 
 The following example displays the `spec.imagePullSecret` template to use if you want to use a custom pull secret. Replace secret with the name of your pull secret:
 
@@ -241,7 +239,7 @@ spec:
     - "ECDHE-RSA-AES128-GCM-SHA256"
 ----
 
-* ClusterBackup
+ClusterBackup::
 
 The `enableClusterBackup` field is no longer supported and is replaced by this component.
 


### PR DESCRIPTION
Updated documentation to clarify namespace and name replacements for configuration.