### PR TITLE
Enhance documentation for Gatekeeper config section

### DIFF
--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -162,7 +162,10 @@ spec:
     timeoutSeconds: 1
 ----
 
-. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-`) and Kubernetes system namespaces (`kube-`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
+. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource.
+
++
+*Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-`) and Kubernetes system namespaces (`kube-`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -162,7 +162,7 @@ spec:
     timeoutSeconds: 1
 ----
 
-. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces and Kubernetes system namespaces to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
+. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces (`openshift-`) and Kubernetes system namespaces (`kube-`) to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/config_gk_operator.adoc
+++ b/governance/gatekeeper_operator/config_gk_operator.adoc
@@ -162,7 +162,7 @@ spec:
     timeoutSeconds: 1
 ----
 
-. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. See the following example:
+. Use the `config` section to exclude namespaces from certain processes for all constraints on your cluster using the Gatekeeper `Config` custom resource. *Note:* The {gate} automatically appends {ocp-short} system namespaces and Kubernetes system namespaces to the exclusion list by default. As a result, Gatekeeper constraints and mutations are _not_ enforced in those namespaces unless you set `disableDefaultMatches: true`. See the following example:
 
 +
 [source,yaml]

--- a/governance/gatekeeper_operator/gk_operator_overview.adoc
+++ b/governance/gatekeeper_operator/gk_operator_overview.adoc
@@ -8,6 +8,12 @@ The {gate} installs Gatekeeper, which is a validating webhook with auditing capa
 - Evaluate Kubernetes resource compliance requests for the Kubernetes API by using the Gatekeeper constraints.
 - Use OPA as the policy engine and use Rego as the policy language.
 
+*Important:* 
+
+* By default, the {gate} automatically excludes {ocp-short} system namespaces (matching `openshift-`) and Kubernetes system namespaces (matching `kube-`) from Gatekeeper constraint and mutation enforcement. Constraints, `ConstraintTemplates`, and `Assign` mutations that you create are _not_ applied to resources in those namespaces unless you explicitly override this behavior.
+
+* To allow Gatekeeper to enforce policies in `openshift-` or `kube-` namespaces, set `spec.config.disableDefaultMatches: true` in the `Gatekeeper` custom resource.
+
 To learn more about using the {gate}, see the following resources:
 
 - xref:../gatekeeper_operator/general_support.adoc#general-support[General support]


### PR DESCRIPTION
Added note about default namespace exclusions in Gatekeeper.

2.17 PR: https://github.com/stolostron/rhacm-docs/pull/8992

Not sure which issue this is related to, but I am updating 2.15 based on this comment: https://github.com/stolostron/rhacm-docs/pull/8923#issuecomment-4849750845