### PR TITLE
ACM-25305: Add port 6388 to network configuration table

### DIFF
--- a/clusters/about/mce_networking.adoc
+++ b/clusters/about/mce_networking.adoc
@@ -45,6 +45,13 @@ For the {mce-short} cluster networking requirements, see the following table:
 | Communication between the Ironic Python Agent and the Ironic service on the hub cluster
 
 | Inbound from the managed cluster
+| Ironic Python Agent on the managed cluster
+| Ironic service (metal3 pod) on the hub cluster
+| TCP
+| 6388
+| Internal communication between the Ironic Python Agent and the metal3 pod on the hub cluster when the provisioning network is disabled or virtual media via external network is enabled. Required when the hub cluster runs on a cloud provider (AWS, Azure, GCP) and spoke clusters are bare metal.
+
+| Inbound from the managed cluster
 | Cluster proxy add-on agent on the managed cluster
 | Cluster proxy ANP service
 | TCP

--- a/clusters/about/mce_networking.adoc
+++ b/clusters/about/mce_networking.adoc
@@ -49,7 +49,7 @@ For the {mce-short} cluster networking requirements, see the following table:
 | Ironic service (metal3 pod) on the hub cluster
 | TCP
 | 6388
-| Internal communication between the Ironic Python Agent and the metal3 pod on the hub cluster when the provisioning network is disabled or virtual media via external network is enabled. Required when the hub cluster runs on a cloud provider (AWS, Azure, GCP) and spoke clusters are bare metal.
+| Internal communication between the Ironic Python Agent and the metal3 pod on the hub cluster when the provisioning network is disabled, or when virtual media through external network is enabled. Required when the hub cluster runs on a cloud provider such as Amazon Web Services, Microsoft Azure, or GCP, and managed clusters are bare metal.
 
 | Inbound from the managed cluster
 | Cluster proxy add-on agent on the managed cluster


### PR DESCRIPTION
## Summary

- Adds port 6388 (Ironic metal3 pod internal API) to the MCE network configuration table in `clusters/about/mce_networking.adoc`
- Port 6388 is required when the ironic-proxy DaemonSet is deployed (`ProvisioningNetwork=Disabled` or `VirtualMediaViaExternalNetwork=true`)
- Applies to hub-on-cloud + spoke-on-baremetal topologies (AWS, Azure, GCP) where cloud security groups do not open this port by default

## Context

A customer (Hub=AWS, Spoke=baremetal) reported the BMO pod failing because port 6388 was not open in the AWS security group. The existing table documents port 6385 for Ironic but omits 6388, which is required in the same provisioning flow.

Validated by Joydeep Banerjee (architect) in [ACM-25305 comments](https://redhat.atlassian.net/browse/ACM-25305?focusedCommentId=17611583).

Reference: [OCP bare metal IPI prerequisites — required ports](https://docs.redhat.com/en/documentation/openshift_container_platform/4.16/html/deploying_installer-provisioned_clusters_on_bare_metal/ipi-install-prerequisites#network-requirements-ensuring-required-ports-are-open_ipi-install-prerequisites) documents 6388 as "Port 6385 uses port 6388 as a proxy."

## Test plan

- [ ] Verify the new row renders correctly in the AsciiDoc table
- [ ] Confirm port/protocol/direction match the OCP reference docs and Jira validation

Fixes: https://issues.redhat.com/browse/ACM-25305

🤖 Generated with [Claude Code](https://claude.com/claude-code)