### PR TITLE
Update Gatekeeper operator config documentation

### DIFF
--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -349,6 +349,6 @@ oc explain gatekeeper.spec.audit.auditFromCache
 .Additional resources 
 
 * link:https://open-policy-agent.github.io/gatekeeper/website/docs/audit/#configuring-audit[Configuring Audit]
-- For more information about configuring fail-open and fail-closed behavior, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/failing-closed[Gatekeeper documentation].
-- For a list of arguments to use for the `containerArguments` parameter, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/runtime-flags[Runtime Flags] in the Gatekeeper documentation.
-- To read explanations about the difference betewwen the `Config` resource and the flags for exempting namespaces, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/[Exempting Namespaces] in the Gatekeeper documentation.
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/failing-closed[Gatekeeper documentation]
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/runtime-flags[Runtime Flags]
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/[Exempting Namespaces]

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -165,7 +165,7 @@ spec:
     timeoutSeconds: 1
 ----
 
-. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces and Kubernetes system namespaces to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
+. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-`) and Kubernetes system namespaces (`kube-`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -177,6 +177,8 @@ spec:
       - excludedNamespaces: ["test-*", "my-namespace"] 
         processes: ["*"]
 ----
++
+*Note:* The {gate} automatically appends {ocp-short} system namespaces and Kubernetes system namespaces to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`.
 
 . The `disableDefaultMatches` parameter is a boolean parameter that disables appending the default exempt namespaces provided by the Gatekeeper operator. The default exempt namespaces are {ocp-short} or Kubernetes system namespaces. By default, this parameter is set to `false` to allow the default namespaces to be appended. See the following example:
 
@@ -346,7 +348,7 @@ oc explain gatekeeper.spec.audit.auditFromCache
 
 .Additional resources 
 
-- For more information, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/audit/#configuring-audit[Configuring Audit] in the Gatekeeper documentation.
+* link:https://open-policy-agent.github.io/gatekeeper/website/docs/audit/#configuring-audit[Configuring Audit]
 - For more information about configuring fail-open and fail-closed behavior, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/failing-closed[Gatekeeper documentation].
 - For a list of arguments to use for the `containerArguments` parameter, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/runtime-flags[Runtime Flags] in the Gatekeeper documentation.
 - To read explanations about the difference betewwen the `Config` resource and the flags for exempting namespaces, see link:https://open-policy-agent.github.io/gatekeeper/website/docs/exempt-namespaces/[Exempting Namespaces] in the Gatekeeper documentation.

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -165,7 +165,7 @@ spec:
     timeoutSeconds: 1
 ----
 
-. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. See the following example:
+. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces and Kubernetes system namespaces to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
 
 +
 [source,yaml]
@@ -177,8 +177,6 @@ spec:
       - excludedNamespaces: ["test-*", "my-namespace"] 
         processes: ["*"]
 ----
-+
-*Note:* The {gate} automatically appends {ocp-short} system namespaces and Kubernetes system namespaces to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`.
 
 . The `disableDefaultMatches` parameter is a boolean parameter that disables appending the default exempt namespaces provided by the Gatekeeper operator. The default exempt namespaces are {ocp-short} or Kubernetes system namespaces. By default, this parameter is set to `false` to allow the default namespaces to be appended. See the following example:
 

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -165,7 +165,10 @@ spec:
     timeoutSeconds: 1
 ----
 
-. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-`) and Kubernetes system namespaces (`kube-`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
+. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource.
+
++
+*Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-`) and Kubernetes system namespaces (`kube-`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/gk_operator_overview.adoc
+++ b/governance/gatekeeper_operator/gk_operator_overview.adoc
@@ -11,6 +11,12 @@ The {gate} installs Gatekeeper, which is a validating webhook with auditing capa
 - Evaluate Kubernetes resource compliance requests for the Kubernetes API by using the Gatekeeper constraints.
 - Use OPA as the policy engine and use Rego as the policy language.
 
+*Important:* 
+
+* By default, the {gate} automatically excludes {ocp-short} system namespaces (matching `openshift-`) and Kubernetes system namespaces (matching `kube-`) from Gatekeeper constraint and mutation enforcement. Constraints, `ConstraintTemplates`, and `Assign` mutations that you create are _not_ applied to resources in those namespaces unless you explicitly override this behavior.
+
+* To allow Gatekeeper to enforce policies in `openshift-` or `kube-` namespaces, set `spec.config.disableDefaultMatches: true` in the `Gatekeeper` custom resource.
+
 To learn more about using the {gate}, see the following resources:
 
 - xref:../gatekeeper_operator/general_support.adoc#general-support[General support]

--- a/release_notes/acm_new.adoc
+++ b/release_notes/acm_new.adoc
@@ -75,7 +75,7 @@ For other Application and GitOps topics, see link:../applications/app_management
 
 Learn about new features for observability.
 
-* *Technology Preview:* You can view hub cluster and managed cluster metrics in Perses dashboards from the {ocp-short} console when you enable the multicluster observability add-on `ui` parameter in the `MultiClusterObservability` custom resource. Perses dashboards are rendered through the Cluster Observability Operator (COO) console plugin and complement existing Grafana dashboards. See link:../observability/obs_enable_mcoa_perses.adoc#enable-mcoa-perses[Enabling Perses dashboards with the multicluster observability add-on (Technology Preview)] and link:../observability/obs_view_perses.adoc#view-perses-dashboards[Viewing Perses dashboards in the console].
+* *Technology Preview:* You can view hub cluster and managed cluster metrics in Perses dashboards from the {ocp-short} console when you enable the multicluster observability add-on `ui` parameter in the `MultiClusterObservability` custom resource. Perses dashboards are rendered through the Cluster Observability Operator console plugin and complement existing Grafana dashboards. See link:../observability/obs_enable_mcoa_perses.adoc#enable-mcoa-perses[Enabling Perses dashboards with the multicluster observability add-on (Technology Preview)] and link:../observability/obs_view_perses.adoc#view-perses-dashboards[Viewing Perses dashboards in the console].
 
 See link:../observability/observe_environments_intro.adoc#observing-environments-intro[Observability service] to learn more.
 


### PR DESCRIPTION
Added notes on default namespace exclusions and the disableDefaultMatches parameter in the Gatekeeper configuration documentation.

Combo of the two PRs: 

https://github.com/stolostron/rhacm-docs/pull/8993/changes
https://github.com/stolostron/rhacm-docs/pull/8923#discussion_r3506948990