### PR TITLE
doc: Add prominent note about default openshift-* and kube-* namespace exclusions in Gatekeeper intro 

### DIFF
--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -345,7 +345,7 @@ oc explain gatekeeper.spec.audit.auditFromCache
 
 .Additional resources 
 
-- For more information, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/audit/#configuring-audit[Configuring Audit] in the Gatekeeper documentation.
-- For more information about configuring fail-open and fail-closed behavior, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/failing-closed[Gatekeeper documentation].
-- For a list of arguments to use for the `containerArguments` parameter, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/runtime-flags[Runtime Flags] in the Gatekeeper documentation.
-- To read explanations about the difference betewwen the `Config` resource and the flags for exempting namespaces, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/[Exempting Namespaces] in the Gatekeeper documentation.
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/audit/#configuring-audit[Configuring Audit] in the Gatekeeper documentation.
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/failing-closed[Gatekeeper documentation].
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/runtime-flags[Runtime Flags] in the Gatekeeper documentation.
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/[Exempting Namespaces] in the Gatekeeper documentation.

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -163,11 +163,8 @@ spec:
 ----
 
 . Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. See the following example:
-+
-[NOTE]
-====
-The {gate} automatically appends {ocp-short} system namespaces (`openshift-*`) and Kubernetes system namespaces (`kube-*`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are *not* enforced in those namespaces unless you set `disableDefaultMatches: true`.
-====
+
+*Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-*`) and Kubernetes system namespaces (`kube-*`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`.
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -163,6 +163,11 @@ spec:
 ----
 
 . Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. See the following example:
++
+[NOTE]
+====
+The {gate} automatically appends {ocp-short} system namespaces (`openshift-*`) and Kubernetes system namespaces (`kube-*`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are *not* enforced in those namespaces unless you set `disableDefaultMatches: true`.
+====
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/gk_operator_overview.adoc
+++ b/governance/gatekeeper_operator/gk_operator_overview.adoc
@@ -8,12 +8,11 @@ The {gate} installs Gatekeeper, which is a validating webhook with auditing capa
 - Evaluate Kubernetes resource compliance requests for the Kubernetes API by using the Gatekeeper constraints.
 - Use OPA as the policy engine and use Rego as the policy language.
 
-[IMPORTANT]
-====
-By default, the {gate} automatically excludes {ocp-short} system namespaces (matching `openshift-*`) and Kubernetes system namespaces (matching `kube-*`) from Gatekeeper constraint and mutation enforcement. Constraints, `ConstraintTemplates`, and `Assign` mutations that you create will *not* apply to resources in those namespaces unless you explicitly override this behavior.
+*Important:* 
 
-To allow Gatekeeper to enforce policies in `openshift-*` or `kube-*` namespaces, set `spec.config.disableDefaultMatches: true` in the `Gatekeeper` custom resource.
-====
+* By default, the {gate} automatically excludes {ocp-short} system namespaces (matching `openshift-*`) and Kubernetes system namespaces (matching `kube-*`) from Gatekeeper constraint and mutation enforcement. Constraints, `ConstraintTemplates`, and `Assign` mutations that you create will _not_ apply to resources in those namespaces unless you explicitly override this behavior.
+
+* To allow Gatekeeper to enforce policies in `openshift-*` or `kube-*` namespaces, set `spec.config.disableDefaultMatches: true` in the `Gatekeeper` custom resource.
 
 To learn more about using the {gate}, see the following resources:
 

--- a/governance/gatekeeper_operator/gk_operator_overview.adoc
+++ b/governance/gatekeeper_operator/gk_operator_overview.adoc
@@ -8,6 +8,13 @@ The {gate} installs Gatekeeper, which is a validating webhook with auditing capa
 - Evaluate Kubernetes resource compliance requests for the Kubernetes API by using the Gatekeeper constraints.
 - Use OPA as the policy engine and use Rego as the policy language.
 
+[IMPORTANT]
+====
+By default, the {gate} automatically excludes {ocp-short} system namespaces (matching `openshift-*`) and Kubernetes system namespaces (matching `kube-*`) from Gatekeeper constraint and mutation enforcement. Constraints, `ConstraintTemplates`, and `Assign` mutations that you create will *not* apply to resources in those namespaces unless you explicitly override this behavior.
+
+To allow Gatekeeper to enforce policies in `openshift-*` or `kube-*` namespaces, set `spec.config.disableDefaultMatches: true` in the `Gatekeeper` custom resource.
+====
+
 To learn more about using the {gate}, see the following resources:
 
 - xref:../gatekeeper_operator/general_support.adoc#general-support[General support]


### PR DESCRIPTION
Fixes: ACM-34959
## What changed
- Added IMPORTANT callout in gk_operator_overview.adoc (intro page) stating that openshift-* and kube-* namespaces are excluded from Gatekeeper constraint enforcement by default.
- Added NOTE callout in config_gk_operator.adoc alongside the config.matches step to surface the same information on the configuration page.
## Why
Customer feedback: Assign mutations and constraints created without specifying disableDefaultMatches silently had no effect in openshift-* namespaces. The behavior is documented in the config section but is not discoverable from the chapter introduction where first-time users land. Customer spent hours before finding the fix.
## Versions needing backport
This fix applies to 2.11 through 2.16 (the gap was introduced when disableDefaultMatches was added but not called out in the overview). Please also apply to 2.17_stage.