### PR TITLE
Mark Errata 2.15.2 as deprecated

### DIFF
--- a/release_notes/acm_fixed_issues.adoc
+++ b/release_notes/acm_fixed_issues.adoc
@@ -9,7 +9,7 @@ See link:../install/upgrade_hub.adoc#upgrading-by-using-the-operator[Upgrading b
 
 *Important:* Cluster lifecycle components and features are within the {mce-short}, which is a software operator that enhances cluster fleet management. Release notes for {mce-short}-specific features are found in at link:../clusters/release_notes/mce_release_notes.adoc#mce-release-notes[Release notes for Cluster lifecycle with {mce-short}].
 
-== Errata 2.15.2
+== Errata 2.15.2 (Deprecated)
 
 * Delivers updates to one or more product container images.
 


### PR DESCRIPTION
Updated errata section to indicate deprecation and added details about fixes.