### PR TITLE
Add release note for custom RBAC roles feature

### DIFF
--- a/release_notes/acm_new.adoc
+++ b/release_notes/acm_new.adoc
@@ -126,6 +126,7 @@ See link:../networking/networking_intro.adoc#networking[Networking] to learn mor
 
 Learn about new features for virtualization.
 
+* You can now create custom `ClusterRole` resources to define environment-specific permissions for virtualization workloads. Distribute custom roles to managed clusters by using governance policies and assign them to users through `MulticlusterRoleAssignment` resources. This enables access control scenarios, such as granting console-only access to virtual machines without lifecycle control. See link:../secure_clusters/fine_grain_mca_custom.adoc#fine-grain-mca-custom[Managing custom roles with _MulticlusterRoleAssignment_] for more information.
 
 See link:../virtualization/virtualization_intro.adoc[Virtualization] for more information.
 


### PR DESCRIPTION
Include documentation for managing custom roles with MulticlusterRoleAssignment in the virtualization section of the release notes. This addition highlights the ability to create custom ClusterRole resources for environment-specific permissions.