### PR TITLE
Fix wording in API documentation

### DIFF
--- a/apis/api.adoc
+++ b/apis/api.adoc
@@ -1,7 +1,7 @@
 [#apis]
 = APIs
 
-You can access APIs to create and manage application resources, channels, subscriptions, and to query information.
+You can access APIs to create and manage application resources, channels, subscriptions, and to the query information.
 
 *Deprecated:* The documentation for the APIs is deprecated. Use the _API Explorer_ in the console, or an `oc` command, to view current and supported APIs.
 


### PR DESCRIPTION
Corrected the phrase 'to query information' for clarity.