### PR TITLE
Update upgrade_hub.adoc with new resources section--clean up

### DIFF
--- a/install/upgrade_hub.adoc
+++ b/install/upgrade_hub.adoc
@@ -64,8 +64,6 @@ While it is upgrading, the `Status` field shows the `Updating` status. After the
 .. Verify that the `csv` version from the previous release, for instance, `2.13` (EUS), is replaced with the upgraded version, for instance, `2.15` (EUS).
 .. Verify that the `MultiClusterHub` instance `status.currentVersion` specification value is set at `2.15` and matches the `desiredVersion` status, which is also set at `2.15`.
 
-For more information about upgrading your operator, see link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/index[Operators] in the {ocp-short} documentation.
-
 . *Optional:* If you are link:../clusters/cluster_lifecycle/cluster_pool_intro.adoc#managing-cluster-pools[Managing cluster pools (Technology Preview)], you need further configuration to stop automatic management of these cluster pools after upgrade.
 
 . Set `cluster.open-cluster-management.io/createmanagedcluster: "false"` in the `ClusterClaim` `metadata.annotations`. 
@@ -73,3 +71,8 @@ For more information about upgrading your operator, see link:https://docs.redhat
 .Results
 
 All existing cluster claims are automatically imported when the product is upgraded unless you change this setting.
+
+.Additional resources
+
+link:https://docs.redhat.com/en/documentation/openshift_container_platform/4.20/html/operators/index[Operators] in the {ocp-short} documentation.
+


### PR DESCRIPTION
Removed outdated link to operator upgrade documentation and added a new resources section.